### PR TITLE
FIX - reactivity in packdetails component

### DIFF
--- a/client/components/EditableText/index.js
+++ b/client/components/EditableText/index.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState,useEffect } from "react";
 import { TextInput } from "react-native";
 import { theme } from "../../theme";
 import { useDispatch } from "react-redux";
@@ -13,6 +13,11 @@ export const EditableInput = ({
   titleRef,
 }) => {
   const [headerTitle, setHeaderTitle] = useState(title || "");
+  
+  useEffect(() => {
+    setHeaderTitle(title);
+  }, [title])
+  
   const dispatch = useDispatch();
   return (
     <TextInput

--- a/client/components/pack/PackDetails.js
+++ b/client/components/pack/PackDetails.js
@@ -42,7 +42,7 @@ export function PackDetails() {
       dispatch(fetchSinglePack(packId));
       if (userId) dispatch(fetchUserPacks(userId));
       setFirstLoad(false)
-  }, [dispatch, packId, updated]); // TODO updated is a temporary fix to re-render when pack is update, due to bug in store
+  }, [dispatch, packId]);
 
   const currentPackId = currentPack && currentPack._id;
 

--- a/client/store/authStore.js
+++ b/client/store/authStore.js
@@ -73,70 +73,79 @@ export const signInWithGoogle = createAsyncThunk(
   }
 );
 
-export const authSlice = createSlice({
+const authSlice = createSlice({
   name: "auth",
   initialState,
   reducers: {},
   extraReducers: (builder) => {
     builder
       .addCase(signUp.pending, (state) => {
-        state.loading = true;
-        state.error = null;
+        return { ...state, loading: true, error: null };
       })
       .addCase(signUp.fulfilled, (state, action) => {
-        authAdapter.setAll(state, [action.payload]);
-        state.user = action.payload;
-        state.loading = false;
-        state.error = null;
+        const newState = {
+          ...state,
+          loading: false,
+          error: null,
+          user: action.payload,
+        };
+        authAdapter.setAll(newState, [action.payload]);
+        return newState;
       })
       .addCase(signUp.rejected, (state, action) => {
-        state.loading = false;
-        state.error = action.payload;
+        return { ...state, loading: false, error: action.payload };
       })
       .addCase(signIn.pending, (state) => {
-        state.loading = true;
-        state.error = null;
-        state.error = null;
+        return { ...state, loading: true, error: null, user: null };
       })
       .addCase(signIn.fulfilled, (state, action) => {
-        authAdapter.setAll(state, [action.payload]);
-        state.user = action.payload;
-        state.loading = false;
-        state.error = null;
+        const newState = {
+          ...state,
+          loading: false,
+          error: null,
+          user: action.payload,
+        };
+        authAdapter.setAll(newState, [action.payload]);
+        return newState;
       })
       .addCase(signIn.rejected, (state, action) => {
-        state.loading = false;
-        state.error = action.payload;
-        state.user = null;
+        return { ...state, loading: false, error: action.payload, user: null };
       })
       .addCase(signOut.pending, (state) => {
-        state.loading = true;
-        state.error = null;
+        return { ...state, loading: true, error: null };
       })
       .addCase(signOut.fulfilled, (state) => {
-        authAdapter.removeAll(state);
-        state.user = null;
-        state.loading = false;
+        const newState = {
+          ...state,
+          loading: false,
+          error: null,
+          user: null,
+        };
+        authAdapter.removeAll(newState);
+        return newState;
       })
       .addCase(signOut.rejected, (state, action) => {
-        state.loading = false;
-        state.error = action.payload;
+        return { ...state, loading: false, error: action.payload };
       })
       .addCase(signInWithGoogle.pending, (state) => {
-        state.loading = true;
-        state.error = null;
+        return { ...state, loading: true, error: null };
       })
       .addCase(signInWithGoogle.fulfilled, (state, action) => {
-        authAdapter.setAll(state, [action.payload]);
-        state.user = action.payload;
-        state.loading = false;
+        const newState = {
+          ...state,
+          loading: false,
+          error: null,
+          user: action.payload,
+        };
+        authAdapter.setAll(newState, [action.payload]);
+        return newState;
       })
       .addCase(signInWithGoogle.rejected, (state, action) => {
-        state.loading = false;
-        state.error = action.payload;
+        return { ...state, loading: false, error: action.payload };
       });
   },
 });
+
 export const authReducer = authSlice.reducer;
 export const { selectAll: selectAllUsers, selectById: selectUserById } = authAdapter.getSelectors((state) => state.auth);
 export default authSlice.reducer;

--- a/client/store/singlePackStore.js
+++ b/client/store/singlePackStore.js
@@ -72,7 +72,11 @@ const singlePackSlice = createSlice({
         state.error = null;
       })
       .addCase(selectItemsGlobal.fulfilled, (state, action) => {
-        state.singlePack.items.push(action.payload.data);
+        const updatedSinglePack = {
+          ...state.singlePack,
+          items: [...state.singlePack.items, action.payload.data],
+        };
+        state.singlePack = updatedSinglePack;
         state.isLoading = false;
         state.error = null;
       })


### PR DESCRIPTION
- Updated EditableInput to take updates whenever global state updates
- Updated PackDetails components useffect dependency array ( removed updated constant  which was a hack around this issue)
- Updated AuthSlice with spread operator of the state and new state while returning ( which solves issue `A case reducer on a non-draftable value must not return undefined`
   ```
   .addCase(signUp.rejected, (state, action) => {
        return { ...state, loading: false, error: action.payload };
      })
    ```
- Fixed SinglePack fetching issue 
```.addCase(selectItemsGlobal.fulfilled, (state, action) => {
        const updatedSinglePack = {
          ...state.singlePack,
          items: [...state.singlePack.items, action.payload.data],
        };
        state.singlePack = updatedSinglePack;

        state.isLoading = false;
        state.error = null;
      })
```