### PR TITLE
Fix vectorize issues

### DIFF
--- a/server/wrangler.toml.example
+++ b/server/wrangler.toml.example
@@ -59,7 +59,7 @@ binding = "AI"
 
 #[[env.production.vectorize]]
 #binding = "VECTOR_INDEX"
-#index_name = "vector-index"
+#index_name = "vector-index-production"
 
 [env.production.vars]
 NODE_ENV="production"
@@ -74,7 +74,7 @@ OSM_URI=""
 WEATHER_URL=""
 OPENWEATHER_KEY=""
 VECTORIZE_API_KEY=""
-VECTOR_INDEX="vector-index"
+VECTOR_INDEX="vector-index-production"
 WORKERS_AI_API_KEY=""
 CLOUDFLARE_ACCOUNT_ID=""
 

--- a/server/wrangler.toml.example
+++ b/server/wrangler.toml.example
@@ -14,9 +14,9 @@ database_id = ""
 [env.preview.ai]
 binding = "AI"
 
-[[env.preview.vectorize]]
-binding = "VECTOR_INDEX"
-index_name = "vector-index-preview"
+#[[env.preview.vectorize]]
+#binding = "VECTOR_INDEX"
+#index_name = "vector-index-preview"
 
 [env.preview.vars]
 NODE_ENV="preview"
@@ -57,9 +57,9 @@ database_id = ""
 [env.production.ai]
 binding = "AI"
 
-[[env.production.vectorize]]
-binding = "VECTOR_INDEX"
-index_name = "vector-index"
+#[[env.production.vectorize]]
+#binding = "VECTOR_INDEX"
+#index_name = "vector-index"
 
 [env.production.vars]
 NODE_ENV="production"


### PR DESCRIPTION
Changes:
- Comment out vectorize binding configuration since REST api (instead of vectorize client) is used currently. This is to also fix the binding name conflicting with VECTOR_INDEX var which is used by the REST api --causes deployment failure.
- The current production vector index was used in both dev and prod. This leads to cluttering of the vector (with dev and prod data) and results in empty cards showing up under similar packs (see: #1200). This was fixed by using a different one for dev instead. The ultimate solution however is to change the production vector index to an entirely new one, thus eliminating the chance of cluttering even when running from previous versions (older commits).