### PR TITLE
Fix/largetitleheader content overlap ios

### DIFF
--- a/apps/expo/components/TabScreen.tsx
+++ b/apps/expo/components/TabScreen.tsx
@@ -1,4 +1,3 @@
-import { useColorScheme } from '@packrat/ui/nativewindui';
 import { StatusBar } from 'expo-status-bar';
 import type React from 'react';
 import { Platform, StyleSheet, type ViewStyle } from 'react-native';
@@ -11,7 +10,6 @@ import {
 interface TabScreenProps extends SafeAreaViewProps {}
 
 export const TabScreen: React.FC<TabScreenProps> = ({ children, style, ...rest }) => {
-  const { colorScheme } = useColorScheme();
   const insets = useSafeAreaInsets();
 
   const TAB_BAR_INSET = Platform.OS === 'android' ? 80 : 0;
@@ -25,9 +23,7 @@ export const TabScreen: React.FC<TabScreenProps> = ({ children, style, ...rest }
 
   return (
     <SafeAreaView style={containerStyle} {...rest} edges={['bottom', 'left', 'right']}>
-      <StatusBar
-        style={Platform.OS === 'ios' ? 'light' : colorScheme === 'dark' ? 'light' : 'dark'}
-      />
+      <StatusBar />
       {children}
     </SafeAreaView>
   );

--- a/apps/expo/components/TabScreen.tsx
+++ b/apps/expo/components/TabScreen.tsx
@@ -1,15 +1,22 @@
 import { StatusBar } from 'expo-status-bar';
 import type React from 'react';
-import { Platform, StyleSheet, type ViewStyle } from 'react-native';
+import { Platform, SafeAreaView as RNSafeAreaView, StyleSheet, type ViewStyle } from 'react-native';
 import {
   SafeAreaView,
   type SafeAreaViewProps,
   useSafeAreaInsets,
 } from 'react-native-safe-area-context';
 
-interface TabScreenProps extends SafeAreaViewProps {}
+interface TabScreenProps extends SafeAreaViewProps {
+  useLegacySafeAreaView?: boolean;
+}
 
-export const TabScreen: React.FC<TabScreenProps> = ({ children, style, ...rest }) => {
+export const TabScreen: React.FC<TabScreenProps> = ({
+  children,
+  style,
+  useLegacySafeAreaView,
+  ...rest
+}) => {
   const insets = useSafeAreaInsets();
 
   const TAB_BAR_INSET = Platform.OS === 'android' ? 80 : 0;
@@ -20,6 +27,14 @@ export const TabScreen: React.FC<TabScreenProps> = ({ children, style, ...rest }
     paddingBottom: TAB_BAR_INSET,
     ...(StyleSheet.flatten(style) as ViewStyle),
   };
+
+  if (useLegacySafeAreaView && Platform.OS === 'ios')
+    return (
+      <RNSafeAreaView style={style} {...rest}>
+        <StatusBar />
+        {children}
+      </RNSafeAreaView>
+    );
 
   return (
     <SafeAreaView style={containerStyle} {...rest} edges={['bottom', 'left', 'right']}>

--- a/apps/expo/features/catalog/screens/CatalogItemsScreen.tsx
+++ b/apps/expo/features/catalog/screens/CatalogItemsScreen.tsx
@@ -1,7 +1,7 @@
 import { LargeTitleHeader, Text } from '@packrat/ui/nativewindui';
-import { Icon } from 'expo-app/components/Icon';
 import { searchValueAtom } from 'expo-app/atoms/itemListAtoms';
 import { CategoriesFilter } from 'expo-app/components/CategoriesFilter';
+import { Icon } from 'expo-app/components/Icon';
 import TabScreen from 'expo-app/components/TabScreen';
 import { withAuthWall } from 'expo-app/features/auth/hocs';
 import { useColorScheme } from 'expo-app/lib/hooks/useColorScheme';
@@ -128,7 +128,7 @@ function CatalogItemsScreen() {
   ]);
 
   return (
-    <TabScreen>
+    <TabScreen useLegacySafeAreaView>
       <LargeTitleHeader
         title={t('catalog.title')}
         backVisible={false}

--- a/apps/expo/features/guides/screens/GuidesListScreen.tsx
+++ b/apps/expo/features/guides/screens/GuidesListScreen.tsx
@@ -4,8 +4,7 @@ import { useColorScheme } from 'expo-app/lib/hooks/useColorScheme';
 import { useTranslation } from 'expo-app/lib/hooks/useTranslation';
 import { useRouter } from 'expo-router';
 import { useCallback, useState } from 'react';
-import { ActivityIndicator, FlatList, RefreshControl, View } from 'react-native';
-import { SafeAreaView } from 'react-native-safe-area-context';
+import { ActivityIndicator, FlatList, RefreshControl, SafeAreaView, View } from 'react-native';
 import { GuideCard } from '../components/GuideCard';
 import { useGuideCategories, useGuides, useSearchGuides } from '../hooks';
 import type { Guide } from '../types';
@@ -113,7 +112,7 @@ export const GuidesListScreen = () => {
   };
 
   return (
-    <SafeAreaView className="flex-1">
+    <SafeAreaView>
       <LargeTitleHeader
         title={t('guides.guides')}
         searchBar={{

--- a/apps/expo/features/packs/screens/PackListScreen.tsx
+++ b/apps/expo/features/packs/screens/PackListScreen.tsx
@@ -180,7 +180,7 @@ export function PackListScreen() {
   };
 
   return (
-    <TabScreen>
+    <TabScreen useLegacySafeAreaView>
       <LargeTitleHeader
         title={t('navigation.packs')}
         backVisible={false}


### PR DESCRIPTION
This PR addresses the issue of LargeTitleHeader overlapping content in FlatList/ScrollView screens on iOS.

Apparently the issues seems to be that either SafeAreaView from react-native-safe-area-context doesn't take large title insets into account, or that react-native-screens is not using react-native-safe-area-context correctly. Eithey way, currently a workaround involves using SafeAreaView from react-native.

### Notes
- The workaround breaks header animation onscroll which is being tracked here: react-navigation#12614
- `react-native`'s SafeAreaView used for the fix is getting deprecated in future versions so this leaves us with hoping that react-native-screens/react-native-safe-area-context actually resolve the insets issue or switch to using `contentInsetAdjustmentBehavior="automatic"` prop on FlatList/ScrollView workaround which might not be the most ideal from my observation.