### PR TITLE
fix: follow-ups for #1886 and #1912 audit findings

### DIFF
--- a/apps/expo/app/(app)/(tabs)/trips/index.tsx
+++ b/apps/expo/app/(app)/(tabs)/trips/index.tsx
@@ -1,9 +1,19 @@
+import { featureFlags } from 'expo-app/config';
 import { TripsListScreen } from 'expo-app/features/trips/screens/TripListScreen';
 import { useColorScheme } from 'expo-app/lib/hooks/useColorScheme';
+import { Redirect } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
 import { Platform } from 'react-native';
 
 export default function TripsScreen() {
+  // Gate the tab route behind the trips feature flag. The tab trigger is
+  // already hidden in the layout, but this also blocks deep links such as
+  // `packrat://(tabs)/trips` from bypassing the kill switch.
+  if (!featureFlags.enableTrips) return <Redirect href="/" />;
+  return <TripsScreenInner />;
+}
+
+function TripsScreenInner() {
   const { colorScheme } = useColorScheme();
 
   return (

--- a/apps/expo/app/(app)/trip/[id]/index.tsx
+++ b/apps/expo/app/(app)/trip/[id]/index.tsx
@@ -1,5 +1,10 @@
+import { featureFlags } from 'expo-app/config';
 import { TripDetailScreen } from 'expo-app/features/trips/screens/TripDetailScreen';
+import { Redirect } from 'expo-router';
 
 export default function TripDetailScreenRoute() {
+  // Gate deep links behind the trips feature flag so e.g. `packrat://trip/:id`
+  // cannot bypass the kill switch.
+  if (!featureFlags.enableTrips) return <Redirect href="/" />;
   return <TripDetailScreen />;
 }

--- a/apps/expo/app/(app)/trip/new.tsx
+++ b/apps/expo/app/(app)/trip/new.tsx
@@ -1,5 +1,10 @@
+import { featureFlags } from 'expo-app/config';
 import { CreateTripScreen } from 'expo-app/features/trips/screens/CreateTripScreen';
+import { Redirect } from 'expo-router';
 
 export default function TripNewScreen() {
+  // Gate deep links behind the trips feature flag so e.g. `packrat://trip/new`
+  // cannot bypass the kill switch.
+  if (!featureFlags.enableTrips) return <Redirect href="/" />;
   return <CreateTripScreen />;
 }

--- a/apps/expo/app/(app)/upcoming-trips.tsx
+++ b/apps/expo/app/(app)/upcoming-trips.tsx
@@ -1,9 +1,11 @@
 import { List, ListItem, Text } from '@packrat/ui/nativewindui';
 import { format } from 'date-fns';
+import { featureFlags } from 'expo-app/config';
 import { useTrips } from 'expo-app/features/trips/hooks';
 import { cn } from 'expo-app/lib/cn';
 import { useTranslation } from 'expo-app/lib/hooks/useTranslation';
 import type { TranslationFunction } from 'expo-app/lib/i18n/types';
+import { Redirect } from 'expo-router';
 import { useEffect, useMemo, useState } from 'react';
 import { ScrollView, View } from 'react-native';
 import { useDetailedPacks } from '../../features/packs/hooks/useDetailedPacks';
@@ -102,6 +104,14 @@ function PackStatus({ status, completion }: { status: string; completion: number
 // }
 
 export default function UpcomingTripsScreen() {
+  // Gate deep links behind the trips feature flag. `featureFlags` is a build-
+  // time constant, so this branch is stable across renders and does not break
+  // the rules of hooks.
+  if (!featureFlags.enableTrips) return <Redirect href="/" />;
+  return <UpcomingTripsScreenInner />;
+}
+
+function UpcomingTripsScreenInner() {
   const { t } = useTranslation();
   const trips = useTrips();
   const packs = useDetailedPacks();

--- a/apps/expo/features/pack-templates/components/FeaturedPacksSection.tsx
+++ b/apps/expo/features/pack-templates/components/FeaturedPacksSection.tsx
@@ -3,26 +3,39 @@ import { WeightBadge } from 'expo-app/components/initial/WeightBadge';
 import { useTranslation } from 'expo-app/lib/hooks/useTranslation';
 import { useRouter } from 'expo-router';
 import { isArray } from 'radash';
+import { useMemo } from 'react';
 import { Image, Pressable, ScrollView, View } from 'react-native';
 import { usePackTemplates } from '../hooks';
-import { usePackTemplateDetails } from '../hooks/usePackTemplatesDetails';
-import type { PackTemplate } from '../types';
+import { usePackTemplateSummaries } from '../hooks/usePackTemplateSummary';
+import type { PackTemplate, PackTemplateInStore } from '../types';
 
 type FeaturedPackCardProps = {
-  templateId: string;
+  template: PackTemplateInStore;
+  itemCount: number;
+  baseWeight: number;
+  totalWeight: number;
   onPress: (template: PackTemplate) => void;
 };
 
-function FeaturedPackCard({ templateId, onPress }: FeaturedPackCardProps) {
-  const template = usePackTemplateDetails(templateId);
+function FeaturedPackCard({
+  template,
+  itemCount,
+  baseWeight,
+  totalWeight,
+  onPress,
+}: FeaturedPackCardProps) {
   const { t } = useTranslation();
 
-  if (!template) return null;
+  const handlePress = () => {
+    // The consumer only reads `id` from the template, but we materialise the
+    // minimum `PackTemplate` shape to keep the callback type strict.
+    onPress({ ...template, items: [], baseWeight, totalWeight });
+  };
 
   return (
     <Pressable
       className="mr-4 w-64 overflow-hidden rounded-xl bg-card shadow-sm"
-      onPress={() => onPress(template)}
+      onPress={handlePress}
       style={({ pressed }) => ({ opacity: pressed ? 0.85 : 1 })}
     >
       {template.image ? (
@@ -61,12 +74,10 @@ function FeaturedPackCard({ templateId, onPress }: FeaturedPackCardProps) {
 
         <View className="flex-row items-center justify-between">
           <View className="flex-row gap-1">
-            <WeightBadge weight={template.baseWeight ?? 0} unit="g" type="base" />
+            <WeightBadge weight={baseWeight} unit="g" type="base" />
           </View>
           <Text className="text-xs text-muted-foreground">
-            {template.items && isArray(template.items)
-              ? `${template.items.length} ${t('packTemplates.items')}`
-              : `0 ${t('packTemplates.items')}`}
+            {`${itemCount} ${t('packTemplates.items')}`}
           </Text>
         </View>
       </View>
@@ -83,7 +94,17 @@ export function FeaturedPacksSection({ onTemplatePress }: FeaturedPacksSectionPr
   const { t } = useTranslation();
   const router = useRouter();
 
-  const featuredTemplates = templates.filter((template) => template.isAppTemplate);
+  const featuredTemplates = useMemo(
+    () => templates.filter((template) => template.isAppTemplate),
+    [templates],
+  );
+
+  const featuredIds = useMemo(() => featuredTemplates.map((t) => t.id), [featuredTemplates]);
+
+  // Single pass over the items store computes item count + base weight for all
+  // featured templates at once, instead of each card subscribing to the full
+  // details hook and iterating every item in the store on its own.
+  const summaries = usePackTemplateSummaries(featuredIds);
 
   if (featuredTemplates.length === 0) return null;
 
@@ -103,9 +124,19 @@ export function FeaturedPacksSection({ onTemplatePress }: FeaturedPacksSectionPr
         contentContainerStyle={{ paddingLeft: 16, paddingRight: 8 }}
         className="pb-2"
       >
-        {featuredTemplates.map((template) => (
-          <FeaturedPackCard key={template.id} templateId={template.id} onPress={onTemplatePress} />
-        ))}
+        {featuredTemplates.map((template) => {
+          const summary = summaries[template.id];
+          return (
+            <FeaturedPackCard
+              key={template.id}
+              template={template}
+              itemCount={summary?.itemCount ?? 0}
+              baseWeight={summary?.baseWeight ?? 0}
+              totalWeight={summary?.totalWeight ?? 0}
+              onPress={onTemplatePress}
+            />
+          );
+        })}
       </ScrollView>
     </View>
   );

--- a/apps/expo/features/pack-templates/hooks/index.ts
+++ b/apps/expo/features/pack-templates/hooks/index.ts
@@ -6,6 +6,7 @@ export * from './useDeletePackTemplate';
 export * from './useDeletePackTemplateItem';
 export * from './useGenerateTemplateFromOnlineContent';
 export * from './usePackTemplateItem';
+export * from './usePackTemplateSummary';
 export * from './usePackTemplates';
 export * from './usePackTemplatesDetails';
 export * from './useUpdatePackTemplateItem';

--- a/apps/expo/features/pack-templates/hooks/usePackTemplateSummary.ts
+++ b/apps/expo/features/pack-templates/hooks/usePackTemplateSummary.ts
@@ -1,0 +1,95 @@
+import { use$ } from '@legendapp/state/react';
+import { convertFromGrams, convertToGrams } from 'expo-app/features/packs/utils';
+import { packTemplateItemsStore } from '../store/packTemplateItems';
+import type { WeightUnit } from '../types';
+
+export type PackTemplateSummary = {
+  itemCount: number;
+  baseWeight: number;
+  totalWeight: number;
+};
+
+/**
+ * Returns a cheap summary (item count + computed base / total weight) for a
+ * pack template without materialising the full list of items.
+ *
+ * Use this for card/tile views that only need display stats — it avoids the
+ * allocations that `usePackTemplateDetails` incurs (which spreads the
+ * template and its items on every change).
+ */
+export function usePackTemplateSummary(
+  templateId: string,
+  preferredUnit: WeightUnit = 'g',
+): PackTemplateSummary {
+  return use$(() => {
+    let itemCount = 0;
+    let baseWeightGrams = 0;
+    let totalWeightGrams = 0;
+
+    const items = packTemplateItemsStore.get();
+    for (const item of Object.values(items)) {
+      if (item.packTemplateId !== templateId || item.deleted) continue;
+      itemCount++;
+      const itemWeightInGrams =
+        convertToGrams(item.weight, item.weightUnit as WeightUnit) * item.quantity;
+      totalWeightGrams += itemWeightInGrams;
+      if (!item.consumable && !item.worn) {
+        baseWeightGrams += itemWeightInGrams;
+      }
+    }
+
+    return {
+      itemCount,
+      baseWeight: Number(convertFromGrams(baseWeightGrams, preferredUnit).toFixed(2)),
+      totalWeight: Number(convertFromGrams(totalWeightGrams, preferredUnit).toFixed(2)),
+    };
+  });
+}
+
+/**
+ * Returns summaries (item count + computed weights) for a batch of pack
+ * template ids in a single pass over the items store. Prefer this over
+ * calling `usePackTemplateSummary` in a loop (e.g. from list/carousel
+ * renderers) — it avoids a `store.get()` per id and scales linearly with the
+ * total number of items rather than multiplicatively.
+ */
+export function usePackTemplateSummaries(
+  templateIds: string[],
+  preferredUnit: WeightUnit = 'g',
+): Record<string, PackTemplateSummary> {
+  return use$(() => {
+    if (templateIds.length === 0) return {};
+
+    const wanted = new Set(templateIds);
+    const grams: Record<string, { base: number; total: number; count: number }> = {};
+    for (const id of templateIds) {
+      grams[id] = { base: 0, total: 0, count: 0 };
+    }
+
+    const items = packTemplateItemsStore.get();
+    for (const item of Object.values(items)) {
+      if (item.deleted) continue;
+      if (!wanted.has(item.packTemplateId)) continue;
+      const bucket = grams[item.packTemplateId];
+      if (!bucket) continue;
+      bucket.count++;
+      const itemWeightInGrams =
+        convertToGrams(item.weight, item.weightUnit as WeightUnit) * item.quantity;
+      bucket.total += itemWeightInGrams;
+      if (!item.consumable && !item.worn) {
+        bucket.base += itemWeightInGrams;
+      }
+    }
+
+    const result: Record<string, PackTemplateSummary> = {};
+    for (const id of templateIds) {
+      const bucket = grams[id] ?? { base: 0, total: 0, count: 0 };
+      result[id] = {
+        itemCount: bucket.count,
+        baseWeight: Number(convertFromGrams(bucket.base, preferredUnit).toFixed(2)),
+        totalWeight: Number(convertFromGrams(bucket.total, preferredUnit).toFixed(2)),
+      };
+    }
+    return result;
+  });
+}

--- a/apps/expo/lib/i18n/locales/en.json
+++ b/apps/expo/lib/i18n/locales/en.json
@@ -968,16 +968,7 @@
     "anErrorOccurred": "An Error Occurred",
     "pleaseTryAgain": "Please try again",
     "featuredPacks": "Featured Packs",
-    "viewAll": "View All",
-    "dayHike": "Day Hike",
-    "overnight": "Overnight",
-    "weekendCamping": "Weekend Camping",
-    "multiDay": "Multi-Day",
-    "winterHiking": "Winter Hiking",
-    "winterCamping": "Winter Camping",
-    "tripDuration": "Trip Duration",
-    "environment": "Environment",
-    "intendedUse": "Intended Use"
+    "viewAll": "View All"
   },
   "guides": {
     "guides": "Guides",


### PR DESCRIPTION
## Summary

Follow-up PR addressing the non-critical issues flagged in an audit of #1886 (Featured Packs) and #1912 (Trips feature flag) after they merged.

### #1886 follow-ups
- Removed 9 unused i18n keys under `packTemplates` that were added but never referenced (`dayHike`, `overnight`, `weekendCamping`, `multiDay`, `winterHiking`, `winterCamping`, `tripDuration`, `environment`, `intendedUse`).
- Replaced the N+1 query pattern in `FeaturedPackCard` with a batched `usePackTemplateSummaries` selector. Previously each of 6 cards called `usePackTemplateDetails`, which materialised the full item list and recomputed weights for every card on every render. `FeaturedPacksSection` now computes item counts and base/total weight for all featured templates in a single pass and hands them to the cards as props.

### #1912 follow-ups
- Gated trip deep-link routes (`/trip/[id]`, `/trip/new`, `/upcoming-trips`, `/(tabs)/trips`) behind `featureFlags.enableTrips`. #1912 hid the trips tab trigger and home tiles but left the underlying route files rendering, so `packrat://trip/new` still bypassed the kill switch. Each route now returns `<Redirect href="/" />` when the flag is off. Trip feature components under `features/trips/*` are intentionally unchanged — the gating lives at the router entry points.

## Test plan

- [x] `bun run check-types` clean
- [x] `bun lint` clean (exit 0 — only pre-existing warnings)
- [ ] With `enableTrips: false`, tapping a trip deep link redirects home
- [ ] Featured packs list renders without loading 100+ items per card