### PR TITLE
chore(ci): add expo-doctor check to biome workflow

### DIFF
--- a/.github/workflows/biome.yml
+++ b/.github/workflows/biome.yml
@@ -27,3 +27,6 @@ jobs:
         run: bun scripts/lint/no-duplicate-deps.ts
       - name: Check package.json ordering
         run: bun scripts/format/sort-package-json.ts --check
+      - name: Run Expo Doctor
+        run: bunx expo-doctor
+        working-directory: apps/expo


### PR DESCRIPTION
## Summary

Adds `expo-doctor` as a step in the existing Biome/checks CI workflow so Expo SDK compatibility issues are caught on every PR.

```yaml
- name: Run Expo Doctor
  run: bunx expo-doctor
  working-directory: apps/expo
```

## Why

Expo doctor validates that all installed packages are compatible with the current Expo SDK version. Without this check, mismatched packages can silently cause runtime issues on device.