### PR TITLE
fix(expo): restore leaf import in itemCalculations to break circular dep

### DIFF
--- a/apps/expo/lib/utils/itemCalculations.ts
+++ b/apps/expo/lib/utils/itemCalculations.ts
@@ -1,6 +1,8 @@
 import { makeEnumGuard } from '@packrat/guards';
 import type { CatalogItem } from 'expo-app/features/catalog/types';
-import type { PackTemplateItem } from 'expo-app/features/pack-templates';
+// Leaf import (not the barrel) — barrel re-exports hooks, one of which
+// imports back into this file, which would be a circular dependency.
+import type { PackTemplateItem } from 'expo-app/features/pack-templates/types';
 import type { PackItem, WeightUnit } from 'expo-app/features/packs';
 
 type Item = CatalogItem | PackItem | PackTemplateItem;


### PR DESCRIPTION
Hotfix for a circular dependency reintroduced when #2066 merged.

## The cycle

```
pack-templates/hooks/index.ts
  → useGenerateTemplateFromOnlineContent.ts
  → itemCalculations.ts
  → pack-templates/index.ts (barrel re-exports ./hooks)
  → pack-templates/hooks/index.ts
```

## The fix

`itemCalculations.ts` imports `PackTemplateItem` directly from the leaf `./types` module instead of via the barrel. This was the original shape in #2066 before I reverted it as part of an unrelated cleanup. Restored with an explanatory comment so no one re-reverts it.

## Verified

- `bun run scripts/lint/no-circular-deps.ts` — 0 cycles
- `bun run check-types` — 0 errors