### PR TITLE
Fix Build Failure Crashing E2E Test Jobs

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -31,7 +31,7 @@ env:
 jobs:
   ios-e2e:
     name: iOS E2E Tests
-    runs-on: macos-26-large
+    runs-on: macos-15
     timeout-minutes: 120
     # Skip on forked PRs — secrets are not available in forks
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
@@ -43,6 +43,11 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+      
+      - name: Setup Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: '26.2'
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v1

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -31,7 +31,7 @@ env:
 jobs:
   ios-e2e:
     name: iOS E2E Tests
-    runs-on: macos-15
+    runs-on: macos-26-large
     timeout-minutes: 120
     # Skip on forked PRs — secrets are not available in forks
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository

--- a/apps/expo/eas.json
+++ b/apps/expo/eas.json
@@ -16,10 +16,14 @@
     },
     "e2e": {
       "ios": {
-        "simulator": true
+        "simulator": true,
+        "image": "latest"
       },
       "android": {
-        "buildType": "apk"
+        "buildType": "apk",
+        "env": {
+          "GRADLE_OPTS": "-Xmx4096m -XX:MaxMetaspaceSize=1024m -Dorg.gradle.jvmargs=-Xmx4096m"
+        }
       }
     },
     "production": {

--- a/apps/expo/eas.json
+++ b/apps/expo/eas.json
@@ -21,8 +21,10 @@
       },
       "android": {
         "buildType": "apk",
+        "resourceClass": "m-medium",
+        "gradleCommand": ":app:assembleRelease -x lint -x lintVitalRelease -x lintVitalAnalyzeRelease",
         "env": {
-          "GRADLE_OPTS": "-Xmx4096m -XX:MaxMetaspaceSize=1024m -Dorg.gradle.jvmargs=-Xmx4096m"
+          "GRADLE_OPTS": "-Xmx4096m -XX:MaxMetaspaceSize=1024m"
         }
       }
     },

--- a/apps/expo/eas.json
+++ b/apps/expo/eas.json
@@ -21,10 +21,11 @@
       },
       "android": {
         "buildType": "apk",
-        "resourceClass": "medium",
-        "gradleCommand": ":app:assembleRelease -x lint -x lintVitalRelease -x lintVitalAnalyzeRelease",
+        "resourceClass": "large",
+        "gradleCommand": ":app:bundleRelease -x lintVitalAnalyzeRelease",
         "env": {
-          "GRADLE_OPTS": "-Xmx4096m -XX:MaxMetaspaceSize=1024m"
+          "GRADLE_OPTS": "-Xmx6144m -XX:MaxMetaspaceSize=1536m",
+          "JAVA_OPTS": "-Xmx6144m"
         }
       }
     },

--- a/apps/expo/eas.json
+++ b/apps/expo/eas.json
@@ -21,7 +21,7 @@
       },
       "android": {
         "buildType": "apk",
-        "resourceClass": "m-medium",
+        "resourceClass": "medium",
         "gradleCommand": ":app:assembleRelease -x lint -x lintVitalRelease -x lintVitalAnalyzeRelease",
         "env": {
           "GRADLE_OPTS": "-Xmx4096m -XX:MaxMetaspaceSize=1024m"

--- a/apps/expo/package.json
+++ b/apps/expo/package.json
@@ -83,7 +83,7 @@
     "expo-constants": "~18.0.13",
     "expo-dev-client": "~6.0.20",
     "expo-file-system": "~19.0.21",
-    "expo-glass-effect": "^55.0.8",
+    "expo-glass-effect": "~0.1.9",
     "expo-haptics": "~15.0.8",
     "expo-image": "~3.0.11",
     "expo-image-picker": "~17.0.10",


### PR DESCRIPTION
- Updates expo-glass-effect to SDK 54 compatible version
- Increase JVM memory and disable lint in android builds
- Build iOS with Xcode version 26.2 in iOS build step
- Prunes outdated code using a dep that's no longer available
- Add manual trigger to e2e job for convenient and faster iteration

