### PR TITLE
Implement ability to stop response generation in AI chat

### DIFF
--- a/apps/expo/app/(app)/ai-chat.tsx
+++ b/apps/expo/app/(app)/ai-chat.tsx
@@ -366,7 +366,7 @@ function Composer({
         />
         <View className="absolute bottom-3 right-5">
           {isLoading ? (
-            <Button onPress={stop} size="icon" variant="tonal" className="h-7 w-7 rounded-full">
+            <Button onPress={stop} size="icon" variant="primary" className="h-7 w-7 rounded-full">
               <Icon name="stop" size={18} color="white" />
             </Button>
           ) : (


### PR DESCRIPTION
Introduce a stop function to halt ongoing response generation, enhancing user control during chat interactions.

Also removed disabling of text input while AI is response.
Rationale: 
- A stop generation button is now present,  safe guarding potential sending of message while response is being generated. 
- Currently the input doesn't provide a clear visual feedback about it's state when disabled, which could lead to confusion or even supposition of unresposiveness to the user. 
- This seems to be the idiomatic pattern as seen in existing similar chat interfaces like ChatGPT 

