### PR TITLE
Change trigger branch for guide synchronization to development

### DIFF
--- a/.github/workflows/sync-guides-r2.yml
+++ b/.github/workflows/sync-guides-r2.yml
@@ -3,7 +3,7 @@ name: Sync Guides to R2 Bucket
 on:
   push:
     branches:
-      - main
+      - development
     paths:
       - 'apps/guides/content/posts/**'
       - 'apps/guides/scripts/**'


### PR DESCRIPTION
Update the trigger branch for syncing guides to the R2 bucket from main to development.