### PR TITLE
feat: Catalog image mismatch detection (#1437)

### DIFF
--- a/packages/api/src/routes/catalog/detectImageMismatchesRoute.ts
+++ b/packages/api/src/routes/catalog/detectImageMismatchesRoute.ts
@@ -1,0 +1,59 @@
+import { createRoute, z } from '@hono/zod-openapi';
+import { ErrorResponseSchema } from '@packrat/api/schemas/catalog';
+import type { RouteHandler } from '@packrat/api/types/routeHandler';
+import { detectImageMismatches } from '../../utils/catalogImageValidator';
+
+export const routeDefinition = createRoute({
+  method: 'get',
+  path: '/image-mismatches',
+  tags: ['Catalog', 'Admin'],
+  summary: 'Detect catalog image mismatches',
+  description: 'Scan catalog for items where the image does not match the item name/category (e.g., backpack showing jacket image)',
+  security: [{ bearerAuth: [] }],
+  responses: {
+    200: {
+      description: 'List of potential image mismatches',
+      content: {
+        'application/json': {
+          schema: z.object({
+            mismatches: z.array(
+              z.object({
+                id: z.number(),
+                name: z.string(),
+                categories: z.array(z.string()),
+                imageUrl: z.string(),
+                issue: z.string(),
+              }),
+            ),
+            count: z.number(),
+          }),
+        },
+      },
+    },
+    500: {
+      description: 'Server error',
+      content: {
+        'application/json': {
+          schema: ErrorResponseSchema,
+        },
+      },
+    },
+  },
+});
+
+export const handler: RouteHandler<typeof routeDefinition> = async (c) => {
+  // TODO: Add admin-only authorization
+  const env = c.env;
+
+  try {
+    const mismatches = await detectImageMismatches(env);
+
+    return c.json({
+      mismatches,
+      count: mismatches.length,
+    }, 200);
+  } catch (error) {
+    console.error('Error detecting image mismatches:', error);
+    return c.json({ error: 'Failed to detect image mismatches' }, 500);
+  }
+};

--- a/packages/api/src/routes/catalog/index.ts
+++ b/packages/api/src/routes/catalog/index.ts
@@ -4,6 +4,7 @@ import type { Variables } from '@packrat/api/types/variables';
 import { backfillEmbeddingsRoute } from './backfillEmbeddingsRoute';
 import * as createCatalogItemRoute from './createCatalogItemRoute';
 import * as deleteCatalogItemRoute from './deleteCatalogItemRoute';
+import * as detectImageMismatchesRoute from './detectImageMismatchesRoute';
 import * as getCatalogItemRoute from './getCatalogItemRoute';
 import { getCatalogItemsCategoriesRoute } from './getCatalogItemsCategoriesRoute';
 import * as getCatalogItemsRoute from './getCatalogItemsRoute';
@@ -23,6 +24,7 @@ catalogRoutes.openapi(
   getSimilarCatalogItemsRoute.routeDefinition,
   getSimilarCatalogItemsRoute.handler,
 );
+catalogRoutes.openapi(detectImageMismatchesRoute.routeDefinition, detectImageMismatchesRoute.handler);
 catalogRoutes.openapi(deleteCatalogItemRoute.routeDefinition, deleteCatalogItemRoute.handler);
 catalogRoutes.openapi(updateCatalogItemRoute.routeDefinition, updateCatalogItemRoute.handler);
 catalogRoutes.route('/', queueCatalogEtlRoute);

--- a/packages/api/src/utils/catalogImageValidator.ts
+++ b/packages/api/src/utils/catalogImageValidator.ts
@@ -1,0 +1,135 @@
+import { createDbClient } from '../db';
+import { catalogItems } from '../db/schema';
+import { like, sql } from 'drizzle-orm';
+import type { Env } from '../types/env';
+
+/**
+ * Detects potential image mismatches in catalog items
+ * Looks for items where the name suggests one type but the image suggests another
+ */
+export async function detectImageMismatches(env: Env): Promise<
+  Array<{
+    id: number;
+    name: string;
+    categories: string[];
+    imageUrl: string;
+    issue: string;
+  }>
+> {
+  const db = createDbClient(env);
+  const mismatches: Array<{
+    id: number;
+    name: string;
+    categories: string[];
+    imageUrl: string;
+    issue: string;
+  }> = [];
+
+  // Define suspicious patterns
+  const suspiciousPatterns = [
+    {
+      namePattern: /backpack|pack/i,
+      imagePattern: /jacket|coat/i,
+      issue: 'Backpack item shows jacket image',
+    },
+    {
+      namePattern: /jacket|coat/i,
+      imagePattern: /backpack|pack/i,
+      issue: 'Jacket item shows backpack image',
+    },
+    {
+      namePattern: /tent/i,
+      imagePattern: /sleeping.?bag/i,
+      issue: 'Tent item shows sleeping bag image',
+    },
+    {
+      namePattern: /sleeping.?bag/i,
+      imagePattern: /tent/i,
+      issue: 'Sleeping bag item shows tent image',
+    },
+    {
+      namePattern: /shoe|boot|footwear/i,
+      imagePattern: /shirt|pant|clothing/i,
+      issue: 'Footwear item shows clothing image',
+    },
+    {
+      namePattern: /shirt|pant/i,
+      imagePattern: /shoe|boot/i,
+      issue: 'Clothing item shows footwear image',
+    },
+  ];
+
+  // Get all catalog items with images
+  const items = await db
+    .select({
+      id: catalogItems.id,
+      name: catalogItems.name,
+      categories: catalogItems.categories,
+      images: catalogItems.images,
+    })
+    .from(catalogItems)
+    .where(sql`${catalogItems.images} IS NOT NULL AND array_length(${catalogItems.images}, 1) > 0`);
+
+  for (const item of items) {
+    const imageUrl = item.images?.[0] || '';
+    const imageLower = imageUrl.toLowerCase();
+
+    for (const pattern of suspiciousPatterns) {
+      if (pattern.namePattern.test(item.name) && pattern.imagePattern.test(imageLower)) {
+        mismatches.push({
+          id: item.id,
+          name: item.name,
+          categories: item.categories || [],
+          imageUrl,
+          issue: pattern.issue,
+        });
+        break; // Only report first match per item
+      }
+    }
+  }
+
+  return mismatches;
+}
+
+/**
+ * Updates a catalog item's images
+ */
+export async function updateCatalogItemImages(
+  env: Env,
+  itemId: number,
+  newImages: string[],
+): Promise<void> {
+  const db = createDbClient(env);
+
+  await db
+    .update(catalogItems)
+    .set({
+      images: newImages,
+      updatedAt: new Date(),
+    })
+    .where(sql`${catalogItems.id} = ${itemId}`);
+}
+
+/**
+ * Run diagnostic and output results
+ */
+export async function runImageMismatchDiagnostic(env: Env): Promise<void> {
+  console.log('🔍 Scanning catalog for image mismatches...\n');
+
+  const mismatches = await detectImageMismatches(env);
+
+  if (mismatches.length === 0) {
+    console.log('✅ No image mismatches detected');
+    return;
+  }
+
+  console.log(`⚠️  Found ${mismatches.length} potential mismatches:\n`);
+
+  for (const mismatch of mismatches) {
+    console.log(`Item #${mismatch.id}: ${mismatch.name}`);
+    console.log(`  Categories: ${mismatch.categories.join(', ')}`);
+    console.log(`  Issue: ${mismatch.issue}`);
+    console.log(`  Image URL: ${mismatch.imageUrl}`);
+    console.log('');
+  }
+}

--- a/packages/api/test/catalog-image-validator.test.ts
+++ b/packages/api/test/catalog-image-validator.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, test } from 'bun:test';
+import { detectImageMismatches } from '../../src/utils/catalogImageValidator';
+
+// Mock the database
+const mockCatalogItems = [
+  {
+    id: 1,
+    name: 'Osprey Atmos AG 65 Backpack',
+    categories: ['backpacks', 'gear'],
+    images: ['https://example.com/backpack.jpg'],
+  },
+  {
+    id: 2,
+    name: 'Patagonia Nano Puff Jacket',
+    categories: ['clothing', 'jackets'],
+    images: ['https://example.com/jacket.jpg'],
+  },
+  {
+    id: 3,
+    name: 'REI Co-op Trail 40 Pack',
+    categories: ['backpacks'],
+    images: ['https://example.com/jacket-image.jpg'], // Mismatch!
+  },
+  {
+    id: 4,
+    name: 'North Face Down Jacket',
+    categories: ['clothing'],
+    images: ['https://example.com/backpack-gear.jpg'], // Mismatch!
+  },
+  {
+    id: 5,
+    name: 'Big Agnes Copper Spur Tent',
+    categories: ['shelter'],
+    images: ['https://example.com/tent.jpg'],
+  },
+];
+
+describe('detectImageMismatches', () => {
+  test('detects backpack with jacket image', async () => {
+    const env = {} as any;
+    
+    // Mock the database response
+    const originalSelect = jest.fn();
+    jest.mock('../../src/db', () => ({
+      createDbClient: () => ({
+        select: () => ({
+          from: () => ({
+            where: () => Promise.resolve(mockCatalogItems),
+          }),
+        }),
+      }),
+    }));
+
+    const mismatches = await detectImageMismatches(env);
+    
+    const backpackMismatch = mismatches.find(m => m.id === 3);
+    expect(backpackMismatch).toBeDefined();
+    expect(backpackMismatch?.issue).toBe('Backpack item shows jacket image');
+  });
+
+  test('detects jacket with backpack image', async () => {
+    const env = {} as any;
+    
+    const mismatches = await detectImageMismatches(env);
+    
+    const jacketMismatch = mismatches.find(m => m.id === 4);
+    expect(jacketMismatch).toBeDefined();
+    expect(jacketMismatch?.issue).toBe('Jacket item shows backpack image');
+  });
+
+  test('does not flag correctly matched items', async () => {
+    const env = {} as any;
+    
+    const mismatches = await detectImageMismatches(env);
+    
+    const correctBackpack = mismatches.find(m => m.id === 1);
+    const correctJacket = mismatches.find(m => m.id === 2);
+    const correctTent = mismatches.find(m => m.id === 5);
+    
+    expect(correctBackpack).toBeUndefined();
+    expect(correctJacket).toBeUndefined();
+    expect(correctTent).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Fixes #1437 - adds diagnostic tools to detect catalog items with mismatched images (e.g., backpack showing jacket image). Includes new utility, API endpoint, and tests.