### PR TITLE
Fix iOS MapView not updating after trip location edit

### DIFF
--- a/apps/expo/features/trips/components/TripForm.tsx
+++ b/apps/expo/features/trips/components/TripForm.tsx
@@ -58,11 +58,16 @@ export const TripForm = ({ trip }: { trip?: Trip }) => {
   const packs = usePacks();
 
   // Initialize location store with trip's location when editing
+  // Only sync when the trip ID changes to avoid infinite re-renders
   useEffect(() => {
     if (trip?.location) {
       setLocation(trip.location);
     }
-  }, [trip?.id, trip?.location, setLocation]);
+    // Cleanup: clear location when component unmounts or trip changes
+    return () => {
+      setLocation(null);
+    };
+  }, [trip?.id, setLocation]);
 
   const [showPackModal, setShowPackModal] = useState(false);
   const [showEndPicker, setShowEndPicker] = useState(false);
@@ -119,8 +124,6 @@ export const TripForm = ({ trip }: { trip?: Trip }) => {
             preset: 'done',
           });
         }
-        // Clear location store after successful submission
-        setLocation(null);
         router.back();
       } catch (_e) {
         Burnt.toast({

--- a/apps/expo/features/trips/components/TripForm.tsx
+++ b/apps/expo/features/trips/components/TripForm.tsx
@@ -57,17 +57,18 @@ export const TripForm = ({ trip }: { trip?: Trip }) => {
   const { location, setLocation } = useTripLocation();
   const packs = usePacks();
 
-  // Initialize location store with trip's location when editing
+  // Initialize location store with trip's location when entering edit mode
   // Only sync when the trip ID changes to avoid infinite re-renders
   useEffect(() => {
     // Set location from trip, or null if trip has no location
     setLocation(trip?.location ?? null);
     
-    // Cleanup: clear location when component unmounts or trip changes
+    // Cleanup: clear location only when component unmounts
     return () => {
       setLocation(null);
     };
-  }, [trip?.id, setLocation]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [trip?.id]);
 
   const [showPackModal, setShowPackModal] = useState(false);
   const [showEndPicker, setShowEndPicker] = useState(false);

--- a/apps/expo/features/trips/components/TripForm.tsx
+++ b/apps/expo/features/trips/components/TripForm.tsx
@@ -60,9 +60,9 @@ export const TripForm = ({ trip }: { trip?: Trip }) => {
   // Initialize location store with trip's location when editing
   // Only sync when the trip ID changes to avoid infinite re-renders
   useEffect(() => {
-    if (trip?.location) {
-      setLocation(trip.location);
-    }
+    // Set location from trip, or null if trip has no location
+    setLocation(trip?.location ?? null);
+    
     // Cleanup: clear location when component unmounts or trip changes
     return () => {
       setLocation(null);

--- a/apps/expo/features/trips/components/TripForm.tsx
+++ b/apps/expo/features/trips/components/TripForm.tsx
@@ -57,18 +57,18 @@ export const TripForm = ({ trip }: { trip?: Trip }) => {
   const { location, setLocation } = useTripLocation();
   const packs = usePacks();
 
-  // Initialize location store with trip's location when entering edit mode
-  // Only sync when the trip ID changes to avoid infinite re-renders
+  // Initialize location store with trip's location when component mounts or trip ID changes
+  // Note: We intentionally don't include trip?.location in dependencies to avoid
+  // overriding the user's selection when the trip object is re-created by the store
   useEffect(() => {
     // Set location from trip, or null if trip has no location
     setLocation(trip?.location ?? null);
     
-    // Cleanup: clear location only when component unmounts
+    // Cleanup: clear location when component unmounts
     return () => {
       setLocation(null);
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [trip?.id]);
+  }, [trip?.id, setLocation]);
 
   const [showPackModal, setShowPackModal] = useState(false);
   const [showEndPicker, setShowEndPicker] = useState(false);

--- a/apps/expo/features/trips/components/TripForm.tsx
+++ b/apps/expo/features/trips/components/TripForm.tsx
@@ -59,10 +59,10 @@ export const TripForm = ({ trip }: { trip?: Trip }) => {
 
   // Initialize location store with trip's location when editing
   useEffect(() => {
-    if (trip?.location && !location) {
+    if (trip?.location) {
       setLocation(trip.location);
     }
-  }, [trip?.location, location, setLocation]);
+  }, [trip?.id, trip?.location, setLocation]);
 
   const [showPackModal, setShowPackModal] = useState(false);
   const [showEndPicker, setShowEndPicker] = useState(false);

--- a/apps/expo/features/trips/components/TripForm.tsx
+++ b/apps/expo/features/trips/components/TripForm.tsx
@@ -57,6 +57,13 @@ export const TripForm = ({ trip }: { trip?: Trip }) => {
   const { location, setLocation } = useTripLocation();
   const packs = usePacks();
 
+  // Initialize location store with trip's location when editing
+  useEffect(() => {
+    if (trip?.location && !location) {
+      setLocation(trip.location);
+    }
+  }, [trip?.location, location, setLocation]);
+
   const [showPackModal, setShowPackModal] = useState(false);
   const [showEndPicker, setShowEndPicker] = useState(false);
   const [showStartPicker, setShowStartPicker] = useState(false);
@@ -112,6 +119,8 @@ export const TripForm = ({ trip }: { trip?: Trip }) => {
             preset: 'done',
           });
         }
+        // Clear location store after successful submission
+        setLocation(null);
         router.back();
       } catch (_e) {
         Burnt.toast({

--- a/apps/expo/features/trips/components/TripForm.tsx
+++ b/apps/expo/features/trips/components/TripForm.tsx
@@ -57,13 +57,16 @@ export const TripForm = ({ trip }: { trip?: Trip }) => {
   const { location, setLocation } = useTripLocation();
   const packs = usePacks();
 
-  // Initialize location store with trip's location when component mounts or trip ID changes
-  // Note: We intentionally don't include trip?.location in dependencies to avoid
-  // overriding the user's selection when the trip object is re-created by the store
+  // Initialize location store with trip's location when component mounts or
+  // trip ID changes. We intentionally depend only on trip?.id (not trip?.location)
+  // so that after the user picks a new location via location-search, a
+  // re-render of the same trip object does not overwrite their selection in
+  // the store.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: intentional — see comment above; reseeding on trip?.location would stomp user-picked values
   useEffect(() => {
     // Set location from trip, or null if trip has no location
     setLocation(trip?.location ?? null);
-    
+
     // Cleanup: clear location when component unmounts
     return () => {
       setLocation(null);

--- a/apps/expo/features/trips/screens/TripDetailScreen.tsx
+++ b/apps/expo/features/trips/screens/TripDetailScreen.tsx
@@ -8,7 +8,7 @@ import { useLocations } from 'expo-app/features/weather/hooks';
 import { useColorScheme } from 'expo-app/lib/hooks/useColorScheme';
 import { useTranslation } from 'expo-app/lib/hooks/useTranslation';
 import { useLocalSearchParams, useRouter } from 'expo-router';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { Modal, ScrollView, Share, View } from 'react-native';
 import MapView, { Marker, PROVIDER_GOOGLE } from 'react-native-maps';
 import { SafeAreaView } from 'react-native-safe-area-context';
@@ -29,6 +29,16 @@ export function TripDetailScreen() {
 
   const trip = useTripDetailsFromStore(id as string) as Trip;
   const packs = useDetailedPacks();
+
+  // Create a stable key for MapView based on location coordinates
+  // This forces remount when location changes, fixing iOS initialRegion issue
+  const mapKey = useMemo(
+    () =>
+      trip?.location
+        ? `map-${trip.location.latitude}-${trip.location.longitude}`
+        : 'map-no-location',
+    [trip?.location],
+  );
 
   if (!trip) {
     return (
@@ -159,7 +169,7 @@ export function TripDetailScreen() {
 
                 <View className="h-36">
                   <MapView
-                    key={`${trip.location.latitude}-${trip.location.longitude}`}
+                    key={mapKey}
                     provider={PROVIDER_GOOGLE}
                     style={{ flex: 1 }}
                     initialRegion={{

--- a/apps/expo/features/trips/screens/TripDetailScreen.tsx
+++ b/apps/expo/features/trips/screens/TripDetailScreen.tsx
@@ -159,6 +159,7 @@ export function TripDetailScreen() {
 
                 <View className="h-36">
                   <MapView
+                    key={`${trip.location.latitude}-${trip.location.longitude}`}
                     provider={PROVIDER_GOOGLE}
                     style={{ flex: 1 }}
                     initialRegion={{

--- a/apps/expo/features/trips/screens/TripDetailScreen.tsx
+++ b/apps/expo/features/trips/screens/TripDetailScreen.tsx
@@ -37,7 +37,7 @@ export function TripDetailScreen() {
       trip?.location
         ? `map-${trip.location.latitude}-${trip.location.longitude}`
         : 'map-no-location',
-    [trip?.location],
+    [trip?.location?.latitude, trip?.location?.longitude],
   );
 
   if (!trip) {

--- a/apps/expo/features/trips/store/tripLocationStore.ts
+++ b/apps/expo/features/trips/store/tripLocationStore.ts
@@ -1,5 +1,6 @@
 import { observable } from '@legendapp/state';
 import { use$ } from '@legendapp/state/react';
+import { useCallback } from 'react';
 
 /**
  * Type for the trip location.
@@ -22,9 +23,9 @@ export const tripLocationStore = observable<TripLocation | null>(null);
 export function useTripLocation() {
   const location = use$(() => tripLocationStore.get());
 
-  const setLocation = (loc: TripLocation | null) => {
+  const setLocation = useCallback((loc: TripLocation | null) => {
     tripLocationStore.set(loc);
-  };
+  }, []);
 
   return { location, setLocation };
 }

--- a/apps/expo/features/trips/store/tripLocationStore.ts
+++ b/apps/expo/features/trips/store/tripLocationStore.ts
@@ -6,7 +6,7 @@ import { useCallback } from 'react';
  * Type for the trip location.
  */
 export type TripLocation = {
-  name: string;
+  name?: string;
   latitude: number;
   longitude: number;
 };


### PR DESCRIPTION
Fresh PR to replace #1854, which was accidentally auto-closed by GitHub after I pushed an empty-diff state to its branch. The branch content has been restored to the pre-incident SHA and this PR brings it back under a new number for review.

Superseded PR: #1854 — same branch, same commits, just a new PR number.

Historical context:
- Original PR #1854 was a work-in-progress draft that had been open for a while and was significantly behind development
- During a merge-conflict cleanup sweep I (Claude Code) instructed a subagent to 'reset to dev tip as last resort' for branches >100 commits behind — that triggered GitHub's empty-diff auto-close
- The branch itself was restored from reflog, but GitHub's API refuses to reopen a PR whose head was ever identical to base
- Rule has been added to never reset a branch to base-tip as a fallback again