### PR TITLE
chore(expo): replace custom date utils with date-fns

### DIFF
--- a/apps/expo/lib/utils/dateUtils.ts
+++ b/apps/expo/lib/utils/dateUtils.ts
@@ -1,3 +1,5 @@
+import { isValid, parse, parseISO } from 'date-fns';
+
 /**
  * Parse a date string, handling YYYY-MM-DD strings as local dates
  * instead of UTC (which is the default `new Date('YYYY-MM-DD')` behavior).
@@ -6,20 +8,15 @@
  */
 export function parseLocalDate(dateString?: string): Date | null {
   if (!dateString) return null;
-  const dateOnlyMatch = /^(\d{4})-(\d{2})-(\d{2})$/.exec(dateString);
-  if (dateOnlyMatch) {
-    const year = Number(dateOnlyMatch[1]);
-    const month = Number(dateOnlyMatch[2]);
-    const day = Number(dateOnlyMatch[3]);
-    const date = new Date(year, month - 1, day);
-    if (Number.isNaN(date.getTime())) return null;
-    if (date.getFullYear() !== year || date.getMonth() !== month - 1 || date.getDate() !== day) {
-      return null;
-    }
-    return date;
+
+  const dateOnlyPattern = /^\d{4}-\d{2}-\d{2}$/;
+  if (dateOnlyPattern.test(dateString)) {
+    const date = parse(dateString, 'yyyy-MM-dd', new Date());
+    return isValid(date) ? date : null;
   }
-  const date = new Date(dateString);
-  return Number.isNaN(date.getTime()) ? null : date;
+
+  const date = parseISO(dateString);
+  return isValid(date) ? date : null;
 }
 
 /**

--- a/apps/expo/lib/utils/getRelativeTime.ts
+++ b/apps/expo/lib/utils/getRelativeTime.ts
@@ -1,14 +1,18 @@
-export function getRelativeTime(dateString: string): string {
-  const diff = (Date.now() - new Date(dateString).getTime()) / 1000;
-  const units = [
-    { label: 'month', seconds: 2592000 },
-    { label: 'week', seconds: 604800 },
-    { label: 'day', seconds: 86400 },
-    { label: 'hour', seconds: 3600 },
-    { label: 'minute', seconds: 60 },
-  ];
+import { differenceInSeconds, parseISO } from 'date-fns';
 
-  for (const { label, seconds } of units) {
+const UNITS: Array<{ label: string; seconds: number }> = [
+  { label: 'month', seconds: 2592000 },
+  { label: 'week', seconds: 604800 },
+  { label: 'day', seconds: 86400 },
+  { label: 'hour', seconds: 3600 },
+  { label: 'minute', seconds: 60 },
+];
+
+export function getRelativeTime(dateString: string): string {
+  const date = parseISO(dateString);
+  const diff = differenceInSeconds(new Date(), date);
+
+  for (const { label, seconds } of UNITS) {
     const val = Math.floor(diff / seconds);
     if (val >= 1) return `${val} ${label}${val > 1 ? 's' : ''} ago`;
   }

--- a/apps/expo/package.json
+++ b/apps/expo/package.json
@@ -126,7 +126,8 @@
     "react-native-web": "^0.21.0",
     "tailwind-merge": "^2.5.5",
     "use-debounce": "^10.0.5",
-    "zod": "^3.24.2"
+    "zod": "^3.24.2",
+    "date-fns": "^4.1.0"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",


### PR DESCRIPTION
## Summary

- Replace `getRelativeTime.ts` with `date-fns` (`parseISO` + `differenceInSeconds`) while preserving the exact same output format and export signature — all callsites unchanged
- Replace `dateUtils.ts` with `date-fns` (`parseISO`, `parse`, `isValid`) while preserving the same `parseLocalDate` / `formatLocalDate` exports
- Add `"date-fns": "^4.1.0"` to `apps/expo/package.json` (version already installed at repo root via `apps/landing` and `apps/guides`)

## Test plan

- [ ] Existing unit tests in `lib/utils/__tests__/getRelativeTime.test.ts` continue to pass (output format unchanged: "Just now", "5 minutes ago", etc.)
- [ ] `bun biome check apps/expo/lib/utils/` passes with zero errors
- [ ] TypeScript `check-types` reports no new errors related to date utils
- [ ] Run app and verify pack "last updated" timestamps display correctly in `recent-packs` and `current-pack/[id]` screens
- [ ] Verify trip date fields display correctly in `UpcomingTripsTile` and `TripCard`