### PR TITLE
Remove unnecessary expo-build-properties dependency

### DIFF
--- a/apps/expo/app.config.ts
+++ b/apps/expo/app.config.ts
@@ -48,14 +48,6 @@ export default (): ExpoConfig =>
         'expo-router',
         'expo-sqlite',
         [
-          'expo-build-properties',
-          {
-            ios: {
-              deploymentTarget: '13.0',
-            },
-          },
-        ],
-        [
           '@react-native-google-signin/google-signin',
           {
             iosUrlScheme:

--- a/apps/expo/package.json
+++ b/apps/expo/package.json
@@ -77,7 +77,6 @@
     "expo": "^54.0.0",
     "expo-apple-authentication": "~8.0.8",
     "expo-blur": "~15.0.8",
-    "expo-build-properties": "~0.15.0",
     "expo-clipboard": "~8.0.8",
     "expo-constants": "~18.0.13",
     "expo-dev-client": "~6.0.20",


### PR DESCRIPTION
Removing the `expo-build-properties` dependency resolves an installation error encountered during setup.