### PR TITLE
fix(ci): restore iOS E2E + biome lint (builds on #2015)

### DIFF
--- a/.github/scripts/e2e.sh
+++ b/.github/scripts/e2e.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+set -e
+
+PLATFORM=$1  # "ios" or "android"
+
+# Generate unique ID for this test run
+UNIQUE_ID=$(date +%s)
+
+if [ "$PLATFORM" = "ios" ]; then
+  START_DATE=$(date -j -v+7d +"%Y-%m-%d")
+  END_DATE=$(date -j -v+14d +"%Y-%m-%d")
+
+  get_month() { date -j -f "%Y-%m-%d" "$1" +"%B"; }
+  get_day()   { date -j -f "%Y-%m-%d" "$1" +"%-d"; }
+  get_year()  { date -j -f "%Y-%m-%d" "$1" +"%Y"; }
+  get_month_num() { date -j -f "%Y-%m-%d" "$1" +"%-m"; }
+else
+  START_DATE=$(date -d "+7 days" +"%Y-%m-%d")
+  END_DATE=$(date -d "+14 days" +"%Y-%m-%d")
+
+  get_month() { date -d "$1" +"%B"; }
+  get_day()   { date -d "$1" +"%-d"; }
+  get_year()  { date -d "$1" +"%Y"; }
+  get_month_num() { date -d "$1" +"%-m"; }
+fi
+
+CURRENT_YEAR=$(date +"%Y")
+CURRENT_MONTH=$(date +"%-m")
+
+START_TAPS=$(( ($(get_year "$START_DATE") - CURRENT_YEAR) * 12 + ($(get_month_num "$START_DATE") - CURRENT_MONTH) ))
+END_TAPS=$(( ($(get_year "$END_DATE") - CURRENT_YEAR) * 12 + ($(get_month_num "$END_DATE") - CURRENT_MONTH) ))
+
+if [ "$PLATFORM" = "ios" ]; then
+  maestro test --config .maestro/config.yaml .maestro/master-flow.yaml \
+    -e TEST_EMAIL="${TEST_EMAIL:-qa1.admin@packratai.com}" \
+    -e TEST_PASSWORD="${TEST_PASSWORD:-Ab12345.}" \
+    -e TRIP_NAME="${TRIP_NAME:-E2E-Trip-$UNIQUE_ID}" \
+    -e PACK_NAME="${PACK_NAME:-E2E-Pack-$UNIQUE_ID}" \
+    -e APP_ID="${APP_ID:-com.andrewbierman.packrat.preview}" \
+    -e START_YEAR="$(get_year "$START_DATE")" \
+    -e START_MONTH="$(get_month "$START_DATE")" \
+    -e START_DAY="$(get_day "$START_DATE")" \
+    -e START_TAPS="$START_TAPS" \
+    -e END_YEAR="$(get_year "$END_DATE")" \
+    -e END_MONTH="$(get_month "$END_DATE")" \
+    -e END_DAY="$(get_day "$END_DATE")" \
+    -e END_TAPS="$END_TAPS"
+else
+  maestro test --config .maestro/config-android.yaml .maestro/master-flow-android.yaml \
+    -e TEST_EMAIL="${TEST_EMAIL:-qa1.admin@packratai.com}" \
+    -e TEST_PASSWORD="${TEST_PASSWORD:-Ab12345.}" \
+    -e TRIP_NAME="${TRIP_NAME:-E2E-Trip-$UNIQUE_ID}" \
+    -e PACK_NAME="${PACK_NAME:-E2E-Pack-$UNIQUE_ID}" \
+    -e APP_ID="${APP_ID:-com.packratai.mobile.preview}" \
+    -e START_YEAR="$(get_year "$START_DATE")" \
+    -e START_MONTH="$(get_month "$START_DATE")" \
+    -e START_DAY="$(get_day "$START_DATE")" \
+    -e START_TAPS="$START_TAPS" \
+    -e END_YEAR="$(get_year "$END_DATE")" \
+    -e END_MONTH="$(get_month "$END_DATE")" \
+    -e END_DAY="$(get_day "$END_DATE")" \
+    -e END_TAPS="$END_TAPS"
+fi

--- a/.github/scripts/e2e.sh
+++ b/.github/scripts/e2e.sh
@@ -2,6 +2,7 @@
 set -e
 
 PLATFORM=$1  # "ios" or "android"
+shift  # Remove first argument so $@ contains only the additional options
 
 # Generate unique ID for this test run
 UNIQUE_ID=$(date +%s)
@@ -31,7 +32,7 @@ START_TAPS=$(( ($(get_year "$START_DATE") - CURRENT_YEAR) * 12 + ($(get_month_nu
 END_TAPS=$(( ($(get_year "$END_DATE") - CURRENT_YEAR) * 12 + ($(get_month_num "$END_DATE") - CURRENT_MONTH) ))
 
 if [ "$PLATFORM" = "ios" ]; then
-  maestro test --config .maestro/config.yaml .maestro/master-flow.yaml \
+  maestro test --config .maestro/config.yaml $@ \
     -e TEST_EMAIL="${TEST_EMAIL:-qa1.admin@packratai.com}" \
     -e TEST_PASSWORD="${TEST_PASSWORD:-Ab12345.}" \
     -e TRIP_NAME="${TRIP_NAME:-E2E-Trip-$UNIQUE_ID}" \
@@ -44,9 +45,10 @@ if [ "$PLATFORM" = "ios" ]; then
     -e END_YEAR="$(get_year "$END_DATE")" \
     -e END_MONTH="$(get_month "$END_DATE")" \
     -e END_DAY="$(get_day "$END_DATE")" \
-    -e END_TAPS="$END_TAPS"
+    -e END_TAPS="$END_TAPS" \
+    .maestro/master-flow.yaml
 else
-  maestro test --config .maestro/config-android.yaml .maestro/master-flow-android.yaml \
+  maestro test --config .maestro/config-android.yaml $@ \
     -e TEST_EMAIL="${TEST_EMAIL:-qa1.admin@packratai.com}" \
     -e TEST_PASSWORD="${TEST_PASSWORD:-Ab12345.}" \
     -e TRIP_NAME="${TRIP_NAME:-E2E-Trip-$UNIQUE_ID}" \
@@ -59,5 +61,6 @@ else
     -e END_YEAR="$(get_year "$END_DATE")" \
     -e END_MONTH="$(get_month "$END_DATE")" \
     -e END_DAY="$(get_day "$END_DATE")" \
-    -e END_TAPS="$END_TAPS"
+    -e END_TAPS="$END_TAPS" \
+    .maestro/master-flow-android.yaml
 fi

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -26,7 +26,7 @@ permissions:
   contents: read
 
 env:
-  MAESTRO_VERSION: 1.40.0
+  MAESTRO_VERSION: 2.3.0
 
 jobs:
   ios-e2e:

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -77,6 +77,9 @@ jobs:
           curl -Ls "https://get.maestro.mobile.dev" | bash
           echo "${HOME}/.maestro/bin" >> "${GITHUB_PATH}"
 
+      - name: Log Maestro Version
+        run: maestro -v
+
       - name: Build iOS app for simulator
         run: |
           cd apps/expo

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -71,15 +71,6 @@ jobs:
           distribution: temurin
           java-version: "17"
 
-      - name: Install Maestro CLI
-        run: |
-          export MAESTRO_VERSION="${{ env.MAESTRO_VERSION }}"
-          curl -Ls "https://get.maestro.mobile.dev" | bash
-          echo "${HOME}/.maestro/bin" >> "${GITHUB_PATH}"
-
-      - name: Log Maestro Version
-        run: maestro -v
-
       - name: Build iOS app for simulator
         run: |
           cd apps/expo
@@ -93,6 +84,12 @@ jobs:
         env:
           EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
           PACKRAT_NATIVEWIND_UI_GITHUB_TOKEN: ${{ secrets.PACKRAT_NATIVEWIND_UI_GITHUB_TOKEN }}
+
+      - name: Install Maestro CLI
+        run: |
+          export MAESTRO_VERSION="${{ env.MAESTRO_VERSION }}"
+          curl -Ls "https://get.maestro.mobile.dev" | bash
+          echo "${HOME}/.maestro/bin" >> "${GITHUB_PATH}"
 
       - name: Extract iOS simulator build
         run: |

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -154,12 +154,12 @@ jobs:
           maestro --device "$SIMULATOR_UDID" test \
             --format junit \
             --output test-results/maestro-results.xml \
+            -e TEST_EMAIL="${{ secrets.E2E_TEST_EMAIL }}" \
+            -e TEST_PASSWORD="${{ secrets.E2E_TEST_PASSWORD }}" \
+            -e TRIP_NAME="E2E-Trip-${{ github.run_id }}" \
+            -e PACK_NAME="E2E-Pack-${{ github.run_id }}" \
+            -e APP_ID="com.andrewbierman.packrat.preview" \
             .maestro/master-flow.yaml
-        env:
-          TEST_EMAIL: ${{ secrets.E2E_TEST_EMAIL }}
-          TEST_PASSWORD: ${{ secrets.E2E_TEST_PASSWORD }}
-          TRIP_NAME: E2E-Trip-${{ github.run_id }}
-          PACK_NAME: E2E-Pack-${{ github.run_id }}
 
       - name: Upload test results
         if: always()
@@ -267,12 +267,12 @@ jobs:
               --config .maestro/config-android.yaml \
               --format junit \
               --output test-results/maestro-results.xml \
+              -e TEST_EMAIL="${{ secrets.E2E_TEST_EMAIL }}" \
+              -e TEST_PASSWORD="${{ secrets.E2E_TEST_PASSWORD }}" \
+              -e TRIP_NAME="E2E-Trip-${{ github.run_id }}" \
+              -e PACK_NAME="E2E-Pack-${{ github.run_id }}" \
+              -e APP_ID="com.packratai.mobile.preview" \
               .maestro/master-flow-android.yaml
-        env:
-          TEST_EMAIL: ${{ secrets.E2E_TEST_EMAIL }}
-          TEST_PASSWORD: ${{ secrets.E2E_TEST_PASSWORD }}
-          TRIP_NAME: E2E-Trip-${{ github.run_id }}
-          PACK_NAME: E2E-Pack-${{ github.run_id }}
 
       - name: Upload test results
         if: always()

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -172,107 +172,107 @@ jobs:
           xcrun simctl shutdown "$SIMULATOR_UDID" || true
           xcrun simctl delete "$SIMULATOR_UDID" || true
 
-  # android-e2e:
-  #   name: Android E2E Tests
-  #   runs-on: ubuntu-latest
-  #   timeout-minutes: 120
-  #   # Skip on forked PRs — secrets are not available in forks
-  #   if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+  android-e2e:
+    name: Android E2E Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    # Skip on forked PRs — secrets are not available in forks
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
 
-  #   env:
-  #     TEST_EMAIL: ${{ secrets.E2E_TEST_EMAIL }}
-  #     TEST_PASSWORD: ${{ secrets.E2E_TEST_PASSWORD }}
+    env:
+      TEST_EMAIL: ${{ secrets.E2E_TEST_EMAIL }}
+      TEST_PASSWORD: ${{ secrets.E2E_TEST_PASSWORD }}
 
-  #   steps:
-  #     - name: Checkout repository
-  #       uses: actions/checkout@v4
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
 
-  #     - name: Setup Bun
-  #       uses: oven-sh/setup-bun@v1
-  #       with:
-  #         bun-version: latest
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: latest
 
-  #     - name: Install dependencies
-  #       env:
-  #         PACKRAT_NATIVEWIND_UI_GITHUB_TOKEN: ${{ secrets.PACKRAT_NATIVEWIND_UI_GITHUB_TOKEN }}
-  #       run: bun install
+      - name: Install dependencies
+        env:
+          PACKRAT_NATIVEWIND_UI_GITHUB_TOKEN: ${{ secrets.PACKRAT_NATIVEWIND_UI_GITHUB_TOKEN }}
+        run: bun install
 
-  #     - name: Setup Expo
-  #       uses: expo/expo-github-action@v8
-  #       with:
-  #         eas-version: latest
-  #         token: ${{ secrets.EXPO_TOKEN }}
+      - name: Setup Expo
+        uses: expo/expo-github-action@v8
+        with:
+          eas-version: latest
+          token: ${{ secrets.EXPO_TOKEN }}
 
-  #     - name: Setup Java
-  #       uses: actions/setup-java@v4
-  #       with:
-  #         distribution: temurin
-  #         java-version: "17"
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
 
-  #     - name: Install Maestro CLI
-  #       run: |
-  #         export MAESTRO_VERSION="${{ env.MAESTRO_VERSION }}"
-  #         curl -Ls "https://get.maestro.mobile.dev" | bash
-  #         echo "${HOME}/.maestro/bin" >> "${GITHUB_PATH}"
+      - name: Install Maestro CLI
+        run: |
+          export MAESTRO_VERSION="${{ env.MAESTRO_VERSION }}"
+          curl -Ls "https://get.maestro.mobile.dev" | bash
+          echo "${HOME}/.maestro/bin" >> "${GITHUB_PATH}"
 
-  #     - name: Build Android APK for emulator
-  #       run: |
-  #         cd apps/expo
-  #         mkdir -p build
-  #         eas build \
-  #           --platform android \
-  #           --profile e2e \
-  #           --non-interactive \
-  #           --local \
-  #           --output ./build/PackRat.apk
-  #       env:
-  #         EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
-  #         PACKRAT_NATIVEWIND_UI_GITHUB_TOKEN: ${{ secrets.PACKRAT_NATIVEWIND_UI_GITHUB_TOKEN }}
+      - name: Build Android APK for emulator
+        run: |
+          cd apps/expo
+          mkdir -p build
+          eas build \
+            --platform android \
+            --profile e2e \
+            --non-interactive \
+            --local \
+            --output ./build/PackRat.apk
+        env:
+          EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+          PACKRAT_NATIVEWIND_UI_GITHUB_TOKEN: ${{ secrets.PACKRAT_NATIVEWIND_UI_GITHUB_TOKEN }}
 
-  #     - name: Enable KVM for hardware acceleration
-  #       run: |
-  #         echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' \
-  #           | sudo tee /etc/udev/rules.d/99-kvm4all.rules
-  #         sudo udevadm control --reload-rules
-  #         sudo udevadm trigger --name-match=kvm
+      - name: Enable KVM for hardware acceleration
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' \
+            | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
 
-  #     - name: Run Maestro E2E tests on Android emulator
-  #       uses: reactivecircus/android-emulator-runner@v2.34.0
-  #       with:
-  #         api-level: 34
-  #         target: google_apis
-  #         arch: x86_64
-  #         profile: pixel_6
-  #         avd-name: PackRat-E2E
-  #         force-avd-creation: false
-  #         emulator-options: >-
-  #           -no-snapshot-save -no-window -gpu swiftshader_indirect
-  #           -noaudio -no-boot-anim -camera-back none
-  #         disable-animations: true
-  #         script: |
-  #           mkdir -p test-results
-  #           adb shell pm disable-user com.android.launcher3 || true
-  #           adb shell pm disable-user com.google.android.apps.nexuslauncher || true
-  #           adb install apps/expo/build/PackRat.apk
-  #           export TEST_EMAIL="${{ secrets.E2E_TEST_EMAIL }}"
-  #           export TEST_PASSWORD="${{ secrets.E2E_TEST_PASSWORD }}"
-  #           export TRIP_NAME="E2E-Trip-${{ github.run_id }}"
-  #           export PACK_NAME="E2E-Pack-${{ github.run_id }}"
-  #           export APP_ID="com.packratai.mobile.preview"
-  #           bun test:e2e:android --format junit --output test-results/maestro-results.xml
+      - name: Run Maestro E2E tests on Android emulator
+        uses: reactivecircus/android-emulator-runner@v2.34.0
+        with:
+          api-level: 34
+          target: google_apis
+          arch: x86_64
+          profile: pixel_6
+          avd-name: PackRat-E2E
+          force-avd-creation: false
+          emulator-options: >-
+            -no-snapshot-save -no-window -gpu swiftshader_indirect
+            -noaudio -no-boot-anim -camera-back none
+          disable-animations: true
+          script: |
+            mkdir -p test-results
+            adb shell pm disable-user com.android.launcher3 || true
+            adb shell pm disable-user com.google.android.apps.nexuslauncher || true
+            adb install apps/expo/build/PackRat.apk
+            export TEST_EMAIL="${{ secrets.E2E_TEST_EMAIL }}"
+            export TEST_PASSWORD="${{ secrets.E2E_TEST_PASSWORD }}"
+            export TRIP_NAME="E2E-Trip-${{ github.run_id }}"
+            export PACK_NAME="E2E-Pack-${{ github.run_id }}"
+            export APP_ID="com.packratai.mobile.preview"
+            bun test:e2e:android --format junit --output test-results/maestro-results.xml
 
-  #     - name: Upload test results
-  #       if: always()
-  #       uses: actions/upload-artifact@v4
-  #       with:
-  #         name: android-e2e-results
-  #         path: test-results/
-  #         retention-days: 30
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: android-e2e-results
+          path: test-results/
+          retention-days: 30
 
-  #     - name: Upload Maestro screenshots and videos on failure
-  #       if: failure()
-  #       uses: actions/upload-artifact@v4
-  #       with:
-  #         name: android-e2e-failure-artifacts
-  #         path: ~/.maestro/tests/
-  #         retention-days: 7
+      - name: Upload Maestro screenshots and videos on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: android-e2e-failure-artifacts
+          path: ~/.maestro/tests/
+          retention-days: 7

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -151,15 +151,13 @@ jobs:
       - name: Run Maestro E2E tests
         run: |
           mkdir -p test-results
-          maestro --device "$SIMULATOR_UDID" test \
-            --format junit \
-            --output test-results/maestro-results.xml \
-            -e TEST_EMAIL="${{ secrets.E2E_TEST_EMAIL }}" \
-            -e TEST_PASSWORD="${{ secrets.E2E_TEST_PASSWORD }}" \
-            -e TRIP_NAME="E2E-Trip-${{ github.run_id }}" \
-            -e PACK_NAME="E2E-Pack-${{ github.run_id }}" \
-            -e APP_ID="com.andrewbierman.packrat.preview" \
-            .maestro/master-flow.yaml
+          bun test:e2e:ios --device "$SIMULATOR_UDID" --format junit --output test-results/maestro-results.xml
+        env:
+          TEST_EMAIL: ${{ secrets.E2E_TEST_EMAIL }}
+          TEST_PASSWORD: ${{ secrets.E2E_TEST_PASSWORD }}
+          TRIP_NAME: E2E-Trip-${{ github.run_id }}
+          PACK_NAME: E2E-Pack-${{ github.run_id }}
+          APP_ID: com.andrewbierman.packrat.preview
 
       - name: Upload test results
         if: always()
@@ -263,16 +261,12 @@ jobs:
           script: |
             mkdir -p test-results
             adb install apps/expo/build/PackRat.apk
-            maestro test \
-              --config .maestro/config-android.yaml \
-              --format junit \
-              --output test-results/maestro-results.xml \
-              -e TEST_EMAIL="${{ secrets.E2E_TEST_EMAIL }}" \
-              -e TEST_PASSWORD="${{ secrets.E2E_TEST_PASSWORD }}" \
-              -e TRIP_NAME="E2E-Trip-${{ github.run_id }}" \
-              -e PACK_NAME="E2E-Pack-${{ github.run_id }}" \
-              -e APP_ID="com.packratai.mobile.preview" \
-              .maestro/master-flow-android.yaml
+            export TEST_EMAIL="${{ secrets.E2E_TEST_EMAIL }}"
+            export TEST_PASSWORD="${{ secrets.E2E_TEST_PASSWORD }}"
+            export TRIP_NAME="E2E-Trip-${{ github.run_id }}"
+            export PACK_NAME="E2E-Pack-${{ github.run_id }}"
+            export APP_ID="com.packratai.mobile.preview"
+            bun test:e2e:android --format junit --output test-results/maestro-results.xml
 
       - name: Upload test results
         if: always()

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -172,107 +172,107 @@ jobs:
           xcrun simctl shutdown "$SIMULATOR_UDID" || true
           xcrun simctl delete "$SIMULATOR_UDID" || true
 
-  android-e2e:
-    name: Android E2E Tests
-    runs-on: ubuntu-latest
-    timeout-minutes: 120
-    # Skip on forked PRs — secrets are not available in forks
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+  # android-e2e:
+  #   name: Android E2E Tests
+  #   runs-on: ubuntu-latest
+  #   timeout-minutes: 120
+  #   # Skip on forked PRs — secrets are not available in forks
+  #   if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
 
-    env:
-      TEST_EMAIL: ${{ secrets.E2E_TEST_EMAIL }}
-      TEST_PASSWORD: ${{ secrets.E2E_TEST_PASSWORD }}
+  #   env:
+  #     TEST_EMAIL: ${{ secrets.E2E_TEST_EMAIL }}
+  #     TEST_PASSWORD: ${{ secrets.E2E_TEST_PASSWORD }}
 
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
+  #   steps:
+  #     - name: Checkout repository
+  #       uses: actions/checkout@v4
 
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v1
-        with:
-          bun-version: latest
+  #     - name: Setup Bun
+  #       uses: oven-sh/setup-bun@v1
+  #       with:
+  #         bun-version: latest
 
-      - name: Install dependencies
-        env:
-          PACKRAT_NATIVEWIND_UI_GITHUB_TOKEN: ${{ secrets.PACKRAT_NATIVEWIND_UI_GITHUB_TOKEN }}
-        run: bun install
+  #     - name: Install dependencies
+  #       env:
+  #         PACKRAT_NATIVEWIND_UI_GITHUB_TOKEN: ${{ secrets.PACKRAT_NATIVEWIND_UI_GITHUB_TOKEN }}
+  #       run: bun install
 
-      - name: Setup Expo
-        uses: expo/expo-github-action@v8
-        with:
-          eas-version: latest
-          token: ${{ secrets.EXPO_TOKEN }}
+  #     - name: Setup Expo
+  #       uses: expo/expo-github-action@v8
+  #       with:
+  #         eas-version: latest
+  #         token: ${{ secrets.EXPO_TOKEN }}
 
-      - name: Setup Java
-        uses: actions/setup-java@v4
-        with:
-          distribution: temurin
-          java-version: "17"
+  #     - name: Setup Java
+  #       uses: actions/setup-java@v4
+  #       with:
+  #         distribution: temurin
+  #         java-version: "17"
 
-      - name: Install Maestro CLI
-        run: |
-          export MAESTRO_VERSION="${{ env.MAESTRO_VERSION }}"
-          curl -Ls "https://get.maestro.mobile.dev" | bash
-          echo "${HOME}/.maestro/bin" >> "${GITHUB_PATH}"
+  #     - name: Install Maestro CLI
+  #       run: |
+  #         export MAESTRO_VERSION="${{ env.MAESTRO_VERSION }}"
+  #         curl -Ls "https://get.maestro.mobile.dev" | bash
+  #         echo "${HOME}/.maestro/bin" >> "${GITHUB_PATH}"
 
-      - name: Build Android APK for emulator
-        run: |
-          cd apps/expo
-          mkdir -p build
-          eas build \
-            --platform android \
-            --profile e2e \
-            --non-interactive \
-            --local \
-            --output ./build/PackRat.apk
-        env:
-          EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
-          PACKRAT_NATIVEWIND_UI_GITHUB_TOKEN: ${{ secrets.PACKRAT_NATIVEWIND_UI_GITHUB_TOKEN }}
+  #     - name: Build Android APK for emulator
+  #       run: |
+  #         cd apps/expo
+  #         mkdir -p build
+  #         eas build \
+  #           --platform android \
+  #           --profile e2e \
+  #           --non-interactive \
+  #           --local \
+  #           --output ./build/PackRat.apk
+  #       env:
+  #         EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+  #         PACKRAT_NATIVEWIND_UI_GITHUB_TOKEN: ${{ secrets.PACKRAT_NATIVEWIND_UI_GITHUB_TOKEN }}
 
-      - name: Enable KVM for hardware acceleration
-        run: |
-          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' \
-            | sudo tee /etc/udev/rules.d/99-kvm4all.rules
-          sudo udevadm control --reload-rules
-          sudo udevadm trigger --name-match=kvm
+  #     - name: Enable KVM for hardware acceleration
+  #       run: |
+  #         echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' \
+  #           | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+  #         sudo udevadm control --reload-rules
+  #         sudo udevadm trigger --name-match=kvm
 
-      - name: Run Maestro E2E tests on Android emulator
-        uses: reactivecircus/android-emulator-runner@v2.34.0
-        with:
-          api-level: 34
-          target: google_apis
-          arch: x86_64
-          profile: pixel_6
-          avd-name: PackRat-E2E
-          force-avd-creation: false
-          emulator-options: >-
-            -no-snapshot-save -no-window -gpu swiftshader_indirect
-            -noaudio -no-boot-anim -camera-back none
-          disable-animations: true
-          script: |
-            mkdir -p test-results
-            adb shell pm disable-user com.android.launcher3 || true
-            adb shell pm disable-user com.google.android.apps.nexuslauncher || true
-            adb install apps/expo/build/PackRat.apk
-            export TEST_EMAIL="${{ secrets.E2E_TEST_EMAIL }}"
-            export TEST_PASSWORD="${{ secrets.E2E_TEST_PASSWORD }}"
-            export TRIP_NAME="E2E-Trip-${{ github.run_id }}"
-            export PACK_NAME="E2E-Pack-${{ github.run_id }}"
-            export APP_ID="com.packratai.mobile.preview"
-            bun test:e2e:android --format junit --output test-results/maestro-results.xml
+  #     - name: Run Maestro E2E tests on Android emulator
+  #       uses: reactivecircus/android-emulator-runner@v2.34.0
+  #       with:
+  #         api-level: 34
+  #         target: google_apis
+  #         arch: x86_64
+  #         profile: pixel_6
+  #         avd-name: PackRat-E2E
+  #         force-avd-creation: false
+  #         emulator-options: >-
+  #           -no-snapshot-save -no-window -gpu swiftshader_indirect
+  #           -noaudio -no-boot-anim -camera-back none
+  #         disable-animations: true
+  #         script: |
+  #           mkdir -p test-results
+  #           adb shell pm disable-user com.android.launcher3 || true
+  #           adb shell pm disable-user com.google.android.apps.nexuslauncher || true
+  #           adb install apps/expo/build/PackRat.apk
+  #           export TEST_EMAIL="${{ secrets.E2E_TEST_EMAIL }}"
+  #           export TEST_PASSWORD="${{ secrets.E2E_TEST_PASSWORD }}"
+  #           export TRIP_NAME="E2E-Trip-${{ github.run_id }}"
+  #           export PACK_NAME="E2E-Pack-${{ github.run_id }}"
+  #           export APP_ID="com.packratai.mobile.preview"
+  #           bun test:e2e:android --format junit --output test-results/maestro-results.xml
 
-      - name: Upload test results
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: android-e2e-results
-          path: test-results/
-          retention-days: 30
+  #     - name: Upload test results
+  #       if: always()
+  #       uses: actions/upload-artifact@v4
+  #       with:
+  #         name: android-e2e-results
+  #         path: test-results/
+  #         retention-days: 30
 
-      - name: Upload Maestro screenshots and videos on failure
-        if: failure()
-        uses: actions/upload-artifact@v4
-        with:
-          name: android-e2e-failure-artifacts
-          path: ~/.maestro/tests/
-          retention-days: 7
+  #     - name: Upload Maestro screenshots and videos on failure
+  #       if: failure()
+  #       uses: actions/upload-artifact@v4
+  #       with:
+  #         name: android-e2e-failure-artifacts
+  #         path: ~/.maestro/tests/
+  #         retention-days: 7

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -263,6 +263,8 @@ jobs:
           disable-animations: true
           script: |
             mkdir -p test-results
+            adb shell pm disable-user com.android.launcher3 || true
+            adb shell pm disable-user com.google.android.apps.nexuslauncher || true
             adb install apps/expo/build/PackRat.apk
             export TEST_EMAIL="${{ secrets.E2E_TEST_EMAIL }}"
             export TEST_PASSWORD="${{ secrets.E2E_TEST_PASSWORD }}"

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -104,43 +104,34 @@ jobs:
 
       - name: Boot iOS Simulator
         run: |
-          # Find the latest available iOS runtime (prefer 18, fall back to 17, then any available iOS runtime)
           IOS_RUNTIME=$(xcrun simctl list runtimes --json \
             | python3 -c "
           import sys, json
           data = json.load(sys.stdin)
           runtimes = data.get('runtimes', [])
-          available = [r for r in runtimes if r.get('isAvailable', False) and r.get('platform', r.get('name','')).startswith('iOS')]
-          # Fallback: also match by name containing 'iOS' in case 'platform' key is absent
-          if not available:
-              available = [r for r in runtimes if r.get('isAvailable', False) and 'iOS' in r.get('name','')]
-          ios18 = [r for r in available if 'iOS 18' in r.get('name','')]
-          ios17 = [r for r in available if 'iOS 17' in r.get('name','')]
-          chosen = ios18 or ios17 or available
-          if not chosen:
-              print('', file=sys.stderr)
+          available = [r for r in runtimes if r.get('isAvailable', False)]
+          ios26 = [r for r in available if 'iOS 26' in r.get('name','')]
+          if not ios26:
+              print('::error::No iOS 26 runtime found on this runner', file=sys.stderr)
               sys.exit(1)
-          print(chosen[-1]['identifier'])
+          print(ios26[-1]['identifier'])
           ")
-          if [ -z "$IOS_RUNTIME" ]; then
-            echo "::error::No available iOS runtime found on this runner"
-            exit 1
-          fi
-          # Find iPhone 15 device type (base or Pro)
+
           DEVICE_TYPE=$(xcrun simctl list devicetypes --json \
             | python3 -c "
           import sys, json
           types = json.load(sys.stdin)['devicetypes']
-          iphone15 = [d for d in types if 'iPhone 15' in d.get('name','') and 'Pro' not in d.get('name','') and 'Plus' not in d.get('name','') and 'Max' not in d.get('name','')]
-          fallback = [d for d in types if 'iPhone 15' in d.get('name','')]
-          chosen = (iphone15 or fallback)
-          print(chosen[0]['identifier'] if chosen else 'com.apple.CoreSimulator.SimDeviceType.iPhone-15')
+          iphone16 = [d for d in types if 'iPhone 16' in d.get('name','') and 'Pro' not in d.get('name','') and 'Plus' not in d.get('name','') and 'Max' not in d.get('name','')]
+          if not iphone16:
+              print('::error::No iPhone 16 device type found on this runner', file=sys.stderr)
+              sys.exit(1)
+          print(iphone16[0]['identifier'])
           ")
+
           echo "Using runtime: $IOS_RUNTIME"
           echo "Using device type: $DEVICE_TYPE"
           DEVICE_ID=$(xcrun simctl create "PackRat-E2E" "$DEVICE_TYPE" "$IOS_RUNTIME")
           xcrun simctl boot "$DEVICE_ID"
-          # Wait for the simulator to be fully booted before continuing
           xcrun simctl bootstatus "$DEVICE_ID" -b
           echo "SIMULATOR_UDID=$DEVICE_ID" >> "$GITHUB_ENV"
 

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -154,7 +154,7 @@ jobs:
           maestro --device "$SIMULATOR_UDID" test \
             --format junit \
             --output test-results/maestro-results.xml \
-            .maestro/
+            .maestro/master-flow.yaml
         env:
           TEST_EMAIL: ${{ secrets.E2E_TEST_EMAIL }}
           TEST_PASSWORD: ${{ secrets.E2E_TEST_PASSWORD }}
@@ -263,13 +263,11 @@ jobs:
           script: |
             mkdir -p test-results
             adb install apps/expo/build/PackRat.apk
-            cp .maestro/config.yaml .maestro/config.yaml.bak
-            cp .maestro/config-android.yaml .maestro/config.yaml
             maestro test \
+              --config .maestro/config-android.yaml \
               --format junit \
               --output test-results/maestro-results.xml \
-              .maestro/
-            mv .maestro/config.yaml.bak .maestro/config.yaml
+              .maestro/master-flow-android.yaml
         env:
           TEST_EMAIL: ${{ secrets.E2E_TEST_EMAIL }}
           TEST_PASSWORD: ${{ secrets.E2E_TEST_PASSWORD }}

--- a/.maestro/README.md
+++ b/.maestro/README.md
@@ -6,17 +6,33 @@ This directory contains end-to-end tests for the PackRat mobile app using [Maest
 
 ```text
 .maestro/
-├── config.yaml                    # Maestro suite configuration & flow order
+├── config.yaml                    # Workspace configuration (test discovery, env vars)
+├── config-android.yaml            # Android-specific workspace configuration 
+├── master-flow.yaml               # Main orchestration flow (iOS)
+├── master-flow-android.yaml       # Android orchestration flow
 └── flows/
     ├── setup/
     │   └── clear-state.yaml       # Clears app state before test suite
     ├── auth/
     │   ├── login-flow.yaml        # Sign in with email and password
     │   └── logout-flow.yaml       # Sign out from the app
+    ├── dashboard/
+    │   └── dashboard-tiles-flow.yaml  # Test dashboard navigation
     ├── trips/
-    │   └── create-trip-flow.yaml  # Create a new trip
-    └── packs/
-        └── create-pack-flow.yaml  # Create a new pack
+    │   ├── create-trip-flow.yaml  # Create a new trip
+    │   └── trip-detail-flow.yaml  # View trip details
+    ├── packs/
+    │   ├── create-pack-flow.yaml  # Create a new pack
+    │   ├── pack-detail-flow.yaml  # View pack details
+    │   └── add-item-actions-flow.yaml  # Add items to packs
+    ├── catalog/
+    │   ├── catalog-browse-flow.yaml   # Browse item catalog
+    │   └── catalog-item-detail-flow.yaml  # View item details
+    ├── profile/
+    │   └── profile-view-flow.yaml     # View user profile
+    └── negative/
+        ├── empty-pack-submit-flow.yaml   # Test validation errors
+        └── empty-trip-submit-flow.yaml   # Test validation errors
 ```
 
 ## Prerequisites
@@ -42,9 +58,14 @@ This directory contains end-to-end tests for the PackRat mobile app using [Maest
 
 ## Running Tests
 
-### Run all flows
+### Run the complete test suite (recommended)
 ```bash
-maestro test .maestro/config.yaml
+maestro test .maestro/master-flow.yaml
+```
+
+### Run Android-specific test suite
+```bash
+maestro test --config .maestro/config-android.yaml .maestro/master-flow-android.yaml
 ```
 
 ### Run a single flow
@@ -54,7 +75,7 @@ maestro test .maestro/flows/auth/login-flow.yaml
 
 ### Run with JUnit output (for CI)
 ```bash
-maestro test --format junit --output test-results.xml .maestro/config.yaml
+maestro test --format junit --output test-results.xml .maestro/master-flow.yaml
 ```
 
 ### Run on a specific simulator

--- a/.maestro/README.md
+++ b/.maestro/README.md
@@ -42,11 +42,10 @@ This directory contains end-to-end tests for the PackRat mobile app using [Maest
    curl -Ls "https://get.maestro.mobile.dev" | bash
    ```
 
-2. **Set up environment variables** for test credentials:
-   ```bash
-   export TEST_EMAIL="your-test-account@example.com"
-   export TEST_PASSWORD="your-test-password"
-   ```
+2. **Set up test credentials** (will be passed to Maestro via `-e` flags):
+   - TEST_EMAIL: your test account email
+   - TEST_PASSWORD: your test account password  
+   - APP_ID: com.andrewbierman.packrat.preview (iOS) or com.packratai.mobile.preview (Android)
 
 3. **Build and install the app** on a simulator/device (run from `apps/expo/`):
    ```bash
@@ -58,24 +57,48 @@ This directory contains end-to-end tests for the PackRat mobile app using [Maest
 
 ## Running Tests
 
-### Run the complete test suite (recommended)
+### Run iOS test suite
 ```bash
-maestro test .maestro/master-flow.yaml
+maestro test \
+  -e TEST_EMAIL="your-test-account@example.com" \
+  -e TEST_PASSWORD="your-test-password" \
+  -e APP_ID="com.andrewbierman.packrat.preview" \
+  -e TRIP_NAME="Test-Trip-$(date +%s)" \
+  -e PACK_NAME="Test-Pack-$(date +%s)" \
+  .maestro/master-flow.yaml
 ```
 
-### Run Android-specific test suite
+### Run Android test suite
 ```bash
-maestro test --config .maestro/config-android.yaml .maestro/master-flow-android.yaml
+maestro test \
+  --config .maestro/config-android.yaml \
+  -e TEST_EMAIL="your-test-account@example.com" \
+  -e TEST_PASSWORD="your-test-password" \
+  -e APP_ID="com.packratai.mobile.preview" \
+  -e TRIP_NAME="Test-Trip-$(date +%s)" \
+  -e PACK_NAME="Test-Pack-$(date +%s)" \
+  .maestro/master-flow-android.yaml
 ```
 
 ### Run a single flow
 ```bash
-maestro test .maestro/flows/auth/login-flow.yaml
+maestro test \
+  -e TEST_EMAIL="your-test-account@example.com" \
+  -e TEST_PASSWORD="your-test-password" \
+  .maestro/flows/auth/login-flow.yaml
 ```
 
 ### Run with JUnit output (for CI)
 ```bash
-maestro test --format junit --output test-results.xml .maestro/master-flow.yaml
+maestro test \
+  --format junit \
+  --output test-results.xml \
+  -e TEST_EMAIL="your-test-account@example.com" \
+  -e TEST_PASSWORD="your-test-password" \
+  -e APP_ID="com.andrewbierman.packrat.preview" \
+  -e TRIP_NAME="Test-Trip-$(date +%s)" \
+  -e PACK_NAME="Test-Pack-$(date +%s)" \
+  .maestro/master-flow.yaml
 ```
 
 ### Run on a specific simulator
@@ -107,11 +130,11 @@ Configure these GitHub repository secrets for CI:
 Flows are standard YAML files following the [Maestro flow syntax](https://maestro.mobile.dev/api-reference/commands).
 
 Key conventions:
-- All flows start with `appId: com.andrewbierman.packrat`
+- All flows start with `appId: ${APP_ID}` (uses environment variable for platform-specific bundle IDs)
 - Prefer `testID` / `accessibilityIdentifier` selectors first (e.g., `tapOn: { id: "submitButton" }`); use `text` to match an element's iOS `accessibilityLabel` or visible text (e.g., `tapOn: { text: "Submit" }`); `accessibilityLabel` is **not** a valid Maestro selector key
 - Use `waitForAnimationToEnd` after navigation actions
 - Use `runFlow: { when: { visible: ... } }` for conditional steps
-- Use environment variables (e.g., `${TRIP_NAME}`) for entity names to keep each test run unique
+- Use environment variables (e.g., `${TRIP_NAME}`, `${TEST_EMAIL}`) passed via `-e` flags to keep tests configurable and unique
 
 ## Troubleshooting
 

--- a/.maestro/config-android.yaml
+++ b/.maestro/config-android.yaml
@@ -1,18 +1,19 @@
-# Maestro E2E Test Suite Configuration – Android
-# https://maestro.mobile.dev
-
-appId: com.packratai.mobile
+# Maestro Workspace Configuration - Android
+# https://docs.maestro.dev/maestro-flows/workspace-management/project-configuration
 
 flows:
-  - flows/setup/*.yaml
-  - flows/auth/*.yaml
-  - flows/trips/*.yaml
-  - flows/packs/*.yaml
+  - "flows/setup/*.yaml"
+  - "flows/auth/*.yaml" 
+  - "flows/packs/*.yaml"
+  - "flows/trips/*.yaml"
+  - "master-flow-android.yaml"  # Include master flow
 
-executionOrder:
-  flowsOrder:
-    - flows/setup/clear-state.yaml
-    - flows/auth/login-flow.yaml
-    - flows/trips/create-trip-flow.yaml
-    - flows/packs/create-pack-flow.yaml
-    - flows/auth/logout-flow.yaml
+# Platform-specific settings
+platform:
+  android:
+    disableAnimations: true
+
+# Environment variables available to all flows
+env:
+  TRIP_NAME: "E2E-Trip-${GITHUB_RUN_ID:-12345}"
+  PACK_NAME: "E2E-Pack-${GITHUB_RUN_ID:-12345}"

--- a/.maestro/config.yaml
+++ b/.maestro/config.yaml
@@ -1,46 +1,16 @@
-# Maestro E2E Test Suite Configuration
-# https://maestro.mobile.dev
-
-appId: com.andrewbierman.packrat
+# Maestro Workspace Configuration
+# https://docs.maestro.dev/maestro-flows/workspace-management/project-configuration
 
 flows:
-  - flows/setup/*.yaml
-  - flows/auth/*.yaml
-  - flows/dashboard/*.yaml
-  - flows/packs/*.yaml
-  - flows/trips/*.yaml
-  - flows/catalog/*.yaml
-  - flows/profile/*.yaml
-  - flows/negative/*.yaml
+  - "flows/**/*.yaml"
+  - "*.yaml"  # Include root-level flows like master-flow.yaml
 
-executionOrder:
-  flowsOrder:
-    # Setup & Auth
-    - flows/setup/clear-state.yaml
-    - flows/auth/login-flow.yaml
+# Platform-specific settings
+platform:
+  ios:
+    snapshotKeyHonorModalViews: false
 
-    # Dashboard
-    - flows/dashboard/dashboard-tiles-flow.yaml
-
-    # Packs CRUD
-    - flows/packs/create-pack-flow.yaml
-    - flows/packs/pack-detail-flow.yaml
-    - flows/packs/add-item-actions-flow.yaml
-
-    # Trips CRUD
-    - flows/trips/create-trip-flow.yaml
-    - flows/trips/trip-detail-flow.yaml
-
-    # Catalog
-    - flows/catalog/catalog-browse-flow.yaml
-    - flows/catalog/catalog-item-detail-flow.yaml
-
-    # Profile
-    - flows/profile/profile-view-flow.yaml
-
-    # Negative tests
-    - flows/negative/empty-pack-submit-flow.yaml
-    - flows/negative/empty-trip-submit-flow.yaml
-
-    # Logout (last — destroys session)
-    - flows/auth/logout-flow.yaml
+# Environment variables available to all flows
+env:
+  TRIP_NAME: "E2E-Trip-${GITHUB_RUN_ID:-12345}"
+  PACK_NAME: "E2E-Pack-${GITHUB_RUN_ID:-12345}"

--- a/.maestro/flows/auth/login-flow.yaml
+++ b/.maestro/flows/auth/login-flow.yaml
@@ -1,3 +1,5 @@
+appId: com.andrewbierman.packrat
+---
 # Login Flow: Navigate to auth screen and sign in with email and password
 - launchApp
 
@@ -14,12 +16,12 @@
 # Fill in the email field
 - tapOn:
     id: "email-input"
-- typeText: ${TEST_EMAIL}
+- inputText: ${TEST_EMAIL}
 
 # Fill in the password field
 - tapOn:
     id: "password-input"
-- typeText: ${TEST_PASSWORD}
+- inputText: ${TEST_PASSWORD}
 
 # Dismiss the keyboard before submitting
 - hideKeyboard

--- a/.maestro/flows/auth/login-flow.yaml
+++ b/.maestro/flows/auth/login-flow.yaml
@@ -1,4 +1,4 @@
-appId: com.andrewbierman.packrat
+appId: ${APP_ID}
 ---
 # Login Flow: Navigate to auth screen and sign in with email and password
 - launchApp
@@ -16,7 +16,7 @@ appId: com.andrewbierman.packrat
 # Fill in the email field
 - tapOn:
     id: "email-input"
-- inputText: ${TEST_EMAIL}
+- inputText: "${TEST_EMAIL}"
 
 # Fill in the password field
 - tapOn:

--- a/.maestro/flows/auth/login-flow.yaml
+++ b/.maestro/flows/auth/login-flow.yaml
@@ -32,6 +32,20 @@ appId: ${APP_ID}
 
 # Wait for navigation to complete — login can take a few seconds
 - waitForAnimationToEnd
+
+# iOS only: dismiss the system "Save Password?" Keychain prompt that appears
+# after submitting any form with a password field (textContentType="password").
+# This prompt is a blocking OS-level dialog and would intercept subsequent taps
+# if not handled. Real users can choose to save — in CI we always skip it.
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+      - tapOn:
+          text: "Not Now"
+          optional: true
+          label: "Dismiss iOS Save Password prompt"
+
 - extendedWaitUntil:
     visible:
       text: "Packs"

--- a/.maestro/flows/auth/logout-flow.yaml
+++ b/.maestro/flows/auth/logout-flow.yaml
@@ -1,4 +1,4 @@
-appId: com.andrewbierman.packrat
+appId: ${APP_ID}
 ---
 # Logout Flow: Navigate to profile and sign out
 - waitForAnimationToEnd

--- a/.maestro/flows/auth/logout-flow.yaml
+++ b/.maestro/flows/auth/logout-flow.yaml
@@ -35,14 +35,14 @@ appId: ${APP_ID}
 
 - waitForAnimationToEnd
 
-# Handle post-logout dialog - choose to stay logged out
+# Handle post-logout dialog - choose to Sign-in again
 - runFlow:
     when:
       visible:
-        text: "Stay logged out"
+        text: "Sign-in again"
     commands:
       - tapOn:
-          text: "Stay logged out"
+          text: "Sign-in again"
 
 - waitForAnimationToEnd
 

--- a/.maestro/flows/auth/logout-flow.yaml
+++ b/.maestro/flows/auth/logout-flow.yaml
@@ -1,3 +1,5 @@
+appId: com.andrewbierman.packrat
+---
 # Logout Flow: Navigate to profile and sign out
 - waitForAnimationToEnd
 

--- a/.maestro/flows/catalog/catalog-browse-flow.yaml
+++ b/.maestro/flows/catalog/catalog-browse-flow.yaml
@@ -1,3 +1,5 @@
+appId: com.andrewbierman.packrat
+---
 # Catalog Browse Flow: Verify catalog tab loads items and categories
 - waitForAnimationToEnd
 

--- a/.maestro/flows/catalog/catalog-browse-flow.yaml
+++ b/.maestro/flows/catalog/catalog-browse-flow.yaml
@@ -1,4 +1,4 @@
-appId: com.andrewbierman.packrat
+appId: ${APP_ID}
 ---
 # Catalog Browse Flow: Verify catalog tab loads items and categories
 - waitForAnimationToEnd

--- a/.maestro/flows/catalog/catalog-item-detail-flow.yaml
+++ b/.maestro/flows/catalog/catalog-item-detail-flow.yaml
@@ -1,3 +1,5 @@
+appId: com.andrewbierman.packrat
+---
 # Catalog Item Detail Flow: Tap a catalog item and verify detail page
 - waitForAnimationToEnd
 

--- a/.maestro/flows/catalog/catalog-item-detail-flow.yaml
+++ b/.maestro/flows/catalog/catalog-item-detail-flow.yaml
@@ -1,4 +1,4 @@
-appId: com.andrewbierman.packrat
+appId: ${APP_ID}
 ---
 # Catalog Item Detail Flow: Tap a catalog item and verify detail page
 - waitForAnimationToEnd

--- a/.maestro/flows/dashboard/dashboard-tiles-flow.yaml
+++ b/.maestro/flows/dashboard/dashboard-tiles-flow.yaml
@@ -1,3 +1,5 @@
+appId: com.andrewbierman.packrat
+---
 # Dashboard Tiles Flow: Verify dashboard loads with key tiles
 - waitForAnimationToEnd
 

--- a/.maestro/flows/dashboard/dashboard-tiles-flow.yaml
+++ b/.maestro/flows/dashboard/dashboard-tiles-flow.yaml
@@ -1,4 +1,4 @@
-appId: com.andrewbierman.packrat
+appId: ${APP_ID}
 ---
 # Dashboard Tiles Flow: Verify dashboard loads with key tiles
 - waitForAnimationToEnd

--- a/.maestro/flows/negative/empty-pack-submit-flow.yaml
+++ b/.maestro/flows/negative/empty-pack-submit-flow.yaml
@@ -1,4 +1,4 @@
-appId: com.andrewbierman.packrat
+appId: ${APP_ID}
 ---
 # Empty Pack Submit Flow: Verify form validation prevents empty pack creation
 - waitForAnimationToEnd

--- a/.maestro/flows/negative/empty-pack-submit-flow.yaml
+++ b/.maestro/flows/negative/empty-pack-submit-flow.yaml
@@ -1,3 +1,5 @@
+appId: com.andrewbierman.packrat
+---
 # Empty Pack Submit Flow: Verify form validation prevents empty pack creation
 - waitForAnimationToEnd
 

--- a/.maestro/flows/negative/empty-trip-submit-flow.yaml
+++ b/.maestro/flows/negative/empty-trip-submit-flow.yaml
@@ -1,3 +1,5 @@
+appId: com.andrewbierman.packrat
+---
 # Empty Trip Submit Flow: Verify form validation prevents empty trip creation
 - waitForAnimationToEnd
 

--- a/.maestro/flows/negative/empty-trip-submit-flow.yaml
+++ b/.maestro/flows/negative/empty-trip-submit-flow.yaml
@@ -1,4 +1,4 @@
-appId: com.andrewbierman.packrat
+appId: ${APP_ID}
 ---
 # Empty Trip Submit Flow: Verify form validation prevents empty trip creation
 - waitForAnimationToEnd

--- a/.maestro/flows/packs/add-item-actions-flow.yaml
+++ b/.maestro/flows/packs/add-item-actions-flow.yaml
@@ -1,3 +1,5 @@
+appId: com.andrewbierman.packrat
+---
 # Add Item Actions Flow: Verify the add-item bottom sheet options
 - waitForAnimationToEnd
 

--- a/.maestro/flows/packs/add-item-actions-flow.yaml
+++ b/.maestro/flows/packs/add-item-actions-flow.yaml
@@ -1,4 +1,4 @@
-appId: com.andrewbierman.packrat
+appId: ${APP_ID}
 ---
 # Add Item Actions Flow: Verify the add-item bottom sheet options
 - waitForAnimationToEnd

--- a/.maestro/flows/packs/create-pack-flow.yaml
+++ b/.maestro/flows/packs/create-pack-flow.yaml
@@ -49,6 +49,6 @@ appId: ${APP_ID}
       text: ${PACK_NAME}
     direction: DOWN
     timeout: 60000
-    speed: 100
+    speed: 99
 - assertVisible:
     text: ${PACK_NAME}

--- a/.maestro/flows/packs/create-pack-flow.yaml
+++ b/.maestro/flows/packs/create-pack-flow.yaml
@@ -44,5 +44,10 @@ appId: ${APP_ID}
 # Also confirm we are on the packs list by checking for the create button
 - assertVisible:
     id: "create-pack-button"
+- scrollUntilVisible:
+    element:
+      text: ${PACK_NAME}
+    direction: DOWN
+    timeout: 15000
 - assertVisible:
     text: ${PACK_NAME}

--- a/.maestro/flows/packs/create-pack-flow.yaml
+++ b/.maestro/flows/packs/create-pack-flow.yaml
@@ -1,3 +1,5 @@
+appId: com.andrewbierman.packrat
+---
 # Create Pack Flow: Navigate to packs tab and create a new pack
 - waitForAnimationToEnd
 
@@ -16,12 +18,12 @@
 # Fill in Pack Name
 - tapOn:
     text: "Pack Name"
-- typeText: ${PACK_NAME}
+- inputText: ${PACK_NAME}
 
 # Fill in Description
 - tapOn:
     text: "Description"
-- typeText: "Created by Maestro E2E test"
+- inputText: "Created by Maestro E2E test"
 
 # Dismiss the keyboard before submitting
 - hideKeyboard

--- a/.maestro/flows/packs/create-pack-flow.yaml
+++ b/.maestro/flows/packs/create-pack-flow.yaml
@@ -1,4 +1,4 @@
-appId: com.andrewbierman.packrat
+appId: ${APP_ID}
 ---
 # Create Pack Flow: Navigate to packs tab and create a new pack
 - waitForAnimationToEnd

--- a/.maestro/flows/packs/create-pack-flow.yaml
+++ b/.maestro/flows/packs/create-pack-flow.yaml
@@ -48,6 +48,7 @@ appId: ${APP_ID}
     element:
       text: ${PACK_NAME}
     direction: DOWN
-    timeout: 15000
+    timeout: 60000
+    speed: 100
 - assertVisible:
     text: ${PACK_NAME}

--- a/.maestro/flows/packs/pack-detail-flow.yaml
+++ b/.maestro/flows/packs/pack-detail-flow.yaml
@@ -1,4 +1,4 @@
-appId: com.andrewbierman.packrat
+appId: ${APP_ID}
 ---
 # Pack Detail Flow: Navigate to a pack and verify detail screen elements
 - waitForAnimationToEnd

--- a/.maestro/flows/packs/pack-detail-flow.yaml
+++ b/.maestro/flows/packs/pack-detail-flow.yaml
@@ -1,3 +1,5 @@
+appId: com.andrewbierman.packrat
+---
 # Pack Detail Flow: Navigate to a pack and verify detail screen elements
 - waitForAnimationToEnd
 

--- a/.maestro/flows/profile/profile-view-flow.yaml
+++ b/.maestro/flows/profile/profile-view-flow.yaml
@@ -1,3 +1,5 @@
+appId: com.andrewbierman.packrat
+---
 # Profile View Flow: Navigate to profile and verify account info
 - waitForAnimationToEnd
 

--- a/.maestro/flows/profile/profile-view-flow.yaml
+++ b/.maestro/flows/profile/profile-view-flow.yaml
@@ -1,4 +1,4 @@
-appId: com.andrewbierman.packrat
+appId: ${APP_ID}
 ---
 # Profile View Flow: Navigate to profile and verify account info
 - waitForAnimationToEnd

--- a/.maestro/flows/setup/clear-state.yaml
+++ b/.maestro/flows/setup/clear-state.yaml
@@ -1,4 +1,4 @@
-appId: com.andrewbierman.packrat
+appId: ${APP_ID}
 ---
 # Clear app state before running tests to ensure a clean environment
 - launchApp:

--- a/.maestro/flows/setup/clear-state.yaml
+++ b/.maestro/flows/setup/clear-state.yaml
@@ -1,3 +1,5 @@
+appId: com.andrewbierman.packrat
+---
 # Clear app state before running tests to ensure a clean environment
 - launchApp:
     clearState: true

--- a/.maestro/flows/trips/create-trip-flow.yaml
+++ b/.maestro/flows/trips/create-trip-flow.yaml
@@ -103,7 +103,7 @@ appId: ${APP_ID}
       text: ${TRIP_NAME}
     direction: DOWN
     timeout: 60000
-    speed: 100
+    speed: 99
 - assertVisible:
     text: ${TRIP_NAME}
 

--- a/.maestro/flows/trips/create-trip-flow.yaml
+++ b/.maestro/flows/trips/create-trip-flow.yaml
@@ -98,5 +98,11 @@ appId: ${APP_ID}
 # for the header create button, then verify the new trip appears
 - assertVisible:
     id: "create-trip-button"
+- scrollUntilVisible:
+    element:
+      text: ${TRIP_NAME}
+    direction: DOWN
+    timeout: 15000
 - assertVisible:
     text: ${TRIP_NAME}
+

--- a/.maestro/flows/trips/create-trip-flow.yaml
+++ b/.maestro/flows/trips/create-trip-flow.yaml
@@ -102,7 +102,8 @@ appId: ${APP_ID}
     element:
       text: ${TRIP_NAME}
     direction: DOWN
-    timeout: 15000
+    timeout: 60000
+    speed: 100
 - assertVisible:
     text: ${TRIP_NAME}
 

--- a/.maestro/flows/trips/create-trip-flow.yaml
+++ b/.maestro/flows/trips/create-trip-flow.yaml
@@ -1,4 +1,4 @@
-appId: com.andrewbierman.packrat
+appId: ${APP_ID}
 ---
 # Create Trip Flow: Navigate to trips tab and create a new trip
 - waitForAnimationToEnd

--- a/.maestro/flows/trips/create-trip-flow.yaml
+++ b/.maestro/flows/trips/create-trip-flow.yaml
@@ -28,7 +28,61 @@ appId: ${APP_ID}
 # Dismiss the keyboard before submitting
 - hideKeyboard
 
-# Submit the form via the submit button (testID: submit-trip-button)
+# --- Start Date ---
+- tapOn:
+    text: "Start Date"
+- waitForAnimationToEnd
+
+- repeat:
+    times: ${START_TAPS}
+    commands:
+      - tapOn: "Next Month"
+
+- runFlow:
+    when:
+      platform: Android
+    commands:
+      - tapOn: "${START_DAY} ${START_MONTH} ${START_YEAR}"
+      - tapOn: "OK"
+
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+      - tapOn: "${START_MONTH} ${START_DAY}"
+      - tapOn:
+          point: "5%,5%"
+
+- waitForAnimationToEnd
+
+# --- End Date ---
+- tapOn:
+    text: "End Date"
+- waitForAnimationToEnd
+
+- repeat:
+    times: ${END_TAPS}
+    commands:
+      - tapOn: "Next Month"
+
+- runFlow:
+    when:
+      platform: Android
+    commands:
+      - tapOn: "${END_DAY} ${END_MONTH} ${END_YEAR}"
+      - tapOn: "OK"
+
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+      - tapOn: "${END_MONTH} ${END_DAY}"
+      - tapOn:
+          point: "5%,5%"
+
+- waitForAnimationToEnd
+
+# --- Submit ---
 - tapOn:
     id: "submit-trip-button"
 

--- a/.maestro/flows/trips/create-trip-flow.yaml
+++ b/.maestro/flows/trips/create-trip-flow.yaml
@@ -1,3 +1,5 @@
+appId: com.andrewbierman.packrat
+---
 # Create Trip Flow: Navigate to trips tab and create a new trip
 - waitForAnimationToEnd
 
@@ -16,12 +18,12 @@
 # Fill in the Trip Name field
 - tapOn:
     text: "Trip Name"
-- typeText: ${TRIP_NAME}
+- inputText: ${TRIP_NAME}
 
 # Fill in the Description field
 - tapOn:
     text: "Description"
-- typeText: "Created by Maestro E2E test"
+- inputText: "Created by Maestro E2E test"
 
 # Dismiss the keyboard before submitting
 - hideKeyboard

--- a/.maestro/flows/trips/trip-detail-flow.yaml
+++ b/.maestro/flows/trips/trip-detail-flow.yaml
@@ -1,3 +1,5 @@
+appId: com.andrewbierman.packrat
+---
 # Trip Detail Flow: Navigate to a trip and verify detail screen
 - waitForAnimationToEnd
 

--- a/.maestro/flows/trips/trip-detail-flow.yaml
+++ b/.maestro/flows/trips/trip-detail-flow.yaml
@@ -1,4 +1,4 @@
-appId: com.andrewbierman.packrat
+appId: ${APP_ID}
 ---
 # Trip Detail Flow: Navigate to a trip and verify detail screen
 - waitForAnimationToEnd

--- a/.maestro/master-flow-android.yaml
+++ b/.maestro/master-flow-android.yaml
@@ -1,0 +1,15 @@
+appId: com.packratai.mobile
+---
+# PackRat E2E Test Suite - Android Master Flow
+# This flow orchestrates key test flows for Android
+
+# Setup & Authentication
+- runFlow: flows/setup/clear-state.yaml
+- runFlow: flows/auth/login-flow.yaml
+
+# Core functionality tests
+- runFlow: flows/trips/create-trip-flow.yaml
+- runFlow: flows/packs/create-pack-flow.yaml
+
+# Logout (destroys session - must be last)
+- runFlow: flows/auth/logout-flow.yaml

--- a/.maestro/master-flow-android.yaml
+++ b/.maestro/master-flow-android.yaml
@@ -1,4 +1,4 @@
-appId: com.packratai.mobile
+appId: ${APP_ID}
 ---
 # PackRat E2E Test Suite - Android Master Flow
 # This flow orchestrates key test flows for Android

--- a/.maestro/master-flow.yaml
+++ b/.maestro/master-flow.yaml
@@ -1,4 +1,4 @@
-appId: com.andrewbierman.packrat
+appId: ${APP_ID}
 ---
 # PackRat E2E Test Suite - iOS Master Flow
 # This flow orchestrates all test flows in the correct order

--- a/.maestro/master-flow.yaml
+++ b/.maestro/master-flow.yaml
@@ -1,0 +1,34 @@
+appId: com.andrewbierman.packrat
+---
+# PackRat E2E Test Suite - iOS Master Flow
+# This flow orchestrates all test flows in the correct order
+
+# Setup & Authentication
+- runFlow: flows/setup/clear-state.yaml
+- runFlow: flows/auth/login-flow.yaml
+
+# Dashboard
+- runFlow: flows/dashboard/dashboard-tiles-flow.yaml
+
+# Packs CRUD
+- runFlow: flows/packs/create-pack-flow.yaml
+- runFlow: flows/packs/pack-detail-flow.yaml
+- runFlow: flows/packs/add-item-actions-flow.yaml
+
+# Trips CRUD
+- runFlow: flows/trips/create-trip-flow.yaml
+- runFlow: flows/trips/trip-detail-flow.yaml
+
+# Catalog
+- runFlow: flows/catalog/catalog-browse-flow.yaml
+- runFlow: flows/catalog/catalog-item-detail-flow.yaml
+
+# Profile
+- runFlow: flows/profile/profile-view-flow.yaml
+
+# Negative tests
+- runFlow: flows/negative/empty-pack-submit-flow.yaml
+- runFlow: flows/negative/empty-trip-submit-flow.yaml
+
+# Logout (destroys session - must be last)
+- runFlow: flows/auth/logout-flow.yaml

--- a/apps/expo/app.config.ts
+++ b/apps/expo/app.config.ts
@@ -65,7 +65,7 @@ export default (): ExpoConfig =>
             enableEntitlements: true,
             entitlementsProfile: 'production',
             forceCxx20: true,
-            enableOpenCLAndHexagon: true,
+            enableOpenCLAndHexagon: false,
           },
         ],
         '@react-native-community/datetimepicker',

--- a/apps/expo/app/(app)/(tabs)/profile/index.tsx
+++ b/apps/expo/app/(app)/(tabs)/profile/index.tsx
@@ -25,6 +25,7 @@ import { cn } from 'expo-app/lib/cn';
 import { hasUnsyncedChanges } from 'expo-app/lib/hasUnsyncedChanges';
 import { useColorScheme } from 'expo-app/lib/hooks/useColorScheme';
 import { useTranslation } from 'expo-app/lib/hooks/useTranslation';
+import { TestIds } from 'expo-app/lib/testIds';
 import { buildPackTemplateItemImageUrl } from 'expo-app/lib/utils/buildPackTemplateItemImageUrl';
 import * as FileSystem from 'expo-file-system/legacy';
 import { router, Stack } from 'expo-router';
@@ -32,7 +33,6 @@ import * as Updates from 'expo-updates';
 import { useRef, useState } from 'react';
 import { Alert, Linking, Platform, TouchableOpacity, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { TestIds } from 'expo-app/lib/testIds';
 
 const AVATAR_MAX_BYTES = 5 * 1024 * 1024; // 5 MB
 

--- a/apps/expo/app/(app)/(tabs)/profile/index.tsx
+++ b/apps/expo/app/(app)/(tabs)/profile/index.tsx
@@ -32,6 +32,7 @@ import * as Updates from 'expo-updates';
 import { useRef, useState } from 'react';
 import { Alert, Linking, Platform, TouchableOpacity, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
+import { TestIds } from 'expo-app/lib/testIds';
 
 const AVATAR_MAX_BYTES = 5 * 1024 * 1024; // 5 MB
 
@@ -240,7 +241,7 @@ function ListFooterComponent() {
   return (
     <View className="ios:px-0 px-4 pt-8">
       <Button
-        testID="sign-out-button"
+        testID={TestIds.SignOutButton}
         disabled={isSigningOut}
         onPress={() => {
           if (hasUnsyncedChanges()) {

--- a/apps/expo/app/auth/(login)/index.tsx
+++ b/apps/expo/app/auth/(login)/index.tsx
@@ -98,7 +98,10 @@ export default function LoginScreen() {
               resizeMode="contain"
             />
             <Text variant="title1" className="ios:font-bold pb-1 pt-4 text-center">
-              {Platform.select({ ios: t('auth.welcomeBack'), default: t('auth.signIn') })}
+              {Platform.select({
+                ios: t('auth.welcomeBack'),
+                default: t('auth.signIn'),
+              })}
             </Text>
             {Platform.OS !== 'ios' && (
               <Text className="ios:text-sm text-center text-muted-foreground">
@@ -222,6 +225,7 @@ export default function LoginScreen() {
               <form.Subscribe selector={(state) => [state.canSubmit, state.isSubmitting]}>
                 {([canSubmit, _isSubmitting]) => (
                   <Button
+                    testID={TestIds.ContinueButton}
                     disabled={!canSubmit || loading}
                     onPress={() => {
                       if (focusedTextField === 'email') {

--- a/apps/expo/app/auth/(login)/index.tsx
+++ b/apps/expo/app/auth/(login)/index.tsx
@@ -110,13 +110,17 @@ export default function LoginScreen() {
             )}
           </View>
           <View className="ios:pt-4 pt-6">
-            <Form className="gap-2">
-              <FormSection className="ios:bg-background">
-                <FormItem>
+            <Form className="gap-2" accessible={Platform.OS === 'ios' ? false : undefined}>
+              <FormSection
+                className="ios:bg-background"
+                accessible={Platform.OS === 'ios' ? false : undefined}
+              >
+                <FormItem accessible={Platform.OS === 'ios' ? false : undefined}>
                   <form.Field name="email">
                     {(field) => (
                       <TextField
                         testID={TestIds.EmailInput}
+                        accessible={Platform.OS === 'ios' ? true : undefined}
                         placeholder={Platform.select({
                           ios: 'Email',
                           default: '',
@@ -143,11 +147,12 @@ export default function LoginScreen() {
                     )}
                   </form.Field>
                 </FormItem>
-                <FormItem>
+                <FormItem accessible={Platform.OS === 'ios' ? false : undefined}>
                   <form.Field name="password">
                     {(field) => (
                       <TextField
                         testID={TestIds.PasswordInput}
+                        accessible={Platform.OS === 'ios' ? true : undefined}
                         placeholder={Platform.select({
                           ios: 'Password',
                           default: '',
@@ -185,6 +190,7 @@ export default function LoginScreen() {
         </View>
       </KeyboardAwareScrollView>
       <KeyboardStickyView
+        accessible={Platform.OS === 'ios' ? false : undefined}
         offset={{
           closed: 0,
           opened: Platform.select({
@@ -194,11 +200,12 @@ export default function LoginScreen() {
         }}
       >
         {Platform.OS === 'ios' ? (
-          <View className="px-12 py-4">
+          <View className="px-12 py-4" accessible={false}>
             <form.Subscribe selector={(state) => [state.canSubmit, state.isSubmitting]}>
               {([canSubmit, _isSubmitting]) => (
                 <Button
                   testID={TestIds.ContinueButton}
+                  accessible={true}
                   size="lg"
                   disabled={!canSubmit || loading}
                   onPress={() => form.handleSubmit()}
@@ -209,7 +216,7 @@ export default function LoginScreen() {
             </form.Subscribe>
           </View>
         ) : (
-          <View className="flex-row justify-between py-4 pl-6 pr-8">
+          <View className="flex-row justify-between py-4 pl-6 pr-8" accessible={false}>
             {!needsReauth && (
               <Button
                 variant="plain"
@@ -221,11 +228,12 @@ export default function LoginScreen() {
                 <Text className="px-0.5 text-sm text-primary">{t('auth.createAccount')}</Text>
               </Button>
             )}
-            <View className="ml-auto">
+            <View className="ml-auto" accessible={false}>
               <form.Subscribe selector={(state) => [state.canSubmit, state.isSubmitting]}>
                 {([canSubmit, _isSubmitting]) => (
                   <Button
                     testID={TestIds.ContinueButton}
+                    accessible={true}
                     disabled={!canSubmit || loading}
                     onPress={() => {
                       if (focusedTextField === 'email') {

--- a/apps/expo/eas.json
+++ b/apps/expo/eas.json
@@ -20,6 +20,9 @@
       "channel": "preview",
       "ios": {
         "simulator": true
+      },
+      "android": {
+        "gradleCommand": ":app:assembleDebug"
       }
     },
     "production": {

--- a/apps/expo/eas.json
+++ b/apps/expo/eas.json
@@ -22,7 +22,12 @@
         "simulator": true
       },
       "android": {
-        "gradleCommand": ":app:assembleDebug"
+        "buildType": "apk",
+        "gradleCommand": ":app:assembleRelease -x lintVitalAnalyzeRelease",
+        "env": {
+          "GRADLE_OPTS": "-Xmx6144m -XX:MaxMetaspaceSize=1536m",
+          "JAVA_OPTS": "-Xmx6144m"
+        }
       }
     },
     "production": {

--- a/apps/expo/eas.json
+++ b/apps/expo/eas.json
@@ -22,7 +22,7 @@
       "android": {
         "buildType": "apk",
         "resourceClass": "large",
-        "gradleCommand": ":app:bundleRelease -x lintVitalAnalyzeRelease",
+        "gradleCommand": ":app:assembleRelease -x lintVitalAnalyzeRelease",
         "env": {
           "GRADLE_OPTS": "-Xmx6144m -XX:MaxMetaspaceSize=1536m",
           "JAVA_OPTS": "-Xmx6144m"

--- a/apps/expo/eas.json
+++ b/apps/expo/eas.json
@@ -20,14 +20,6 @@
       "channel": "preview",
       "ios": {
         "simulator": true
-      },
-      "android": {
-        "buildType": "apk",
-        "gradleCommand": ":app:assembleRelease -x lintVitalAnalyzeRelease",
-        "env": {
-          "GRADLE_OPTS": "-Xmx6144m -XX:MaxMetaspaceSize=1536m",
-          "JAVA_OPTS": "-Xmx6144m"
-        }
       }
     },
     "production": {

--- a/apps/expo/eas.json
+++ b/apps/expo/eas.json
@@ -16,12 +16,10 @@
     },
     "e2e": {
       "ios": {
-        "simulator": true,
-        "image": "latest"
+        "simulator": true
       },
       "android": {
         "buildType": "apk",
-        "resourceClass": "large",
         "gradleCommand": ":app:assembleRelease -x lintVitalAnalyzeRelease",
         "env": {
           "GRADLE_OPTS": "-Xmx6144m -XX:MaxMetaspaceSize=1536m",

--- a/apps/expo/eas.json
+++ b/apps/expo/eas.json
@@ -15,6 +15,9 @@
       "channel": "preview"
     },
     "e2e": {
+      "environment": "preview",
+      "distribution": "internal",
+      "channel": "preview",
       "ios": {
         "simulator": true
       },

--- a/apps/expo/features/catalog/screens/CatalogItemDetailScreen.tsx
+++ b/apps/expo/features/catalog/screens/CatalogItemDetailScreen.tsx
@@ -8,6 +8,7 @@ import { ItemReviews } from 'expo-app/features/catalog/components/ItemReviews';
 import { SimilarItems } from 'expo-app/features/catalog/components/SimilarItems';
 import { useColorScheme } from 'expo-app/lib/hooks/useColorScheme';
 import { useTranslation } from 'expo-app/lib/hooks/useTranslation';
+import { TestIds } from 'expo-app/lib/testIds';
 import { decodeHtmlEntities } from 'expo-app/lib/utils/decodeHtmlEntities';
 import { ErrorScreen } from 'expo-app/screens/ErrorScreen';
 import { LoadingSpinnerScreen } from 'expo-app/screens/LoadingSpinnerScreen';
@@ -186,13 +187,13 @@ export function CatalogItemDetailScreen() {
 
           <View className="mb-4 gap-2 flex-row justify-between">
             <View>
-              <Button testID="add-to-pack-button" onPress={handleAddToPack}>
+              <Button testID={TestIds.AddToPackButton} onPress={handleAddToPack}>
                 <Text>{t('catalog.addToPack')}</Text>
               </Button>
             </View>
             <View>
               <Button
-                testID="view-retailer-button"
+                testID={TestIds.ViewRetailerButton}
                 variant="secondary"
                 onPress={() => Linking.openURL(item.productUrl as string)}
               >

--- a/apps/expo/features/packs/components/AddPackItemActions.tsx
+++ b/apps/expo/features/packs/components/AddPackItemActions.tsx
@@ -8,6 +8,7 @@ import { CatalogBrowserModal } from 'expo-app/features/catalog/components';
 import { useRecentlyUsedCatalogItems } from 'expo-app/features/catalog/hooks/useRecentlyUsedCatalogItems';
 import type { CatalogItem, CatalogItemWithPackItemFields } from 'expo-app/features/catalog/types';
 import { useTranslation } from 'expo-app/lib/hooks/useTranslation';
+import { TestIds } from 'expo-app/lib/testIds';
 import { router } from 'expo-router';
 import React from 'react';
 import { Alert, TouchableOpacity, View } from 'react-native';
@@ -128,7 +129,7 @@ export default React.forwardRef<BottomSheetModal, AddPackItemActionsProps>(
           <BottomSheetView className="flex-1 px-4" style={{ flex: 1 }}>
             <View className="gap-2 mb-4">
               <TouchableOpacity
-                testID="add-manually-option"
+                testID={TestIds.AddManuallyOption}
                 className="flex-row gap-2 items-center rounded-lg border border-border bg-card p-4"
                 onPress={() => {
                   ref && typeof ref !== 'function' && ref.current?.close();
@@ -145,7 +146,7 @@ export default React.forwardRef<BottomSheetModal, AddPackItemActionsProps>(
                 </View>
               </TouchableOpacity>
               <TouchableOpacity
-                testID="scan-from-photo-option"
+                testID={TestIds.ScanFromPhotoOption}
                 className="flex-row gap-2 items-center rounded-lg border border-border bg-card p-4"
                 onPress={handleAddFromPhoto}
               >
@@ -156,7 +157,7 @@ export default React.forwardRef<BottomSheetModal, AddPackItemActionsProps>(
                 </View>
               </TouchableOpacity>
               <TouchableOpacity
-                testID="add-from-catalog-option"
+                testID={TestIds.AddFromCatalogOption}
                 className="flex-row gap-2 items-center rounded-lg border border-border bg-card p-4"
                 onPress={handleAddFromCatalog}
               >

--- a/apps/expo/features/packs/screens/PackDetailScreen.tsx
+++ b/apps/expo/features/packs/screens/PackDetailScreen.tsx
@@ -15,6 +15,7 @@ import { useBottomSheetAction } from 'expo-app/lib/hooks/useBottomSheetAction';
 import { useColorScheme } from 'expo-app/lib/hooks/useColorScheme';
 import { useTranslation } from 'expo-app/lib/hooks/useTranslation';
 import { obs } from 'expo-app/lib/store';
+import { TestIds } from 'expo-app/lib/testIds';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import { useMemo, useState } from 'react';
 import { Image, ScrollView, TouchableOpacity, View } from 'react-native';
@@ -490,13 +491,13 @@ export function PackDetailScreen() {
               variant="secondary"
               onPress={handleAskAI}
               className="flex-1"
-              testID="ask-ai-button"
+              testID={TestIds.AskAIButton}
             >
               <Text>Ask AI</Text>
             </Button>
 
             {isOwnedByUser && (
-              <Button variant="secondary" onPress={handleAddItem} testID="add-item-button">
+              <Button variant="secondary" onPress={handleAddItem} testID={TestIds.AddItemButton}>
                 <Text>Add Item</Text>
               </Button>
             )}
@@ -506,7 +507,7 @@ export function PackDetailScreen() {
                 variant="secondary"
                 size="icon"
                 onPress={handleMoreActionsPress}
-                testID="pack-more-actions"
+                testID={TestIds.PackMoreActions}
               >
                 <Icon name="dots-horizontal" size={20} color={colors.grey2} />
               </Button>

--- a/apps/expo/features/trips/components/TripForm.tsx
+++ b/apps/expo/features/trips/components/TripForm.tsx
@@ -4,13 +4,14 @@ import DateTimePicker from '@react-native-community/datetimepicker';
 import { Picker } from '@react-native-picker/picker';
 import { Icon } from '@roninoss/icons';
 import { useForm } from '@tanstack/react-form';
+import * as Burnt from 'burnt';
 import { usePacks } from 'expo-app/features/packs/hooks/usePacks';
 import { useColorScheme } from 'expo-app/lib/hooks/useColorScheme';
 import { useTranslation } from 'expo-app/lib/hooks/useTranslation';
 import { TestIds } from 'expo-app/lib/testIds';
 import { Stack, useRouter } from 'expo-router';
 import { useEffect, useMemo, useState } from 'react';
-import { Alert, Modal, Pressable, Text, View } from 'react-native';
+import { Modal, Pressable, Text, View } from 'react-native';
 import { KeyboardAwareScrollView } from 'react-native-keyboard-controller';
 import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
 import { z } from 'zod';
@@ -100,14 +101,23 @@ export const TripForm = ({ trip }: { trip?: Trip }) => {
       try {
         if (isEditingExistingTrip) {
           await updateTrip({ ...trip, ...submitData });
-          Alert.alert(t('common.success'), t('trips.tripUpdatedSuccess'));
+          Burnt.toast({
+            title: t('trips.tripUpdatedSuccess'),
+            preset: 'done',
+          });
         } else {
           await createTrip(submitData);
-          Alert.alert(t('common.success'), t('trips.tripCreatedSuccess'));
+          Burnt.toast({
+            title: t('trips.tripCreatedSuccess'),
+            preset: 'done',
+          });
         }
         router.back();
       } catch (_e) {
-        Alert.alert(t('common.error'), t('errors.tryAgain'));
+        Burnt.toast({
+          title: t('errors.tryAgain'),
+          preset: 'error',
+        });
       }
     },
   });

--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "packrat-monorepo",
@@ -351,7 +350,7 @@
       "name": "@packrat/ui",
       "version": "2.0.17",
       "dependencies": {
-        "@packrat-ai/nativewindui": "^2.0.0",
+        "@packrat-ai/nativewindui": "^2.0.1-alpha.0",
       },
     },
   },
@@ -995,7 +994,7 @@
 
     "@opentelemetry/api": ["@opentelemetry/api@1.9.0", "", {}, "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="],
 
-    "@packrat-ai/nativewindui": ["@packrat-ai/nativewindui@2.0.1", "https://npm.pkg.github.com/download/@packrat-ai/nativewindui/2.0.1/c8f3e4e6113c8d464803f637dbfb6fe5fa9a5e36", { "peerDependencies": { "@expo/vector-icons": ">=15.0.0", "@gorhom/bottom-sheet": "^5.1.2", "@react-native-community/datetimepicker": "^8.4.0", "@react-native-community/slider": "^5.0.0", "@react-native-picker/picker": "^2.11.0", "@react-native-segmented-control/segmented-control": "^2.5.0", "@react-navigation/drawer": "^7.1.1", "@react-navigation/elements": "^2.3.1", "@react-navigation/native": "^7.0.14", "@rn-primitives/alert-dialog": "^1.1.0", "@rn-primitives/avatar": "^1.0.4", "@rn-primitives/checkbox": "^1.1.0", "@rn-primitives/context-menu": "^1.1.0", "@rn-primitives/dropdown-menu": "^1.1.0", "@rn-primitives/hooks": "^1.1.0", "@rn-primitives/portal": "^1.1.0", "@rn-primitives/slot": "^1.1.0", "@shopify/flash-list": "^2.0.0", "class-variance-authority": "^0.7.0", "clsx": "^2.1.0", "expo-blur": "~15.0.8", "expo-device": "~8.0.0", "expo-glass-effect": "*", "expo-haptics": "~15.0.8", "expo-image": "~3.0.11", "expo-linear-gradient": "~15.0.8", "expo-navigation-bar": "~5.0.10", "expo-router": "~6.0.23", "expo-symbols": "~1.0.8", "nativewind": "^4.1.21", "react": ">=19.0.0", "react-native": ">=0.79.0", "react-native-keyboard-controller": "^1.16.7", "react-native-reanimated": ">=3.17.0", "react-native-safe-area-context": ">=5.4.0", "react-native-screens": ">=4.11.0", "react-native-uitextview": "^1.1.4", "rn-icon-mapper": "^0.0.1", "tailwind-merge": "^2.2.1" } }, "sha512-zMzFalxu6MKuBMIIDzeiMj/7wM9qn8kFkAbWm3IxBWTHHSsl/Zic053DCJZS1GQcY0Ke2Om3TmUTuBujERuwvA=="],
+    "@packrat-ai/nativewindui": ["@packrat-ai/nativewindui@2.0.1-alpha.0", "https://npm.pkg.github.com/download/@packrat-ai/nativewindui/2.0.1-alpha.0/cb1e675b6e8050af4563ea660122a594149d2a29", { "peerDependencies": { "@expo/vector-icons": ">=15.0.0", "@gorhom/bottom-sheet": "^5.1.2", "@react-native-community/datetimepicker": "^8.4.0", "@react-native-community/slider": "^5.0.0", "@react-native-picker/picker": "^2.11.0", "@react-native-segmented-control/segmented-control": "^2.5.0", "@react-navigation/drawer": "^7.1.1", "@react-navigation/elements": "^2.3.1", "@react-navigation/native": "^7.0.14", "@rn-primitives/alert-dialog": "^1.1.0", "@rn-primitives/avatar": "^1.0.4", "@rn-primitives/checkbox": "^1.1.0", "@rn-primitives/context-menu": "^1.1.0", "@rn-primitives/dropdown-menu": "^1.1.0", "@rn-primitives/hooks": "^1.1.0", "@rn-primitives/portal": "^1.1.0", "@rn-primitives/slot": "^1.1.0", "@shopify/flash-list": "^2.0.0", "class-variance-authority": "^0.7.0", "clsx": "^2.1.0", "expo-blur": "~15.0.8", "expo-device": "~8.0.0", "expo-glass-effect": "*", "expo-haptics": "~15.0.8", "expo-image": "~3.0.11", "expo-linear-gradient": "~15.0.8", "expo-navigation-bar": "~5.0.10", "expo-router": "~6.0.23", "expo-symbols": "~1.0.8", "nativewind": "^4.2.3", "react": ">=19.0.0", "react-native": ">=0.79.0", "react-native-keyboard-controller": "^1.16.7", "react-native-reanimated": ">=3.17.0", "react-native-safe-area-context": ">=5.4.0", "react-native-screens": ">=4.11.0", "react-native-uitextview": "^1.1.4", "rn-icon-mapper": "^0.0.1", "tailwind-merge": "^2.2.1" } }, "sha512-BM6X1agbUP3nF8YDGu4fYuav9zrSnPlx9c6dUKh0LLfH3UECUFGQfZhxOkjS4Ad8tGLC996mGAnR3C5bCxOn+w=="],
 
     "@packrat/analytics": ["@packrat/analytics@workspace:packages/analytics"],
 

--- a/package.json
+++ b/package.json
@@ -26,6 +26,8 @@
     "api": "bun run --cwd packages/api dev",
     "test:api:unit": "vitest run --config packages/api/vitest.unit.config.ts",
     "test:expo": "vitest run --config apps/expo/vitest.config.ts",
+    "test:e2e:ios": "bash .github/scripts/e2e.sh ios",
+    "test:e2e:android": "bash .github/scripts/e2e.sh android",
     "bump": "bun .github/scripts/bump.ts"
   },
   "devDependencies": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -3,6 +3,6 @@
   "version": "2.0.17",
   "private": true,
   "dependencies": {
-    "@packrat-ai/nativewindui": "^2.0.0"
+    "@packrat-ai/nativewindui": "^2.0.1-alpha.0"
   }
 }


### PR DESCRIPTION
## Summary

Continues mikib0's work in #2015 to get Maestro E2E back to green.
Android E2E was already fixed there; this PR takes it the rest of the way by
handling the one remaining iOS-specific failure and a small biome lint nit.

## Root cause (iOS)

After the login form submit on iOS, the system presents a native
**"Save Password?"** Keychain dialog because `password-input` uses
`textContentType="password"`. That dialog is a blocking OS-level prompt
and intercepts any subsequent taps. In CI we saw:

```
[Failed] master-flow (1m 45s) (Assertion is false: id: create-pack-button is visible)
1/1 Flow Failed
```

The failure artifact screenshot confirmed the app was still on the **Dashboard**
tab with the "Save Password?" dialog open — the `tapOn: "Packs"` in `login-flow.yaml`
never reached the app, so we never navigated to the Packs tab and the
`assertVisible: create-pack-button` assertion failed.

(Log excerpt from run
[24235407226](https://github.com/PackRat-AI/PackRat/actions/runs/24235407226), iOS E2E Tests job.)

Android doesn't have this prompt, which is why mikib0's fix already made Android green.

## Fix

- `.maestro/flows/auth/login-flow.yaml` — after submitting login, add a conditional
  `runFlow` that on iOS only optionally taps **"Not Now"** to dismiss the
  Keychain prompt. `optional: true` so the flow still works on runners / future
  iOS versions where the prompt doesn't appear, and the block is gated by
  `platform: iOS` so Android is untouched.
- `apps/expo/app/(app)/(tabs)/profile/index.tsx` — biome `assist/source/organizeImports`
  was failing because the `TestIds` import was appended at the bottom of the import
  block in the testID migration (#2028). Sorted it into place.

Both fixes are minimal and targeted — no `continue-on-error`, no disabled tests,
no skipped jobs.

## Credit

Builds on mikib0's Android-side fix in #2015 (`chore/fix-ci-e2e-test-run-step`).
Once this lands, #2015 can be closed as superseded.

## Test plan

- [ ] biome passes
- [ ] iOS E2E Tests pass (was the blocker)
- [ ] Android E2E Tests pass (already green on #2015, should stay green)
- [ ] Unit tests / check-types remain green