### PR TITLE
fix(ci): harden e2e.sh and maestro config (#2037 review followups)

### DIFF
--- a/.github/scripts/e2e.sh
+++ b/.github/scripts/e2e.sh
@@ -4,6 +4,13 @@ set -e
 PLATFORM=$1  # "ios" or "android"
 shift  # Remove first argument so $@ contains only the additional options
 
+# Require test credentials to be supplied via env (CI secrets or local .env.local).
+# Never fall back to baked-in defaults.
+if [ -z "${TEST_EMAIL:-}" ] || [ -z "${TEST_PASSWORD:-}" ]; then
+  echo "ERROR: TEST_EMAIL and TEST_PASSWORD must be set (via CI secrets or a gitignored .env.local)" >&2
+  exit 1
+fi
+
 # Generate unique ID for this test run
 UNIQUE_ID=$(date +%s)
 
@@ -33,8 +40,8 @@ END_TAPS=$(( ($(get_year "$END_DATE") - CURRENT_YEAR) * 12 + ($(get_month_num "$
 
 if [ "$PLATFORM" = "ios" ]; then
   maestro test --config .maestro/config.yaml $@ \
-    -e TEST_EMAIL="${TEST_EMAIL:-qa1.admin@packratai.com}" \
-    -e TEST_PASSWORD="${TEST_PASSWORD:-Ab12345.}" \
+    -e TEST_EMAIL="$TEST_EMAIL" \
+    -e TEST_PASSWORD="$TEST_PASSWORD" \
     -e TRIP_NAME="${TRIP_NAME:-E2E-Trip-$UNIQUE_ID}" \
     -e PACK_NAME="${PACK_NAME:-E2E-Pack-$UNIQUE_ID}" \
     -e APP_ID="${APP_ID:-com.andrewbierman.packrat.preview}" \
@@ -49,8 +56,8 @@ if [ "$PLATFORM" = "ios" ]; then
     .maestro/master-flow.yaml
 else
   maestro test --config .maestro/config-android.yaml $@ \
-    -e TEST_EMAIL="${TEST_EMAIL:-qa1.admin@packratai.com}" \
-    -e TEST_PASSWORD="${TEST_PASSWORD:-Ab12345.}" \
+    -e TEST_EMAIL="$TEST_EMAIL" \
+    -e TEST_PASSWORD="$TEST_PASSWORD" \
     -e TRIP_NAME="${TRIP_NAME:-E2E-Trip-$UNIQUE_ID}" \
     -e PACK_NAME="${PACK_NAME:-E2E-Pack-$UNIQUE_ID}" \
     -e APP_ID="${APP_ID:-com.packratai.mobile.preview}" \

--- a/.github/scripts/e2e.sh
+++ b/.github/scripts/e2e.sh
@@ -39,7 +39,7 @@ START_TAPS=$(( ($(get_year "$START_DATE") - CURRENT_YEAR) * 12 + ($(get_month_nu
 END_TAPS=$(( ($(get_year "$END_DATE") - CURRENT_YEAR) * 12 + ($(get_month_num "$END_DATE") - CURRENT_MONTH) ))
 
 if [ "$PLATFORM" = "ios" ]; then
-  maestro test --config .maestro/config.yaml $@ \
+  maestro test --config .maestro/config.yaml "$@" \
     -e TEST_EMAIL="$TEST_EMAIL" \
     -e TEST_PASSWORD="$TEST_PASSWORD" \
     -e TRIP_NAME="${TRIP_NAME:-E2E-Trip-$UNIQUE_ID}" \
@@ -55,7 +55,7 @@ if [ "$PLATFORM" = "ios" ]; then
     -e END_TAPS="$END_TAPS" \
     .maestro/master-flow.yaml
 else
-  maestro test --config .maestro/config-android.yaml $@ \
+  maestro test --config .maestro/config-android.yaml "$@" \
     -e TEST_EMAIL="$TEST_EMAIL" \
     -e TEST_PASSWORD="$TEST_PASSWORD" \
     -e TRIP_NAME="${TRIP_NAME:-E2E-Trip-$UNIQUE_ID}" \

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -104,28 +104,56 @@ jobs:
 
       - name: Boot iOS Simulator
         run: |
+          # Pick the newest available iOS runtime on this runner. GitHub's
+          # macOS images ship different iOS runtimes over time; hard-coding a
+          # specific major version breaks CI every time Apple ships a new one.
           IOS_RUNTIME=$(xcrun simctl list runtimes --json \
             | python3 -c "
-          import sys, json
+          import sys, json, re
           data = json.load(sys.stdin)
-          runtimes = data.get('runtimes', [])
-          available = [r for r in runtimes if r.get('isAvailable', False)]
-          ios26 = [r for r in available if 'iOS 26' in r.get('name','')]
-          if not ios26:
-              print('::error::No iOS 26 runtime found on this runner', file=sys.stderr)
+          runtimes = [r for r in data.get('runtimes', [])
+                      if r.get('isAvailable', False) and 'iOS' in r.get('name','')]
+          if not runtimes:
+              print('::error::No available iOS runtimes found on this runner', file=sys.stderr)
               sys.exit(1)
-          print(ios26[-1]['identifier'])
+          def ver_key(r):
+              m = re.search(r'iOS\s+(\d+)(?:\.(\d+))?', r.get('name',''))
+              return (int(m.group(1)) if m else 0, int(m.group(2) or 0) if m else 0)
+          runtimes.sort(key=ver_key)
+          picked = runtimes[-1]
+          print(f\"Picked runtime: {picked['name']}\", file=sys.stderr)
+          print(picked['identifier'])
           ")
 
+          # Prefer a plain iPhone (no Pro/Plus/Max) from a recent generation.
+          # Fall back through 17 -> 16 -> 15 -> any available plain iPhone so
+          # the workflow survives device-type churn on the runner images.
           DEVICE_TYPE=$(xcrun simctl list devicetypes --json \
             | python3 -c "
-          import sys, json
+          import sys, json, re
           types = json.load(sys.stdin)['devicetypes']
-          iphone16 = [d for d in types if 'iPhone 16' in d.get('name','') and 'Pro' not in d.get('name','') and 'Plus' not in d.get('name','') and 'Max' not in d.get('name','')]
-          if not iphone16:
-              print('::error::No iPhone 16 device type found on this runner', file=sys.stderr)
+          def plain_iphone(name):
+              return ('iPhone' in name
+                      and 'Pro' not in name
+                      and 'Plus' not in name
+                      and 'Max' not in name
+                      and 'mini' not in name
+                      and 'SE' not in name)
+          plain = [d for d in types if plain_iphone(d.get('name',''))]
+          if not plain:
+              print('::error::No plain iPhone device types found on this runner', file=sys.stderr)
               sys.exit(1)
-          print(iphone16[0]['identifier'])
+          def gen(d):
+              m = re.search(r'iPhone\s+(\d+)', d.get('name',''))
+              return int(m.group(1)) if m else 0
+          # Prefer generations 15/16/17 (current sweet spot), then fall back
+          # to whatever plain iPhone is newest.
+          preferred = [d for d in plain if gen(d) in (17, 16, 15)]
+          pool = preferred if preferred else plain
+          pool.sort(key=gen, reverse=True)
+          picked = pool[0]
+          print(f\"Picked device type: {picked['name']}\", file=sys.stderr)
+          print(picked['identifier'])
           ")
 
           echo "Using runtime: $IOS_RUNTIME"

--- a/.maestro/config.yaml
+++ b/.maestro/config.yaml
@@ -3,7 +3,7 @@
 
 flows:
   - "flows/**/*.yaml"
-  - "*.yaml"  # Include root-level flows like master-flow.yaml
+  - "master-flow.yaml"  # Root-level iOS master flow (config*.yaml intentionally excluded)
 
 # Platform-specific settings
 platform:


### PR DESCRIPTION
## Summary

Follow-up to #2037 addressing four issues Copilot flagged in its review that merged without being fixed:

1. **Hardcoded TEST_EMAIL / TEST_PASSWORD fallbacks removed** in `.github/scripts/e2e.sh`. The script now errors out with a clear message unless both variables are supplied via CI secrets or a local (gitignored) `.env.local`, so test credentials can never ship in the repo again. (Same defaults did not appear anywhere else in `.github/`.)
2. **`$@` → `"$@"`** in both the iOS and Android `maestro test` invocations so caller-supplied arguments containing whitespace or glob characters pass through intact.
3. **`.maestro/config.yaml` flows glob narrowed** from `"*.yaml"` (which matched `config.yaml` itself and would have caused Maestro to execute the config file as a flow) to an explicit `"master-flow.yaml"` reference. `config-android.yaml` was already specific and needed no change.
4. **iOS simulator selection made resilient to runtime churn** in `.github/workflows/e2e-tests.yml`. The Boot iOS Simulator step previously hard-coded `iOS 26` + iPhone 16 and exited 1 when either was missing — this breaks CI whenever Apple ships a new major version. It now:
   - picks the newest available iOS runtime by parsed version number
   - prefers a plain iPhone (no Pro/Plus/Max/mini/SE) from generations 17/16/15, falling back to the newest plain iPhone available
   - no longer hard-fails when the exact pinned device or runtime isn't present

## Not changed

- **`@packrat-ai/nativewindui` pin** (Copilot also flagged the `^2.0.1-alpha.0` bump in `packages/ui/package.json`). Left as-is because the bump is deliberate — commit `cd2f36b` explicitly describes it: "update nativewindui package to the version with TextField with only TextInput accessible". Reverting would regress that fix.
- `.maestro/flows/**` YAML files (out of scope of this PR per ask).

## Test plan
- [x] `bash -n .github/scripts/e2e.sh` — clean
- [x] `bun run check-types` — passes
- [x] lefthook pre-commit biome lint — clean on all touched files
- [ ] iOS E2E Maestro run in CI
- [ ] Android E2E Maestro run in CI