### PR TITLE
Fix: login screen not scrollable

### DIFF
--- a/packages/app/modules/auth/screens/LoginScreen.tsx
+++ b/packages/app/modules/auth/screens/LoginScreen.tsx
@@ -3,6 +3,7 @@ import useTheme from '../../../hooks/useTheme';
 import { useGoogleAuth, useLogin } from 'app/modules/auth';
 import { SignInScreen } from '@packrat/ui/src/Bento/forms/layouts';
 import { View } from 'react-native';
+import { ScrollView } from 'react-native';
 
 const demoUser = {
   email: 'zoot3@email.com',
@@ -35,25 +36,30 @@ export function LoginScreen() {
     <View
       style={{
         width: '100%',
-        alignItems: 'center',
+        height: '100%',
         backgroundColor: currentTheme.colors.background,
       }}
     >
-      <View
-        style={{
-          paddingTop: 32,
-          paddingBottom: 32,
-          width: '90%',
-          maxWidth: 400,
-        }}
-      >
-        <SignInScreen
-          promptAsync={promptAsync}
-          signIn={signIn}
-          signInStatus={signInStatus}
-          isGoogleSignInReady={isGoogleSignInReady}
-        />
-      </View>
+      <ScrollView>
+        <View
+          style={{
+            paddingTop: 32,
+            paddingBottom: 32,
+            justifyContent: 'center',
+            alignSelf: 'center',
+            alignItems: 'center',
+            width: '90%',
+            maxWidth: 400,
+          }}
+        >
+          <SignInScreen
+            promptAsync={promptAsync}
+            signIn={signIn}
+            signInStatus={signInStatus}
+            isGoogleSignInReady={isGoogleSignInReady}
+          />
+        </View>
+      </ScrollView>
     </View>
   );
 }

--- a/packages/app/modules/auth/screens/RegisterScreen.tsx
+++ b/packages/app/modules/auth/screens/RegisterScreen.tsx
@@ -1,8 +1,10 @@
+import React from 'react';
 import { View } from 'react-native';
 import useTheme from 'app/hooks/useTheme';
 import { useRegisterUser, useGoogleAuth } from 'app/modules/auth';
 import { SignUpScreen } from '@packrat/ui/src/Bento/forms/layouts';
 import { useState } from 'react';
+import { ScrollView } from 'react-native';
 
 export function RegisterScreen() {
   const { currentTheme } = useTheme();
@@ -29,26 +31,29 @@ export function RegisterScreen() {
     <View
       style={{
         width: '100%',
-        alignItems: 'center',
         backgroundColor: currentTheme.colors.background,
       }}
     >
-      <View
-        style={{
-          paddingTop: 32,
-          paddingBottom: 32,
-          height: '100%',
-          width: '90%',
-          maxWidth: 400,
-        }}
-      >
-        <SignUpScreen
-          promptAsync={promptAsync}
-          signup={signup}
-          signUpStatus={signUpStatus}
-          isGoogleSignInReady={isGoogleSignInReady}
-        />
-      </View>
+      <ScrollView>
+        <View
+          style={{
+            paddingTop: 32,
+            paddingBottom: 32,
+            alignItems: 'center',
+            alignSelf: 'center',
+            height: '100%',
+            width: '90%',
+            maxWidth: 400,
+          }}
+        >
+          <SignUpScreen
+            promptAsync={promptAsync}
+            signup={signup}
+            signUpStatus={signUpStatus}
+            isGoogleSignInReady={isGoogleSignInReady}
+          />
+        </View>
+      </ScrollView>
     </View>
   );
 }

--- a/packages/ui/src/Bento/forms/layouts/SignInScreen.tsx
+++ b/packages/ui/src/Bento/forms/layouts/SignInScreen.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import * as LocalAuthentication from 'expo-local-authentication';
 import {
   AnimatePresence,
@@ -71,13 +72,14 @@ export function SignInScreen({
   return (
     <FormCard>
       <View
-        flexDirection="column"
-        alignItems="stretch"
-        minWidth="100%"
-        maxWidth="100%"
+        fd="column"
+        f={1}
+        ai="stretch"
+        miw="100%"
+        maw="100%"
         gap="$4"
-        padding="$4"
-        paddingVertical="$14"
+        p="$4"
+        py="$14"
         $group-window-gtSm={{
           paddingVertical: '$4',
           width: 400,


### PR DESCRIPTION
The login screen should automatically scroll and show the current input field when the virtual keyboard show up on mobile device.

This actual look:
![image](https://github.com/user-attachments/assets/6f842235-d103-48d4-a8f9-7ffea37c6bfb)

The expected look:
![image](https://github.com/user-attachments/assets/96c0dea4-55fc-4daa-a891-d213aaf237d4)
