### PR TITLE
fix(e2e): update Maestro flows for 1.40.0 config section requirement

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -148,7 +148,7 @@ jobs:
           TEST_PASSWORD: ${{ secrets.E2E_TEST_PASSWORD }}
           TRIP_NAME: E2E-Trip-${{ github.run_id }}
           PACK_NAME: E2E-Pack-${{ github.run_id }}
-          APP_ID: com.andrewbierman.packrat.preview
+          APP_ID: com.andrewbierman.packrat
 
       - name: Upload test results
         if: always()
@@ -254,12 +254,19 @@ jobs:
             adb shell pm disable-user com.android.launcher3 || true
             adb shell pm disable-user com.google.android.apps.nexuslauncher || true
             adb install apps/expo/build/PackRat.apk
-            export TEST_EMAIL="${{ secrets.E2E_TEST_EMAIL }}"
-            export TEST_PASSWORD="${{ secrets.E2E_TEST_PASSWORD }}"
-            export TRIP_NAME="E2E-Trip-${{ github.run_id }}"
-            export PACK_NAME="E2E-Pack-${{ github.run_id }}"
-            export APP_ID="com.packratai.mobile.preview"
-            bun test:e2e:android --format junit --output test-results/maestro-results.xml
+            cp .maestro/config.yaml .maestro/config.yaml.bak
+            cp .maestro/config-android.yaml .maestro/config.yaml
+            maestro test \
+              --format junit \
+              --output test-results/maestro-results.xml \
+              .maestro/
+            mv .maestro/config.yaml.bak .maestro/config.yaml
+        env:
+          TEST_EMAIL: ${{ secrets.E2E_TEST_EMAIL }}
+          TEST_PASSWORD: ${{ secrets.E2E_TEST_PASSWORD }}
+          TRIP_NAME: E2E-Trip-${{ github.run_id }}
+          PACK_NAME: E2E-Pack-${{ github.run_id }}
+          APP_ID: com.packratai.mobile
 
       - name: Upload test results
         if: always()


### PR DESCRIPTION
## Summary

- Maestro 1.40.0 introduced a breaking change requiring each flow file to have its own config section (`appId:` + `---` separator)
- All 14 flow files under `.maestro/flows/` now start with `appId: ${APP_ID}` followed by `---`
- CI workflow passes `APP_ID` per platform via env vars (iOS: `com.andrewbierman.packrat`, Android: `com.packratai.mobile`)
- The `config.yaml` / `config-android.yaml` suite-level configs remain unchanged

## Root Cause

E2E tests were failing on `main` before this PR — `gh run list` confirmed the pre-existing breakage. Maestro 1.40.0 (pinned in the workflow) changed the flow file format, requiring every flow to declare its `appId` upfront rather than inheriting it only from the suite config.

## Test plan

- [ ] E2E workflow triggers on this PR and passes for both iOS and Android jobs
- [ ] `APP_ID` resolves correctly per platform at runtime
- [ ] Flow execution order in `config.yaml` / `config-android.yaml` is unaffected

---

[![Compound Engineered](https://img.shields.io/badge/Compound-Engineered-6366f1)](https://github.com/EveryInc/compound-engineering-plugin) 🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end test automation infrastructure by configuring explicit app identifiers for iOS and Android platforms across the test suite. This ensures proper app targeting during test execution and strengthens test reliability and consistency throughout all automated test workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->