### PR TITLE
Create web version of downlaod button

### DIFF
--- a/packages/app/modules/map/components/DownloadMapBtn/DownloadMapBtn.web.tsx
+++ b/packages/app/modules/map/components/DownloadMapBtn/DownloadMapBtn.web.tsx
@@ -1,0 +1,7 @@
+import React, { type FC } from 'react';
+import { View } from 'react-native';
+
+export const DownloadMapBtn: FC = () => {
+  // Returns empty component on the on the web implementation.
+  return <View />;
+};

--- a/packages/app/modules/map/components/MapPreviewCard/index.tsx
+++ b/packages/app/modules/map/components/MapPreviewCard/index.tsx
@@ -1,11 +1,9 @@
-import React, { useEffect, useState, type FC } from 'react';
-import { StatusLabel } from './StatusLabel';
-import { View, RText, Card } from '@packrat/ui';
+import React, { type FC } from 'react';
+import { RText, Card } from '@packrat/ui';
 import { TouchableOpacity } from 'react-native';
 import { MapImage } from './MapImage';
-import { Entypo } from '@expo/vector-icons';
-import { useDownloadMapProgress } from 'app/modules/map/hooks/useDownloadMapProgress';
 import { type OfflineMap } from 'app/modules/map/screens/OfflineMapsScreen';
+import { DownloadMapBtn } from '../DownloadMapBtn';
 
 interface MapPreviewCardProps {
   id: string;
@@ -18,54 +16,11 @@ export const MapPreviewCard: FC<MapPreviewCardProps> = ({
   onShowMapClick,
   item,
 }) => {
-  const [isDownloaded, setIsDownloaded] = useState(item.downloaded);
-  const { downloadMap, isDownloading, progress } = useDownloadMapProgress(() =>
-    setIsDownloaded(true),
-  );
-
-  const handleDownloadMap = () => {
-    downloadMap({
-      name: item.name,
-      bounds: item.bounds,
-      styleURL: item.styleURL,
-      minZoom: item.minZoom,
-      maxZoom: item.maxZoom,
-      metadata: {
-        id: item.id,
-        userId: item.userId,
-      },
-    });
-  };
-
-  useEffect(() => {
-    setIsDownloaded(item.downloaded);
-  }, [item.downloaded]);
-
   return (
     <Card
       title={item.name}
       subtitle={
-        isDownloaded ? (
-          <StatusLabel />
-        ) : (
-          <TouchableOpacity onPress={handleDownloadMap}>
-            {isDownloading ? (
-              <RText style={{ color: '#000' }}>{`${progress}%`}</RText>
-            ) : (
-              <View
-                style={{
-                  flexDirection: 'row',
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                  gap: 8,
-                }}
-              >
-                <Entypo name={'download'} size={16} color="grey" />
-                <RText>Download</RText>
-              </View>
-            )}
-          </TouchableOpacity>
-        )
+        <DownloadMapBtn currentBounds={item.bounds} shape={item.bounds} />
       }
       link=""
       image={<MapImage />}


### PR DESCRIPTION
Fix `@rnmapbox_maps.js?v=ee7bbe6b' does not provide an export named 'offlineManager' `
![image](https://github.com/user-attachments/assets/198797e8-7510-4e34-a746-0a3b1df75f34)

Actually, the web version does not support the map download feature. 
The purpose of this pr is to disable the download button on the web platoform.
