### PR TITLE
Configure remote appVersion management

### DIFF
--- a/apps/expo/eas.json
+++ b/apps/expo/eas.json
@@ -1,6 +1,7 @@
 {
   "cli": {
-    "version": ">= 3.8.1"
+    "version": ">= 3.8.1",
+    "appVersionSource": "remote"
   },
   "build": {
     "development": {
@@ -21,6 +22,7 @@
       }
     },
     "production": {
+      "autoIncrement": true,
       "ios": {
         "resourceClass": "m-medium"
       }


### PR DESCRIPTION
Forgetting to update the [developer-facing build version](https://docs.expo.dev/build-reference/app-versions/#developer-facing-build-version)  could cause app store rejections. This will delegate incrementing of the build version to EAS Build; eliminating the need to manually increment it everytime when creating a new build.

https://docs.expo.dev/build-reference/app-versions