### PR TITLE
[QA] Remove stale pnpm-lock.yaml

### DIFF
--- a/apps/landing/pnpm-lock.yaml
+++ b/apps/landing/pnpm-lock.yaml
@@ -1,5 +1,0 @@
-lockfileVersion: '9.0'
-
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false


### PR DESCRIPTION
## Summary
- Removed stale `apps/landing/pnpm-lock.yaml` lockfile
- This is a bun workspace monorepo with a root `bun.lock` — the pnpm lockfile was leftover and incorrect
- No other stale lockfiles (`pnpm-lock.yaml` or `package-lock.json`) were found in the repo

Closes #1866

## Test plan
- [x] Verify `apps/landing/pnpm-lock.yaml` no longer exists
- [x] Confirm no other stale lockfiles remain in the repo
- [ ] Ensure `bun install` still works correctly at the root

🤖 Generated with [Claude Code](https://claude.com/claude-code)