### PR TITLE
chore(biome): tighten useMaxParams from 3 to 2

### DIFF
--- a/apps/expo/features/trail-conditions/hooks/useTrailConditionReports.ts
+++ b/apps/expo/features/trail-conditions/hooks/useTrailConditionReports.ts
@@ -18,23 +18,22 @@ function cacheKey(userId: string, trailName?: string): string {
 /** Persist fetched reports to AsyncStorage for offline / cold-start access. */
 async function writeCachedReports(
   reports: TrailConditionReport[],
-  userId: string,
-  trailName?: string,
+  opts: { userId: string; trailName?: string },
 ) {
   try {
-    await AsyncStorage.setItem(cacheKey(userId, trailName), JSON.stringify(reports));
+    await AsyncStorage.setItem(cacheKey(opts.userId, opts.trailName), JSON.stringify(reports));
   } catch {
     // Best-effort — swallow write errors silently
   }
 }
 
 /** Read previously-cached reports from AsyncStorage. */
-async function readCachedReports(
-  userId: string,
-  trailName?: string,
-): Promise<TrailConditionReport[] | undefined> {
+async function readCachedReports(opts: {
+  userId: string;
+  trailName?: string;
+}): Promise<TrailConditionReport[] | undefined> {
   try {
-    const raw = await AsyncStorage.getItem(cacheKey(userId, trailName));
+    const raw = await AsyncStorage.getItem(cacheKey(opts.userId, opts.trailName));
     if (raw) return JSON.parse(raw) as TrailConditionReport[];
   } catch {
     // Corrupt or missing cache — ignore
@@ -78,7 +77,7 @@ export function useTrailConditionReports(trailName?: string) {
   useEffect(() => {
     let cancelled = false;
     setCachedReports(undefined);
-    readCachedReports(currentUserId, trailName).then((reports) => {
+    readCachedReports({ userId: currentUserId, trailName }).then((reports) => {
       if (!cancelled) setCachedReports(reports);
     });
     return () => {
@@ -106,7 +105,7 @@ export function useTrailConditionReports(trailName?: string) {
   useEffect(() => {
     if (query.data && query.data !== prevDataRef.current && query.isFetched) {
       prevDataRef.current = query.data;
-      writeCachedReports(query.data, currentUserId, trailName);
+      writeCachedReports(query.data, { userId: currentUserId, trailName });
     }
   }, [query.data, query.isFetched, currentUserId, trailName]);
 

--- a/biome.json
+++ b/biome.json
@@ -37,7 +37,7 @@
         "useMaxParams": {
           "level": "error",
           "options": {
-            "max": 3
+            "max": 2
           }
         }
       },

--- a/biome.json
+++ b/biome.json
@@ -46,6 +46,28 @@
       }
     }
   },
+  "overrides": [
+    {
+      "includes": [
+        "apps/expo/atoms/atomWith*.ts",
+        "apps/expo/features/weather/atoms/locationsAtoms.ts",
+        "packages/api/src/routes/admin/index.ts",
+        "packages/api/src/services/r2-bucket.ts",
+        "packages/api/src/services/etl/processCatalogEtl.ts",
+        "packages/api/test/guides.test.ts",
+        "packages/api/test/setup.ts",
+        "apps/expo/utils/weight.ts",
+        "packages/api/src/utils/weight.ts"
+      ],
+      "linter": {
+        "rules": {
+          "complexity": {
+            "useMaxParams": "off"
+          }
+        }
+      }
+    }
+  ],
   "css": {
     "parser": {
       "cssModules": false,


### PR DESCRIPTION
## Summary

Tightens `useMaxParams` from `max: 3` to `max: 2`, making "one positional + one typed options object" the canonical function shape for new code.

Follows #2042, which did the bulk of the refactoring prep work.

## Framework-required signatures exempted via override

Biome's `useMaxParams` rule counts callback arity naively, so the following paths are exempted where the 3rd arg is framework-required:

- `apps/expo/atoms/atomWith*.ts` — Jotai write atom `(get, set, update)`
- `apps/expo/features/weather/atoms/locationsAtoms.ts` — Jotai write atom `(get, set, newActiveId)`
- `packages/api/src/routes/admin/index.ts` — Hono `basicAuth` `verifyUser(user, pass, c)`
- `packages/api/src/services/r2-bucket.ts` — Cloudflare `R2Bucket.put` / `uploadPart` contract
- `packages/api/src/services/etl/processCatalogEtl.ts` — `.reduce((acc, header, idx))`
- `packages/api/test/{guides.test,setup}.ts` — R2 put mocks mirroring the interface

## Application-code refactors

- `apps/expo/features/trail-conditions/hooks/useTrailConditionReports.ts` — `writeCachedReports` / `readCachedReports` now take an `opts` object (`{ userId, trailName? }`) instead of positional `userId, trailName?`.

## Out of scope

`convertWeight(weight, from, to)` in `apps/expo/utils/weight.ts` and `packages/api/src/utils/weight.ts` has ~24 call sites across the monorepo. Refactoring is its own PR, so it's exempted for now.

## Test plan
- [x] `bun biome check` passes at max: 2 (0 useMaxParams errors)
- [x] `bun run check-types` clean
- [x] `bun lint` clean (same 186 warnings / 7 infos as baseline, no new errors)