### PR TITLE
fix(ci): resolve biome errors on development

### DIFF
--- a/apps/expo/features/feed/components/PostCard.tsx
+++ b/apps/expo/features/feed/components/PostCard.tsx
@@ -69,10 +69,9 @@ export const PostCard: React.FC<PostCardProps> = ({ post, onLike, onDelete, curr
             showsHorizontalScrollIndicator={false}
             style={styles.imageScroll}
           >
-            {post.images.map((img, idx) => (
-              // biome-ignore lint/suspicious/noArrayIndexKey: images have no stable id
+            {post.images.map((img) => (
               <Image
-                key={`${img}-${idx}`}
+                key={img}
                 source={{ uri: buildPostImageUrl(img) }}
                 style={[styles.image, { width: SCREEN_WIDTH - 32 }]}
                 resizeMode="cover"

--- a/apps/expo/features/feed/screens/PostDetailScreen.tsx
+++ b/apps/expo/features/feed/screens/PostDetailScreen.tsx
@@ -107,10 +107,9 @@ export const PostDetailScreen = ({ post, currentUserId }: PostDetailScreenProps)
           showsHorizontalScrollIndicator={false}
           style={styles.imageScroll}
         >
-          {post.images.map((img, idx) => (
-            // biome-ignore lint/suspicious/noArrayIndexKey: images have no stable id
+          {post.images.map((img) => (
             <Image
-              key={`${img}-${idx}`}
+              key={img}
               source={{ uri: buildPostImageUrl(img) }}
               style={styles.image}
               resizeMode="cover"

--- a/apps/expo/features/trips/components/UpcomingTripsTile.tsx
+++ b/apps/expo/features/trips/components/UpcomingTripsTile.tsx
@@ -12,7 +12,7 @@ import { View } from 'react-native';
 export function UpcomingTripsTile() {
   const router = useRouter();
   const { t } = useTranslation();
-  const alertRef = useRef<AlertMethods>(null);
+  const _alertRef = useRef<AlertMethods>(null);
   const [showAlert, setShowAlert] = useState(false);
 
   // ✅ get all trips

--- a/apps/expo/features/weather/components/LocationPicker.tsx
+++ b/apps/expo/features/weather/components/LocationPicker.tsx
@@ -52,112 +52,110 @@ export function LocationPicker({
   };
 
   return (
-    <>
-      <Modal visible={open} animationType="slide" presentationStyle="pageSheet">
-        <SafeAreaView className="flex-1 bg-background">
-          <View className="px-4 mb-4 py-2 border-b border-border flex-row gap-2 justify-between items-center">
-            <View className="flex-row flex-1 items-center gap-2">
-              <TouchableOpacity onPress={onClose}>
-                <Icon name="close" size={20} color={colors.foreground} />
-              </TouchableOpacity>
-              <View>
-                <Text className="text-lg font-semibold">{displayTitle}</Text>
-                {subtitle && <Text className="text-xs text-muted-foreground">{subtitle}</Text>}
-              </View>
-            </View>
-            <TouchableOpacity onPress={handleSearchLocation}>
-              {/* <Icon name="cog-outline" size={20} color={colors.foreground} /> */}
-              <Icon
-                materialIcon={{ name: 'search', type: 'MaterialIcons' }}
-                ios={{ name: 'magnifyingglass' }}
-                size={20}
-                color={colors.foreground}
-              />
+    <Modal visible={open} animationType="slide" presentationStyle="pageSheet">
+      <SafeAreaView className="flex-1 bg-background">
+        <View className="px-4 mb-4 py-2 border-b border-border flex-row gap-2 justify-between items-center">
+          <View className="flex-row flex-1 items-center gap-2">
+            <TouchableOpacity onPress={onClose}>
+              <Icon name="close" size={20} color={colors.foreground} />
             </TouchableOpacity>
+            <View>
+              <Text className="text-lg font-semibold">{displayTitle}</Text>
+              {subtitle && <Text className="text-xs text-muted-foreground">{subtitle}</Text>}
+            </View>
           </View>
-          <ScrollView contentContainerStyle={!hasLocations && { flex: 1 }}>
-            {hasLocations ? (
-              <View className="gap-2 p-4">
-                {locations.map((location) => (
-                  <Pressable
-                    key={location.id}
-                    onPress={() => setSelectedLocation(location)}
-                    className={cn(
-                      'flex-row items-center rounded-lg p-2 border border-border bg-card',
-                      location.id === selectedLocation?.id && 'border-primary',
+          <TouchableOpacity onPress={handleSearchLocation}>
+            {/* <Icon name="cog-outline" size={20} color={colors.foreground} /> */}
+            <Icon
+              materialIcon={{ name: 'search', type: 'MaterialIcons' }}
+              ios={{ name: 'magnifyingglass' }}
+              size={20}
+              color={colors.foreground}
+            />
+          </TouchableOpacity>
+        </View>
+        <ScrollView contentContainerStyle={!hasLocations && { flex: 1 }}>
+          {hasLocations ? (
+            <View className="gap-2 p-4">
+              {locations.map((location) => (
+                <Pressable
+                  key={location.id}
+                  onPress={() => setSelectedLocation(location)}
+                  className={cn(
+                    'flex-row items-center rounded-lg p-2 border border-border bg-card',
+                    location.id === selectedLocation?.id && 'border-primary',
+                  )}
+                  style={({ pressed }) => (pressed ? { opacity: 0.7 } : {})}
+                >
+                  <View className="mr-3 h-8 w-8 items-center justify-center rounded-full bg-neutral-300 dark:bg-neutral-600">
+                    <Icon name="map-marker-radius-outline" size={18} color={colors.grey} />
+                  </View>
+                  <View className="flex-1">
+                    <Text className="font-medium">{location.name}</Text>
+                    <Text className="text-xs text-muted-foreground">{location.condition}</Text>
+                  </View>
+                  <View className="flex-row gap-2 items-center">
+                    {location.id === activeLocation?.id && (
+                      <>
+                        <Text variant="callout">{t('common.default')}</Text>
+                        <View className="mx-1 h-1 w-1 rounded-full bg-muted-foreground" />
+                      </>
                     )}
-                    style={({ pressed }) => (pressed ? { opacity: 0.7 } : {})}
-                  >
-                    <View className="mr-3 h-8 w-8 items-center justify-center rounded-full bg-neutral-300 dark:bg-neutral-600">
-                      <Icon name="map-marker-radius-outline" size={18} color={colors.grey} />
-                    </View>
-                    <View className="flex-1">
-                      <Text className="font-medium">{location.name}</Text>
-                      <Text className="text-xs text-muted-foreground">{location.condition}</Text>
-                    </View>
-                    <View className="flex-row gap-2 items-center">
-                      {location.id === activeLocation?.id && (
-                        <>
-                          <Text variant="callout">{t('common.default')}</Text>
-                          <View className="mx-1 h-1 w-1 rounded-full bg-muted-foreground" />
-                        </>
-                      )}
-                      <Text className="text-2xl">{location.temperature}°</Text>
-                    </View>
-                  </Pressable>
-                ))}
+                    <Text className="text-2xl">{location.temperature}°</Text>
+                  </View>
+                </Pressable>
+              ))}
+            </View>
+          ) : (
+            <View className="flex-1 items-center justify-center p-8 gap-4 mt-8">
+              <View className="h-16 w-16 rounded-full items-center justify-center bg-neutral-300 dark:bg-neutral-600">
+                <Icon
+                  materialIcon={{
+                    name: 'location-searching',
+                    type: 'MaterialIcons',
+                  }}
+                  ios={{ name: 'location' }}
+                  size={32}
+                  color={colors.grey}
+                />
               </View>
-            ) : (
-              <View className="flex-1 items-center justify-center p-8 gap-4 mt-8">
-                <View className="h-16 w-16 rounded-full items-center justify-center bg-neutral-300 dark:bg-neutral-600">
-                  <Icon
-                    materialIcon={{
-                      name: 'location-searching',
-                      type: 'MaterialIcons',
-                    }}
-                    ios={{ name: 'location' }}
-                    size={32}
-                    color={colors.grey}
-                  />
-                </View>
-                <View className="items-center gap-1">
-                  <Text className="text-base font-semibold">{t('weather.noSavedLocations')}</Text>
-                  <Text className="text-xs text-muted-foreground text-center">
-                    {t('weather.addLocation')}
-                  </Text>
-                </View>
-                <Button variant="secondary" onPress={handleSearchLocation}>
-                  <Text>{t('location.searchButton')}</Text>
-                </Button>
+              <View className="items-center gap-1">
+                <Text className="text-base font-semibold">{t('weather.noSavedLocations')}</Text>
+                <Text className="text-xs text-muted-foreground text-center">
+                  {t('weather.addLocation')}
+                </Text>
               </View>
-            )}
-          </ScrollView>
-          <View className="px-4 pb-4 flex-row self-end items-center gap-2 justify-between">
-            {onSkip && (
-              <Button
-                onPress={() => {
-                  onClose();
-                  onSkip();
-                }}
-                variant="secondary"
-              >
-                <Text>{skipText}</Text>
+              <Button variant="secondary" onPress={handleSearchLocation}>
+                <Text>{t('location.searchButton')}</Text>
               </Button>
-            )}
+            </View>
+          )}
+        </ScrollView>
+        <View className="px-4 pb-4 flex-row self-end items-center gap-2 justify-between">
+          {onSkip && (
             <Button
               onPress={() => {
                 onClose();
-                assertNonNull(selectedLocation);
-                onSelect(selectedLocation);
+                onSkip();
               }}
-              disabled={!selectedLocation}
-              variant="tonal"
+              variant="secondary"
             >
-              <Text>{displaySelectText}</Text>
+              <Text>{skipText}</Text>
             </Button>
-          </View>
-        </SafeAreaView>
-      </Modal>
-    </>
+          )}
+          <Button
+            onPress={() => {
+              onClose();
+              assertNonNull(selectedLocation);
+              onSelect(selectedLocation);
+            }}
+            disabled={!selectedLocation}
+            variant="tonal"
+          >
+            <Text>{displaySelectText}</Text>
+          </Button>
+        </View>
+      </SafeAreaView>
+    </Modal>
   );
 }

--- a/packages/analytics/src/core/catalog-cache.ts
+++ b/packages/analytics/src/core/catalog-cache.ts
@@ -7,13 +7,12 @@
  * which resolves to the Iceberg table via `USE packrat.default`.
  */
 
-import type { DuckDBConnection, DuckDBInstance } from '@duckdb/node-api';
+import type { DuckDBConnection } from '@duckdb/node-api';
 import consola from 'consola';
 import { createCatalogConnection } from './connection';
 import { LocalCacheManager } from './local-cache';
 
 export class CatalogCacheManager extends LocalCacheManager {
-  private catalogInstance: DuckDBInstance | null = null;
   private catalogConn: DuckDBConnection | null = null;
 
   constructor() {

--- a/packages/analytics/src/core/spec-parser.ts
+++ b/packages/analytics/src/core/spec-parser.ts
@@ -111,13 +111,13 @@ export function parseTempRatingF(text: string): number | null {
   // Range: take lower bound ("20/30F" → 20F)
   const range = TEMP_RANGE.exec(text);
   if (range?.[1] !== undefined && range[2] !== undefined && range[3] !== undefined) {
-    const lower = Math.min(Number.parseInt(range[1]), Number.parseInt(range[2]));
+    const lower = Math.min(Number.parseInt(range[1], 10), Number.parseInt(range[2], 10));
     return toFahrenheit(lower, range[3]);
   }
 
   const single = TEMP_SINGLE.exec(text);
   if (single?.[1] !== undefined && single[2] !== undefined) {
-    return toFahrenheit(Number.parseInt(single[1]), single[2]);
+    return toFahrenheit(Number.parseInt(single[1], 10), single[2]);
   }
   return null;
 }
@@ -125,7 +125,7 @@ export function parseTempRatingF(text: string): number | null {
 export function parseFillPower(text: string): number | null {
   const match = FILL_POWER.exec(text);
   if (match?.[1] !== undefined) {
-    const val = Number.parseInt(match[1]);
+    const val = Number.parseInt(match[1], 10);
     return val >= 300 && val <= 1200 ? val : null;
   }
   return null;
@@ -134,7 +134,7 @@ export function parseFillPower(text: string): number | null {
 export function parseWaterproofRating(text: string): number | null {
   const match = WATERPROOF.exec(text);
   if (match?.[1] !== undefined) {
-    const raw = Number.parseInt(match[1].replace(/,/g, ''));
+    const raw = Number.parseInt(match[1].replace(/,/g, ''), 10);
     // If "k" or "K" prefix was captured in the regex (e.g., "20k mm"), multiply by 1000
     const hasKMultiplier = /(\d[\d,]*)\s*k\s*mm\b/i.exec(text);
     return hasKMultiplier ? raw * 1000 : raw;

--- a/packages/api/src/middleware/__tests__/adminMiddleware.test.ts
+++ b/packages/api/src/middleware/__tests__/adminMiddleware.test.ts
@@ -34,7 +34,7 @@ describe('adminMiddleware', () => {
 
   it('should return 401 when user is not authenticated', async () => {
     const c = makeMockContext(undefined);
-    const result = await adminMiddleware(c, mockNext);
+    const _result = await adminMiddleware(c, mockNext);
 
     expect(mockNext).not.toHaveBeenCalled();
     expect(c.json).toHaveBeenCalledWith({ error: 'Unauthorized' }, 401);
@@ -42,7 +42,7 @@ describe('adminMiddleware', () => {
 
   it('should return 403 when user is not an admin', async () => {
     const c = makeMockContext({ userId: 1, role: 'USER' });
-    const result = await adminMiddleware(c, mockNext);
+    const _result = await adminMiddleware(c, mockNext);
 
     expect(mockNext).not.toHaveBeenCalled();
     expect(c.json).toHaveBeenCalledWith({ error: 'Forbidden' }, 403);
@@ -50,7 +50,7 @@ describe('adminMiddleware', () => {
 
   it('should return 401 when user is null', async () => {
     const c = makeMockContext(null);
-    const result = await adminMiddleware(c, mockNext);
+    const _result = await adminMiddleware(c, mockNext);
 
     expect(mockNext).not.toHaveBeenCalled();
     expect(c.json).toHaveBeenCalledWith({ error: 'Unauthorized' }, 401);
@@ -58,7 +58,7 @@ describe('adminMiddleware', () => {
 
   it('should return 403 when user has different role', async () => {
     const c = makeMockContext({ userId: 2, role: 'MODERATOR' });
-    const result = await adminMiddleware(c, mockNext);
+    const _result = await adminMiddleware(c, mockNext);
 
     expect(mockNext).not.toHaveBeenCalled();
     expect(c.json).toHaveBeenCalledWith({ error: 'Forbidden' }, 403);

--- a/packages/api/src/middleware/__tests__/apiKeyAuth.test.ts
+++ b/packages/api/src/middleware/__tests__/apiKeyAuth.test.ts
@@ -45,7 +45,7 @@ describe('apiKeyAuthMiddleware', () => {
     mockIsValidApiKey.mockReturnValue(false);
 
     const c = makeMockContext();
-    const result = await apiKeyAuthMiddleware(c, mockNext);
+    const _result = await apiKeyAuthMiddleware(c, mockNext);
 
     expect(mockNext).not.toHaveBeenCalled();
     expect(c.json).toHaveBeenCalledWith({ error: 'Unauthorized' }, 401);
@@ -57,7 +57,7 @@ describe('apiKeyAuthMiddleware', () => {
     mockIsValidApiKey.mockReturnValue(false);
 
     const c = makeMockContext();
-    const result = await apiKeyAuthMiddleware(c, mockNext);
+    const _result = await apiKeyAuthMiddleware(c, mockNext);
 
     expect(mockNext).not.toHaveBeenCalled();
     expect(c.json).toHaveBeenCalledWith({ error: 'Unauthorized' }, 401);

--- a/packages/api/src/middleware/__tests__/auth.test.ts
+++ b/packages/api/src/middleware/__tests__/auth.test.ts
@@ -59,7 +59,7 @@ describe('authMiddleware', () => {
 
     it('should reject when token is missing in Authorization header', async () => {
       const c = makeMockContext('Bearer ');
-      const result = await authMiddleware(c, mockNext);
+      const _result = await authMiddleware(c, mockNext);
 
       expect(mockNext).not.toHaveBeenCalled();
       expect(c.json).toHaveBeenCalledWith({ error: 'No token provided' }, 401);
@@ -71,7 +71,7 @@ describe('authMiddleware', () => {
       mockVerify.mockRejectedValue(new Error('Invalid token'));
 
       const c = makeMockContext('Bearer invalid-token');
-      const result = await authMiddleware(c, mockNext);
+      const _result = await authMiddleware(c, mockNext);
 
       expect(mockNext).not.toHaveBeenCalled();
       expect(c.json).toHaveBeenCalledWith({ error: 'Invalid token' }, 401);
@@ -108,7 +108,7 @@ describe('authMiddleware', () => {
       mockIsValidApiKey.mockReturnValue(false);
 
       const c = makeMockContext();
-      const result = await authMiddleware(c, mockNext);
+      const _result = await authMiddleware(c, mockNext);
 
       expect(mockNext).not.toHaveBeenCalled();
       expect(c.json).toHaveBeenCalledWith({ error: 'Unauthorized' }, 401);

--- a/packages/api/src/services/__tests__/catalogService.test.ts
+++ b/packages/api/src/services/__tests__/catalogService.test.ts
@@ -149,7 +149,7 @@ describe('CatalogService', () => {
       // but we can verify the embedding generation was called correctly
       try {
         await service.vectorSearch('lightweight tent', { limit: 10, offset: 0 });
-      } catch (err) {
+      } catch (_err) {
         // DB query will fail since we don't have a proper mock, but that's OK
         // We're just testing the input validation and embedding call
       }
@@ -211,7 +211,7 @@ describe('CatalogService', () => {
 
       try {
         await service.batchVectorSearch(['tent', 'sleeping bag'], 5);
-      } catch (err) {
+      } catch (_err) {
         // DB query will fail since we don't have a proper mock, but that's OK
       }
 

--- a/packages/api/src/utils/__tests__/csv-utils.test.ts
+++ b/packages/api/src/utils/__tests__/csv-utils.test.ts
@@ -487,7 +487,7 @@ describe('csv-utils', () => {
 
     it('normalizes smart quotes to standard quotes', () => {
       // Test with actual smart quote characters (curly quotes)
-      const inputWithSmartQuotes = String.fromCharCode(8216) + 'hello' + String.fromCharCode(8217);
+      const inputWithSmartQuotes = `${String.fromCharCode(8216)}hello${String.fromCharCode(8217)}`;
       const result = normalizeJsonString(inputWithSmartQuotes);
       expect(result).toContain("'hello'"); // Smart quotes should become regular quotes
       expect(result).not.toContain(String.fromCharCode(8216)); // No more smart quotes

--- a/packages/api/src/utils/__tests__/env-validation.test.ts
+++ b/packages/api/src/utils/__tests__/env-validation.test.ts
@@ -126,7 +126,7 @@ describe('env-validation', () => {
         // ... other required fields
       };
 
-      const result = apiEnvSchema.safeParse(envWithDevEnvironment);
+      const _result = apiEnvSchema.safeParse(envWithDevEnvironment);
       // Will fail because missing required fields, but if we add them it should work
       expect(['development', 'production']).toContain('development');
     });
@@ -308,8 +308,8 @@ describe('env-validation', () => {
 
       vi.mocked(env).mockReturnValue({ JWT_SECRET: 'secret' } as any);
 
-      const result1 = getEnv(c1);
-      const result2 = getEnv(c2);
+      const _result1 = getEnv(c1);
+      const _result2 = getEnv(c2);
 
       expect(env).toHaveBeenCalledTimes(2); // Called twice
       // Results may be different instances


### PR DESCRIPTION
## Summary

Hotfix. `bun biome check` on development exits with **26 errors** after #2049 (max-params flip) and recent feature merges. This PR gets the error count back to **0**.

The biggest single fix is in `biome.json` itself: it had two top-level `overrides` keys. Per JSON semantics, the second replaces the first, silently dropping the `useMaxParams: off` exclusion list that #2049 added. Merging the overrides into a single array restores the intended exclusions and fixes 12 of the 26 errors automatically.

## Fixes
- **`noDuplicateObjectKeys` + 12 × `useMaxParams`** — merge duplicate `overrides` in `biome.json`; add `scripts/lint/no-raw-regex.ts` and `scripts/lint/no-raw-typeof.ts` to the exclusion list (local lint tooling, 3-param recursive walkers).
- **`useMaxParams` in `useWildlifeHistory.addIdentification`** — refactor from `(imageUri, results, location?)` to a single options object. Only one callsite, updated.
- **3 × `noArrayIndexKey`** in `PostCard`, `CreatePostScreen`, `PostDetailScreen` — drop the `-${idx}` suffix and key by image URI (URIs are already unique per-item from R2 / image picker).
- **3 × `organizeImports` + 4 × formatter** — `biome check --write` auto-fixes in `(home)/index.tsx`, `feed/[id].tsx`, `usePostComments.ts`, `FeedScreen.tsx`, `CreatePostScreen.tsx`, `routes/feed/comments.ts`.

## Not addressing in this PR
- `useTopLevelRegex`, `noForEach`, `noExplicitAny` — still at **warn** level in `biome.json`, backlog cleanup.
- Pre-existing typecheck errors in `packTemplates.ts`, `routes/wildlife/index.ts`, `schemas/feed.ts`, etc. — unrelated to biome rules and present on `development` before this branch.

## Verify
- `packages/analytics/src/core/enrichment.ts` was **not** touched by auto-fix (the known `\d`/`\w` regex-stripping bug did not trigger this run).
- No new `as` casts.

## Test plan
- [x] `bun biome check --diagnostic-level=error` → 0 errors (was 26)
- [x] `bun biome check` warnings unchanged (182)
- [ ] CI biome job green