### PR TITLE
Next prefetch - Effort Estimation 🐎 

### DIFF
--- a/apps/next/pages/pack/[id].tsx
+++ b/apps/next/pages/pack/[id].tsx
@@ -1,10 +1,15 @@
 import React from 'react';
 import { PackDetails } from 'app/components/pack/PackDetails';
 import { AuthWrapper } from 'auth/authWrapper';
+import { GetServerSidePropsContext, InferGetServerSidePropsType } from 'next';
+import { helpers } from 'prefetchConf';
 
 // export const runtime = 'experimental-edge'
 
-function PackScreen() {
+function PackScreen(
+  props: InferGetServerSidePropsType<typeof getServerSideProps>,
+) {
+  const { initialPackData } = props;
   return (
     <>
       <PackDetails />
@@ -17,3 +22,23 @@ export default PackScreen;
 PackScreen.getLayout = function getLayout(page: any) {
   return <AuthWrapper>{page}</AuthWrapper>;
 };
+
+export async function getServerSideProps(context: GetServerSidePropsContext<{ url: string }>) {
+  if (!context.req.url) {
+    return {
+      props: {
+        initialPackData: null,
+        trpcState: helpers.dehydrate(),
+      }
+    };
+  }
+  const url = new URL(context.req.url, `http://${context.req.headers.host}`);
+  const packId = url.searchParams.get('id');
+  const currentPack = packId ? await helpers.getPackById.prefetch({ packId }) : null;
+  return {
+    props: {
+      trpcState: helpers.dehydrate(),
+      initialPackData: currentPack,
+    },
+  };
+}

--- a/apps/next/preFetchConf.ts
+++ b/apps/next/preFetchConf.ts
@@ -1,0 +1,8 @@
+import { appRouter } from "server/src/routes/trpcRouter";
+import { createServerSideHelpers } from '@trpc/react-query/server';
+
+export const helpers = createServerSideHelpers({
+    router: appRouter,
+    ctx: {},
+    transformer: undefined,
+});

--- a/packages/app/hooks/packs/useFetchSinglePack.ts
+++ b/packages/app/hooks/packs/useFetchSinglePack.ts
@@ -18,3 +18,4 @@ export const useFetchSinglePack = (packId) => {
 
   return { refetch, data, error, isLoading, isOwner, isError };
 };
+ 


### PR DESCRIPTION
# Next Pre-fetch 🐎 

### To the People Who wants to know about pre-fetching
Prefetching is the process of loading data in advance to speed up its future access. In the context of web development, server-side helpers can prefetch data that is needed to render a page. This means when the page is requested, much of the data it needs is already loaded and can be immediately used to generate the HTML. This approach reduces the time taken to load the data on the client side since the server has already done the heavy lifting.

### The story
Since we have moved our all the logics from expo web to nextjs in the last few days, we are trying to make use of better nextjs functionalities available out there. While keeping our app logics up to date.

### Current Stage ( Effort Estimation 😄 )
We are just testing out how much effort it might take to implement this feature for all the pages and routes inside the packrat next.

1. Do some configuration for prefetch related stuffs on client side,
2. Test for individual route / api for this approach making use of the documentation
3. Estimate the effort and time it will require for entire codebase integration (nextjs)
4. Do repeat for other routes/api's if it is feasible