### PR TITLE
fix(landing): remove placeholder legal footer links

### DIFF
--- a/apps/landing/config/site.ts
+++ b/apps/landing/config/site.ts
@@ -359,12 +359,7 @@ export const siteConfig = {
       { title: 'Careers', href: '/about#careers' },
       { title: 'Contact', href: 'mailto:hello@packratai.com' },
     ],
-    legal: [
-      { title: 'Terms', href: '#' },
-      { title: 'Privacy', href: '/privacy-policy' },
-      { title: 'Cookies', href: '#' },
-      { title: 'Licenses', href: '#' },
-    ],
+    legal: [{ title: 'Privacy', href: '/privacy-policy' }],
   },
 
   // Social links


### PR DESCRIPTION
## Summary

Fixes #1918. The landing site footer had 4 legal links: Terms, Privacy, Cookies, Licenses. Three of them (Terms, Cookies, Licenses) pointed to \`#\` because the underlying pages don't exist.

Dropped the three dead entries. Kept Privacy since \`/privacy-policy\` is a real page.

## Why remove instead of create pages

- Terms of Service, Cookies Policy, and Licenses (software licenses) all need actual legal review before they can be written
- A broken link is a worse user experience than no link at all
- Real pages can be added in a follow-up when they're ready

Closes #1918

## Test plan

- [x] \`apps/landing\` builds cleanly
- [ ] Visual check: footer still renders with Privacy link
- [ ] No broken anchors on the home page