### PR TITLE
chore(guards): migrate remaining expo files to @packrat/guards

### DIFF
--- a/apps/expo/features/pack-templates/components/PackTemplateCard.tsx
+++ b/apps/expo/features/pack-templates/components/PackTemplateCard.tsx
@@ -1,4 +1,5 @@
 import { useActionSheet } from '@expo/react-native-action-sheet';
+import { isArray } from '@packrat/guards';
 import { Button, Text } from '@packrat/ui/nativewindui';
 import { Icon } from '@roninoss/icons';
 import { appAlert } from 'expo-app/app/_layout';
@@ -6,7 +7,6 @@ import { WeightBadge } from 'expo-app/components/initial/WeightBadge';
 import { useColorScheme } from 'expo-app/lib/hooks/useColorScheme';
 import { useTranslation } from 'expo-app/lib/hooks/useTranslation';
 import { router } from 'expo-router';
-import { isArray } from 'radash';
 import { Image, Pressable, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useDeletePackTemplate, usePackTemplateDetails } from '../hooks';

--- a/apps/expo/features/pack-templates/hooks/useGenerateTemplateFromOnlineContent.ts
+++ b/apps/expo/features/pack-templates/hooks/useGenerateTemplateFromOnlineContent.ts
@@ -1,13 +1,10 @@
 import { useMutation } from '@tanstack/react-query';
 import axiosInstance, { handleApiError } from 'expo-app/lib/api/client';
 import { obs } from 'expo-app/lib/store';
+import { isWeightUnit } from 'expo-app/lib/utils/itemCalculations';
 import { packTemplateItemsStore } from '../store/packTemplateItems';
 import { packTemplatesStore } from '../store/packTemplates';
-import type { PackTemplateInStore, PackTemplateItem, WeightUnit } from '../types';
-
-const WEIGHT_UNITS: ReadonlySet<WeightUnit> = new Set(['g', 'kg', 'oz', 'lb']);
-const isWeightUnit = (value: string): value is WeightUnit =>
-  (WEIGHT_UNITS as ReadonlySet<string>).has(value);
+import type { PackTemplateInStore, PackTemplateItem } from '../types';
 
 export interface GenerateFromOnlineContentInput {
   contentUrl: string;

--- a/apps/expo/features/packs/components/PackCard.tsx
+++ b/apps/expo/features/packs/components/PackCard.tsx
@@ -1,10 +1,10 @@
 import { useActionSheet } from '@expo/react-native-action-sheet';
+import { isArray } from '@packrat/guards';
 import { Button, Text } from '@packrat/ui/nativewindui';
 import { Icon } from '@roninoss/icons';
 import { WeightBadge } from 'expo-app/components/initial/WeightBadge';
 import { useColorScheme } from 'expo-app/lib/hooks/useColorScheme';
 import { router } from 'expo-router';
-import { isArray } from 'radash';
 import { Alert, Image, Pressable, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useDeletePack, usePackDetailsFromStore } from '../hooks';

--- a/apps/expo/lib/utils/itemCalculations.ts
+++ b/apps/expo/lib/utils/itemCalculations.ts
@@ -1,8 +1,12 @@
+import { makeEnumGuard } from '@packrat/guards';
 import type { CatalogItem } from 'expo-app/features/catalog/types';
 import type { PackTemplateItem } from 'expo-app/features/pack-templates';
 import type { PackItem, WeightUnit } from 'expo-app/features/packs';
 
 type Item = CatalogItem | PackItem | PackTemplateItem;
+
+const WEIGHT_UNITS = ['g', 'kg', 'oz', 'lb'] as const satisfies readonly WeightUnit[];
+export const isWeightUnit = makeEnumGuard(WEIGHT_UNITS);
 
 /**
  * Checks if an item is a catalog item
@@ -41,10 +45,6 @@ export function getWeightUnit(item: Item): WeightUnit {
     return 'g'; // default fallback
   }
   return item.weightUnit;
-}
-
-function isWeightUnit(value: string): value is WeightUnit {
-  return ['g', 'oz', 'kg', 'lb'].includes(value);
 }
 
 /** Gets the notes of an item */


### PR DESCRIPTION
## Summary

Finishes the `@packrat/guards` migration started in #2039 by touching the expo files that were intentionally left out of scope:

- `apps/expo/lib/utils/itemCalculations.ts` — `isWeightUnit` now uses `makeEnumGuard` from `@packrat/guards`, and is exported so other call sites can reuse it
- `apps/expo/features/packs/components/PackCard.tsx` — `isArray` now comes from `@packrat/guards`
- `apps/expo/features/pack-templates/components/PackTemplateCard.tsx` — same
- `apps/expo/features/pack-templates/hooks/useGenerateTemplateFromOnlineContent.ts` — drops its duplicate inline `isWeightUnit` and imports the canonical one from `itemCalculations`

No behavior change. Pure canonicalization.

## Test plan

- [x] `bun run check-types` clean (no new errors in touched files)
- [x] `bun lint` clean (no new diagnostics in touched files)
- [ ] CI passes