### PR TITLE
fix(api-tests): seed users via extracted userService, kill hardcoded user_id=1

### DIFF
--- a/docs/plans/2026-04-14-fix-api-tests-user-seed-via-service-plan.md
+++ b/docs/plans/2026-04-14-fix-api-tests-user-seed-via-service-plan.md
@@ -1,0 +1,73 @@
+---
+title: Fix api-tests by seeding users through a service func, not raw inserts
+type: fix
+status: active
+date: 2026-04-14
+---
+
+# Fix api-tests by seeding users through a service func
+
+## Overview
+
+After #2170 merged, `api-tests` is still red on `development`. Every test that uses `seedTestUser()` and then references `user_id` hits `FK constraint "*_user_id_users_id_fk"` — the user isn't reliably present at FK-check time. Root cause isn't the global `beforeEach` TRUNCATE; it's a cluster of assumptions that only held by accident:
+
+1. Fixtures (`createTestPackTemplate`, `createTestPack`, `TEST_USER`) hardcode `userId: 1`, assuming `TRUNCATE ... RESTART IDENTITY` + auto-generated serial means "the first seeded user is always id 1."
+2. Under the new `@neondatabase/serverless` + wsproxy path (post-#2170), connection/session semantics differ enough that this assumption is no longer load-bearing reliably.
+3. `seedTestUser` does a raw `db.insert(users).values({...}).returning()` — no password hashing, no validation, no service-level side effects (OTP setup, welcome flow). It's out of sync with what the real register path produces.
+
+There is no `userService.createUser` — the registration logic lives inline in `packages/api/src/routes/auth/index.ts:231`. The fix is to extract it and have tests seed through it.
+
+## Problem statement
+
+- **Immediate**: api-tests red; blocks every subsequent PR that touches api.
+- **Structural**: test fixtures lie about user IDs; any code path that relies on the returned id rather than `1` starts failing the moment sequence assumptions shift. This already tripped on the wsproxy cutover and will trip again on any future refactor that touches connection lifecycle.
+- **Duplication**: `seedTestUser` ≠ what `/auth/register` produces. Tests are validating behaviors against a user shape that doesn't match production's register output.
+
+## Proposed solution
+
+Three steps, roughly independently shippable but best as one PR:
+
+1. **Extract `userService.create`** from `packages/api/src/routes/auth/index.ts:231` (the `registerRoute` handler). Move the password hashing + DB insert + initial state setup into `packages/api/src/services/userService.ts`. Route handler calls the service; behavior unchanged.
+2. **Rewrite `seedTestUser`** in `packages/api/test/utils/user-helpers.ts` to call `userService.create`. Return the real DB user (real id, real hash, real state).
+3. **Remove hardcoded `userId: 1`** from fixtures. `TEST_USER` becomes a convenience const for defaults (email, name) — not the id. Tests read the id off the returned user.
+
+## Acceptance criteria
+
+- [ ] `packages/api/src/services/userService.ts` exports `createUser` with the same behavior as the current inline register handler (hash password, insert, return user).
+- [ ] `registerRoute` in `auth/index.ts` is reduced to "validate input → call service → shape response."
+- [ ] `seedTestUser` calls `userService.create`; no `db.insert(users)` in test helpers.
+- [ ] Grep for `TEST_USER.id`, `userId: 1`, and `user_id=1` in `packages/api/test/` returns zero results (or only intentional negative-test cases).
+- [ ] `api-tests` green on CI for this branch.
+- [ ] No new failing tests; non-api CI stays green.
+
+## Out of scope
+
+- Switching cleanup to `reset(testDb, schema)` via `drizzle-seed` — good follow-up, not required for this fix.
+- Extracting services for the other auth endpoints (login, OTP, password reset). Separate refactor.
+- Changing the TRUNCATE → DELETE cleanup strategy or the tablesToClean list.
+- Admin / pre-verified / OAuth user states — if tests need them, they call `userService.create` then a second helper or direct `db.update` for the state tweak.
+
+## Implementation steps
+
+1. **Branch** (done): `fix/api-tests-user-seed-via-service` off `origin/development`.
+2. **Extract service.** Read `packages/api/src/routes/auth/index.ts:231-320` (registerRoute handler). Identify the pure "create user" portion (hash + insert + returning). Move to `packages/api/src/services/userService.ts` as `createUser({ email, password, firstName, lastName, role?, emailVerified? })`. Re-export from `services/index.ts`. Update `registerRoute` to call it.
+3. **Verify extraction** with existing auth tests (they should still pass — register behavior unchanged).
+4. **Swap `seedTestUser`** in `packages/api/test/utils/user-helpers.ts` to call `userService.createUser`. Preserve its `overrides` signature.
+5. **Kill hardcoded IDs.** In fixtures (`createTestPackTemplate`, `createTestPack`, etc.), remove the `userId: 1` default — force callers to pass a real id. In tests, capture the seeded user's id and pass it through.
+6. **Run api-tests locally** (once env token is available) or push and watch CI.
+7. **Open PR** against `development` with this plan linked.
+
+## Risks
+
+- Extraction touches the hottest route in the repo. Mitigation: keep the extraction mechanical — move code, don't refactor behavior in the same commit.
+- Some tests may rely on `TEST_USER.id = 1` for things other than FK (e.g., JWT signing for synthetic tokens). Grep will find them; update to use the seeded user's id.
+- Password hashing per-test adds latency. bcrypt/argon cost at test setting is <150ms; across a test suite with `beforeEach`, plausible 10-30s overhead. Acceptable. If not, lower the test-time cost factor via a config knob.
+
+## Sources & references
+
+- `packages/api/src/routes/auth/index.ts:231` — current registerRoute handler (extraction source)
+- `packages/api/test/utils/user-helpers.ts` — current `seedTestUser`
+- `packages/api/test/utils/test-helpers.ts:17` — `TEST_USER` with hardcoded `id: 1`
+- `packages/api/test/fixtures/pack-template-fixtures.ts:17` — `userId ?? 1` default
+- PR #2170 (merged) — introduced the wsproxy path that exposed the fixture fragility
+- `docs/plans/2026-04-14-chore-narrow-pr-2170-spike-scope-plan.md` — preceding plan for the spike narrowing

--- a/packages/api/src/routes/auth/index.ts
+++ b/packages/api/src/routes/auth/index.ts
@@ -30,6 +30,7 @@ import {
   VerifyEmailRequestSchema,
   VerifyEmailResponseSchema,
 } from '@packrat/api/schemas/auth';
+import { UserService } from '@packrat/api/services/userService';
 import type { Env } from '@packrat/api/types/env';
 import type { Variables } from '@packrat/api/types/variables';
 import {
@@ -231,6 +232,7 @@ const registerRoute = createRoute({
 authRoutes.openapi(registerRoute, async (c) => {
   const { email, password, firstName, lastName } = await c.req.json();
   const db = createDb(c);
+  const userService = new UserService(c);
 
   // Validate input
   if (!email || !password) {
@@ -246,35 +248,11 @@ authRoutes.openapi(registerRoute, async (c) => {
     return c.json({ error: passwordValidation.message || 'Invalid password' }, 400);
   }
 
-  // Check if user already exists
-  const existingUser = await db
-    .select()
-    .from(users)
-    .where(eq(users.email, email.toLowerCase()))
-    .limit(1);
-
-  if (existingUser.length > 0) {
+  if (await userService.findByEmail(email)) {
     return c.json({ error: 'Email already in use' }, 409);
   }
 
-  // Hash password
-  const passwordHash = await hashPassword(password);
-
-  // Create user
-  const [newUser] = await db
-    .insert(users)
-    .values({
-      email: email.toLowerCase(),
-      passwordHash,
-      firstName,
-      lastName,
-      emailVerified: false,
-    })
-    .returning();
-
-  if (!newUser) {
-    return c.json({ error: 'Failed to create user' }, 500);
-  }
+  const newUser = await userService.create({ email, password, firstName, lastName });
 
   const code = generateVerificationCode(5);
 

--- a/packages/api/src/services/index.ts
+++ b/packages/api/src/services/index.ts
@@ -3,5 +3,6 @@ export * from './catalogService';
 export * from './imageDetectionService';
 export * from './packItemService';
 export * from './packService';
+export * from './userService';
 export * from './weatherService';
 export * from './wildlifeIdentificationService';

--- a/packages/api/src/services/userService.ts
+++ b/packages/api/src/services/userService.ts
@@ -1,0 +1,52 @@
+import { createDb } from '@packrat/api/db';
+import { type User, users } from '@packrat/api/db/schema';
+import { hashPassword } from '@packrat/api/utils/auth';
+import { eq } from 'drizzle-orm';
+import type { Context } from 'hono';
+
+export type CreateUserInput = {
+  email: string;
+  password?: string;
+  firstName?: string | null;
+  lastName?: string | null;
+  role?: 'USER' | 'ADMIN';
+  emailVerified?: boolean;
+};
+
+export class UserService {
+  private db;
+
+  constructor(c: Context) {
+    this.db = createDb(c);
+  }
+
+  async findByEmail(email: string): Promise<User | null> {
+    const [user] = await this.db
+      .select()
+      .from(users)
+      .where(eq(users.email, email.toLowerCase()))
+      .limit(1);
+    return user ?? null;
+  }
+
+  async create(input: CreateUserInput): Promise<User> {
+    const passwordHash = input.password ? await hashPassword(input.password) : null;
+
+    const [user] = await this.db
+      .insert(users)
+      .values({
+        email: input.email.toLowerCase(),
+        passwordHash,
+        firstName: input.firstName ?? null,
+        lastName: input.lastName ?? null,
+        role: input.role ?? 'USER',
+        emailVerified: input.emailVerified ?? false,
+      })
+      .returning();
+
+    if (!user) {
+      throw new Error('Failed to create user');
+    }
+    return user;
+  }
+}

--- a/packages/api/test/auth.test.ts
+++ b/packages/api/test/auth.test.ts
@@ -6,7 +6,6 @@ import {
   expectBadRequest,
   expectUnauthorized,
   httpMethods,
-  type TEST_USER,
 } from './utils/test-helpers';
 import { createTestUser } from './utils/user-helpers';
 
@@ -259,7 +258,9 @@ describe('Auth Routes', () => {
 
     it('returns user data when authenticated', async () => {
       const testUser = await createTestUser();
-      const res = await apiWithAuthAs('/auth/me', { user: testUser as typeof TEST_USER });
+      const res = await apiWithAuthAs('/auth/me', {
+        user: { id: testUser.id, role: (testUser.role ?? 'USER') as 'USER' | 'ADMIN' },
+      });
       expect(res.status).toBe(200);
       const data = await res.json();
       expect(data.success).toBe(true);

--- a/packages/api/test/fixtures/pack-fixtures.ts
+++ b/packages/api/test/fixtures/pack-fixtures.ts
@@ -15,7 +15,6 @@ export const createTestPack = (overrides: PackOverrides): InferInsertModel<typeo
     name: overrides.name ?? 'Test Backpacking Pack',
     description: overrides.description ?? 'A test pack for backpacking trips',
     category: overrides.category ?? 'backpacking',
-    userId: overrides.userId,
     templateId: overrides.templateId ?? null,
     isPublic: overrides.isPublic ?? false,
     image: overrides.image ?? null,
@@ -46,7 +45,6 @@ export const createTestPackItem = (
     notes: overrides.notes ?? null,
     packId,
     catalogItemId: overrides.catalogItemId ?? null,
-    userId: overrides.userId,
     deleted: overrides.deleted ?? false,
     ...overrides,
   };

--- a/packages/api/test/fixtures/pack-fixtures.ts
+++ b/packages/api/test/fixtures/pack-fixtures.ts
@@ -1,68 +1,61 @@
 import type { InferInsertModel } from 'drizzle-orm';
 import type { packItems, packs } from '../../src/db/schema';
 
+type PackOverrides = Partial<InferInsertModel<typeof packs>> & { userId: number };
+type PackItemOverrides = Partial<InferInsertModel<typeof packItems>> & { userId: number };
+
 /**
- * Test fixture for creating a minimal valid pack
+ * Test fixture for creating a minimal valid pack.
+ * `userId` is required — no default (#2180).
  */
-export const createTestPack = (
-  overrides?: Partial<InferInsertModel<typeof packs>>,
-): InferInsertModel<typeof packs> => {
+export const createTestPack = (overrides: PackOverrides): InferInsertModel<typeof packs> => {
   const now = new Date();
   return {
-    id: overrides?.id ?? `pack_test_${Date.now()}_${Math.random().toString(36).substring(7)}`,
-    name: overrides?.name ?? 'Test Backpacking Pack',
-    description: overrides?.description ?? 'A test pack for backpacking trips',
-    category: overrides?.category ?? 'backpacking',
-    userId: overrides?.userId ?? 1, // Default test user
-    templateId: overrides?.templateId ?? null,
-    isPublic: overrides?.isPublic ?? false,
-    image: overrides?.image ?? null,
-    tags: overrides?.tags ?? ['hiking', 'backpacking'],
-    deleted: overrides?.deleted ?? false,
-    isAIGenerated: overrides?.isAIGenerated ?? false,
-    localCreatedAt: overrides?.localCreatedAt ?? now,
-    localUpdatedAt: overrides?.localUpdatedAt ?? now,
+    id: overrides.id ?? `pack_test_${Date.now()}_${Math.random().toString(36).substring(7)}`,
+    name: overrides.name ?? 'Test Backpacking Pack',
+    description: overrides.description ?? 'A test pack for backpacking trips',
+    category: overrides.category ?? 'backpacking',
+    userId: overrides.userId,
+    templateId: overrides.templateId ?? null,
+    isPublic: overrides.isPublic ?? false,
+    image: overrides.image ?? null,
+    tags: overrides.tags ?? ['hiking', 'backpacking'],
+    deleted: overrides.deleted ?? false,
+    isAIGenerated: overrides.isAIGenerated ?? false,
+    localCreatedAt: overrides.localCreatedAt ?? now,
+    localUpdatedAt: overrides.localUpdatedAt ?? now,
     ...overrides,
   };
 };
-
-/**
- * Test fixture for creating a pack item
- */
 
 export const createTestPackItem = (
   packId: string,
-  overrides?: Partial<InferInsertModel<typeof packItems>>,
+  overrides: PackItemOverrides,
 ): InferInsertModel<typeof packItems> => {
   return {
-    id: overrides?.id ?? `item_test_${Date.now()}_${Math.random().toString(36).substring(7)}`,
-    name: overrides?.name ?? 'Test Backpack',
-    description: overrides?.description ?? 'A test item for the pack',
-    weight: overrides?.weight ?? 1200,
-    weightUnit: overrides?.weightUnit ?? 'g',
-    quantity: overrides?.quantity ?? 1,
-    category: overrides?.category ?? 'pack',
-    consumable: overrides?.consumable ?? false,
-    worn: overrides?.worn ?? false,
-    image: overrides?.image ?? null,
-    notes: overrides?.notes ?? null,
+    id: overrides.id ?? `item_test_${Date.now()}_${Math.random().toString(36).substring(7)}`,
+    name: overrides.name ?? 'Test Backpack',
+    description: overrides.description ?? 'A test item for the pack',
+    weight: overrides.weight ?? 1200,
+    weightUnit: overrides.weightUnit ?? 'g',
+    quantity: overrides.quantity ?? 1,
+    category: overrides.category ?? 'pack',
+    consumable: overrides.consumable ?? false,
+    worn: overrides.worn ?? false,
+    image: overrides.image ?? null,
+    notes: overrides.notes ?? null,
     packId,
-    catalogItemId: overrides?.catalogItemId ?? null,
-    userId: overrides?.userId ?? 1, // Default test user
-    deleted: overrides?.deleted ?? false,
+    catalogItemId: overrides.catalogItemId ?? null,
+    userId: overrides.userId,
+    deleted: overrides.deleted ?? false,
     ...overrides,
   };
 };
 
-/**
- * Test fixture for creating a full pack with custom properties
- */
-export const createFullTestPack = (
-  overrides?: Partial<InferInsertModel<typeof packs>>,
-): InferInsertModel<typeof packs> => {
+export const createFullTestPack = (overrides: PackOverrides): InferInsertModel<typeof packs> => {
   return {
     ...createTestPack(overrides),
-    tags: overrides?.tags ?? ['ultralight', 'thru-hiking', 'backpacking'],
-    isPublic: overrides?.isPublic ?? true,
+    tags: overrides.tags ?? ['ultralight', 'thru-hiking', 'backpacking'],
+    isPublic: overrides.isPublic ?? true,
   };
 };

--- a/packages/api/test/fixtures/pack-template-fixtures.ts
+++ b/packages/api/test/fixtures/pack-template-fixtures.ts
@@ -1,25 +1,28 @@
 import type { InferInsertModel } from 'drizzle-orm';
 import type { packTemplateItems, packTemplates } from '../../src/db/schema';
 
+type PackTemplateOverrides = Partial<InferInsertModel<typeof packTemplates>> & { userId: number };
+
 /**
- * Test fixture for creating a minimal valid pack template
+ * Test fixture for creating a minimal valid pack template.
+ * `userId` is required — no default (#2180).
  */
 export const createTestPackTemplate = (
-  overrides?: Partial<InferInsertModel<typeof packTemplates>>,
+  overrides: PackTemplateOverrides,
 ): InferInsertModel<typeof packTemplates> => {
   const now = new Date();
   return {
-    id: overrides?.id ?? `pt_test_${Date.now()}_${Math.random().toString(36).substring(7)}`,
-    name: overrides?.name ?? 'Test Backpacking Template',
-    description: overrides?.description ?? 'A test template for backpacking trips',
-    category: overrides?.category ?? 'backpacking',
-    userId: overrides?.userId ?? 1, // Default test user
-    image: overrides?.image ?? null,
-    tags: overrides?.tags ?? ['hiking', 'backpacking'],
-    isAppTemplate: overrides?.isAppTemplate ?? true, // Make it accessible by default
-    deleted: overrides?.deleted ?? false,
-    localCreatedAt: overrides?.localCreatedAt ?? now,
-    localUpdatedAt: overrides?.localUpdatedAt ?? now,
+    id: overrides.id ?? `pt_test_${Date.now()}_${Math.random().toString(36).substring(7)}`,
+    name: overrides.name ?? 'Test Backpacking Template',
+    description: overrides.description ?? 'A test template for backpacking trips',
+    category: overrides.category ?? 'backpacking',
+    userId: overrides.userId,
+    image: overrides.image ?? null,
+    tags: overrides.tags ?? ['hiking', 'backpacking'],
+    isAppTemplate: overrides.isAppTemplate ?? true,
+    deleted: overrides.deleted ?? false,
+    localCreatedAt: overrides.localCreatedAt ?? now,
+    localUpdatedAt: overrides.localUpdatedAt ?? now,
     ...overrides,
   };
 };
@@ -28,26 +31,30 @@ export const createTestPackTemplate = (
  * Test fixture for creating a pack template item
  */
 
+type PackTemplateItemOverrides = Partial<InferInsertModel<typeof packTemplateItems>> & {
+  userId: number;
+};
+
 export const createTestPackTemplateItem = (
   packTemplateId: string,
-  overrides?: Partial<InferInsertModel<typeof packTemplateItems>>,
+  overrides: PackTemplateItemOverrides,
 ): InferInsertModel<typeof packTemplateItems> => {
   return {
-    id: overrides?.id ?? `pti_test_${Date.now()}_${Math.random().toString(36).substring(7)}`,
-    name: overrides?.name ?? 'Test Backpack',
-    description: overrides?.description ?? 'A test item for the pack template',
-    weight: overrides?.weight ?? 1200,
-    weightUnit: overrides?.weightUnit ?? 'g',
-    quantity: overrides?.quantity ?? 1,
-    category: overrides?.category ?? 'pack',
-    consumable: overrides?.consumable ?? false,
-    worn: overrides?.worn ?? false,
-    image: overrides?.image ?? null,
-    notes: overrides?.notes ?? null,
+    id: overrides.id ?? `pti_test_${Date.now()}_${Math.random().toString(36).substring(7)}`,
+    name: overrides.name ?? 'Test Backpack',
+    description: overrides.description ?? 'A test item for the pack template',
+    weight: overrides.weight ?? 1200,
+    weightUnit: overrides.weightUnit ?? 'g',
+    quantity: overrides.quantity ?? 1,
+    category: overrides.category ?? 'pack',
+    consumable: overrides.consumable ?? false,
+    worn: overrides.worn ?? false,
+    image: overrides.image ?? null,
+    notes: overrides.notes ?? null,
     packTemplateId,
-    catalogItemId: overrides?.catalogItemId ?? null,
-    userId: overrides?.userId ?? 1, // Default test user
-    deleted: overrides?.deleted ?? false,
+    catalogItemId: overrides.catalogItemId ?? null,
+    userId: overrides.userId,
+    deleted: overrides.deleted ?? false,
     ...overrides,
   };
 };
@@ -56,10 +63,10 @@ export const createTestPackTemplateItem = (
  * Test fixture for creating a full pack template with items
  */
 export const createFullTestPackTemplate = (
-  overrides?: Partial<InferInsertModel<typeof packTemplates>>,
+  overrides: PackTemplateOverrides,
 ): InferInsertModel<typeof packTemplates> => {
   return {
     ...createTestPackTemplate(overrides),
-    tags: overrides?.tags ?? ['ultralight', 'thru-hiking', 'backpacking'],
+    tags: overrides.tags ?? ['ultralight', 'thru-hiking', 'backpacking'],
   };
 };

--- a/packages/api/test/fixtures/pack-template-fixtures.ts
+++ b/packages/api/test/fixtures/pack-template-fixtures.ts
@@ -16,7 +16,6 @@ export const createTestPackTemplate = (
     name: overrides.name ?? 'Test Backpacking Template',
     description: overrides.description ?? 'A test template for backpacking trips',
     category: overrides.category ?? 'backpacking',
-    userId: overrides.userId,
     image: overrides.image ?? null,
     tags: overrides.tags ?? ['hiking', 'backpacking'],
     isAppTemplate: overrides.isAppTemplate ?? true,
@@ -53,7 +52,6 @@ export const createTestPackTemplateItem = (
     notes: overrides.notes ?? null,
     packTemplateId,
     catalogItemId: overrides.catalogItemId ?? null,
-    userId: overrides.userId,
     deleted: overrides.deleted ?? false,
     ...overrides,
   };

--- a/packages/api/test/generate-from-online-content.test.ts
+++ b/packages/api/test/generate-from-online-content.test.ts
@@ -123,10 +123,12 @@ vi.mock('@packrat/api/services/catalogService', () => ({
 }));
 
 describe('Generate From Online Content Routes', () => {
+  let testAdmin: Awaited<ReturnType<typeof seedTestUser>>;
+
   beforeEach(async () => {
     // Re-seed both users before each test (global beforeEach truncates all tables)
     await seedTestUser();
-    await seedTestUser({
+    testAdmin = await seedTestUser({
       email: 'admin@example.com',
       firstName: 'Admin',
       lastName: 'User',
@@ -188,8 +190,9 @@ describe('Generate From Online Content Routes', () => {
     it('returns 409 for existing template with same contentId', async () => {
       const duplicateContentId = 'duplicate-content-test-123';
 
-      // Seed an existing template with a TikTok content ID
+      // Seed an existing template with a TikTok content ID (owned by admin)
       await seedPackTemplate({
+        userId: testAdmin.id,
         name: 'Existing TikTok Template',
         contentSource: 'tiktok',
         contentId: duplicateContentId,

--- a/packages/api/test/image-detection.test.ts
+++ b/packages/api/test/image-detection.test.ts
@@ -1,14 +1,20 @@
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { seedTestUser } from './utils/db-helpers';
 import {
   api,
   apiWithAuth,
   expectJsonResponse,
   expectUnauthorized,
   httpMethods,
-  TEST_USER,
 } from './utils/test-helpers';
 
 describe('Image Detection Routes', () => {
+  let testUser: Awaited<ReturnType<typeof seedTestUser>>;
+
+  beforeEach(async () => {
+    testUser = await seedTestUser();
+  });
+
   describe('Authentication', () => {
     it('POST /packs/analyze-image requires auth', async () => {
       const res = await api('/packs/analyze-image', httpMethods.post({}));
@@ -36,7 +42,7 @@ describe('Image Detection Routes', () => {
       const res = await apiWithAuth(
         '/packs/analyze-image',
         httpMethods.post({
-          image: `${TEST_USER.id}-Ly81kadKndZ1pH2miQu8A.jpg`,
+          image: `${testUser.id}-Ly81kadKndZ1pH2miQu8A.jpg`,
         }),
       );
 
@@ -50,7 +56,7 @@ describe('Image Detection Routes', () => {
       const res = await apiWithAuth(
         '/packs/analyze-image',
         httpMethods.post({
-          image: `${TEST_USER.id}-Ly81kadKndZ1pH2miQu8A.jpg`,
+          image: `${testUser.id}-Ly81kadKndZ1pH2miQu8A.jpg`,
           matchLimit: 5,
         }),
       );

--- a/packages/api/test/pack-templates.test.ts
+++ b/packages/api/test/pack-templates.test.ts
@@ -15,9 +15,11 @@ import {
 } from './utils/test-helpers';
 
 describe('Pack Templates Routes', () => {
+  let testUser: Awaited<ReturnType<typeof seedTestUser>>;
+
   // Re-seed user before each test (global beforeEach truncates all tables)
   beforeEach(async () => {
-    await seedTestUser();
+    testUser = await seedTestUser();
   });
   describe('Authentication', () => {
     it('GET /pack-templates requires auth', async () => {
@@ -39,7 +41,7 @@ describe('Pack Templates Routes', () => {
   describe('GET /pack-templates', () => {
     it('returns pack templates list', async () => {
       // Seed a template first
-      await seedPackTemplate();
+      await seedPackTemplate({ userId: testUser.id });
 
       const res = await apiWithAuth('/pack-templates');
 
@@ -52,7 +54,10 @@ describe('Pack Templates Routes', () => {
   describe('GET /pack-templates/:id', () => {
     it('returns single pack template', async () => {
       // Seed a template first
-      const seededTemplate = await seedPackTemplate({ name: 'Test Template for GET' });
+      const seededTemplate = await seedPackTemplate({
+        userId: testUser.id,
+        name: 'Test Template for GET',
+      });
 
       const res = await apiWithAuth(`/pack-templates/${seededTemplate.id}`);
 
@@ -64,7 +69,7 @@ describe('Pack Templates Routes', () => {
 
     it('returns template with metadata', async () => {
       // Seed a template first
-      const seededTemplate = await seedPackTemplate();
+      const seededTemplate = await seedPackTemplate({ userId: testUser.id });
 
       const res = await apiWithAuth(`/pack-templates/${seededTemplate.id}`);
 
@@ -83,8 +88,11 @@ describe('Pack Templates Routes', () => {
   describe('GET /pack-templates/:id/items', () => {
     it('returns template items list', async () => {
       // Seed a template with items
-      const seededTemplate = await seedPackTemplate();
-      await seedPackTemplateItems(seededTemplate.id, { count: 3 });
+      const seededTemplate = await seedPackTemplate({ userId: testUser.id });
+      await seedPackTemplateItems(seededTemplate.id, {
+        count: 3,
+        overrides: { userId: testUser.id },
+      });
 
       const res = await apiWithAuth(`/pack-templates/${seededTemplate.id}/items`);
 
@@ -95,8 +103,8 @@ describe('Pack Templates Routes', () => {
 
     it('returns items with quantities', async () => {
       // Seed a template with items
-      const seededTemplate = await seedPackTemplate();
-      await seedPackTemplateItem(seededTemplate.id, { quantity: 2 });
+      const seededTemplate = await seedPackTemplate({ userId: testUser.id });
+      await seedPackTemplateItem(seededTemplate.id, { userId: testUser.id, quantity: 2 });
 
       const res = await apiWithAuth(`/pack-templates/${seededTemplate.id}/items`);
 

--- a/packages/api/test/packs.test.ts
+++ b/packages/api/test/packs.test.ts
@@ -10,7 +10,6 @@ import {
   expectNotFound,
   expectUnauthorized,
   httpMethods,
-  TEST_USER,
 } from './utils/test-helpers';
 
 // Mock PackService.generatePacks to avoid AI dependencies in tests
@@ -55,32 +54,31 @@ vi.mock('../src/services/packService', async () => {
 });
 
 describe('Packs Routes', () => {
+  let testUser: Awaited<ReturnType<typeof seedTestUser>>;
   let testPackId: string;
   let testPackItemId: string;
   let testCatalogItemId: number;
 
   // Re-seed test data before each test (global beforeEach truncates all tables)
   beforeEach(async () => {
-    await seedTestUser();
+    testUser = await seedTestUser();
+    await seedTestUser({ role: 'ADMIN', email: 'admin@example.com' });
 
-    // Create a test catalog item for pack items
     const catalogItem = await seedCatalogItem({
       name: 'Test Tent',
       categories: ['shelter'],
     });
     testCatalogItemId = catalogItem.id;
 
-    // Create a test pack owned by the test user
     const pack = await seedPack({
-      userId: TEST_USER.id,
+      userId: testUser.id,
       name: 'Test Pack',
       category: 'hiking',
     });
     testPackId = pack.id;
 
-    // Add some items to the pack
     const packItem = await seedPackItem(pack.id, {
-      userId: TEST_USER.id,
+      userId: testUser.id,
       catalogItemId: catalogItem.id,
       name: 'Test Tent Item',
       category: 'shelter',
@@ -242,7 +240,7 @@ describe('Packs Routes', () => {
     it('deletes pack', async () => {
       // Create a new pack just for this test
       const packToDelete = await seedPack({
-        userId: TEST_USER.id,
+        userId: testUser.id,
         name: 'Pack to Delete',
         category: 'hiking',
       });
@@ -336,7 +334,7 @@ describe('Packs Routes', () => {
       it('removes item from pack', async () => {
         // Create a new item to delete
         const itemToDelete = await seedPackItem(testPackId, {
-          userId: TEST_USER.id,
+          userId: testUser.id,
           name: 'Item to Delete',
           category: 'gear',
         });

--- a/packages/api/test/setup.ts
+++ b/packages/api/test/setup.ts
@@ -2,6 +2,7 @@ import { neonConfig, Pool } from '@neondatabase/serverless';
 import { drizzle } from 'drizzle-orm/neon-serverless';
 import { afterAll, beforeAll, beforeEach, vi } from 'vitest';
 import * as schema from '../src/db/schema';
+import { clearCurrentTestUsers } from './utils/test-helpers';
 
 // Route @neondatabase/serverless through the local wsproxy (docker-compose.test.yml),
 // so tests use the same driver as production against Docker Postgres.
@@ -430,6 +431,8 @@ beforeAll(async () => {
 
 beforeEach(async () => {
   if (!testPool) return;
+
+  clearCurrentTestUsers();
 
   const tablesToClean = [
     'one_time_passwords',

--- a/packages/api/test/utils/db-helpers.ts
+++ b/packages/api/test/utils/db-helpers.ts
@@ -1,4 +1,5 @@
 import { createDb } from '@packrat/api/db';
+import { UserService } from '@packrat/api/services/userService';
 import { assertDefined } from '@packrat/guards';
 import type { InferInsertModel } from 'drizzle-orm';
 import type { Context } from 'hono';
@@ -8,7 +9,7 @@ import {
   packs,
   packTemplateItems,
   packTemplates,
-  users,
+  type users,
 } from '../../src/db/schema';
 import { createTestCatalogItem } from '../fixtures/catalog-fixtures';
 import { createTestPack, createTestPackItem } from '../fixtures/pack-fixtures';
@@ -16,6 +17,7 @@ import {
   createTestPackTemplate,
   createTestPackTemplateItem,
 } from '../fixtures/pack-template-fixtures';
+import { setCurrentTestAdmin, setCurrentTestUser } from './test-helpers';
 
 /**
  * Generates a mock embedding vector
@@ -35,27 +37,33 @@ function generateUniqueSku(): string {
 }
 
 /**
- * Seeds a test user into the database
- * @returns The created user with id
+ * Seeds a test user via UserService (same path production register uses) and
+ * registers them as the current JWT subject for apiWithAuth / apiWithAdmin.
+ * Callers must use the returned `user.id` — it is DB-assigned (#2180).
  */
-export async function seedTestUser(overrides?: Partial<InferInsertModel<typeof users>>) {
-  const db = createDb({} as unknown as Context);
+export async function seedTestUser(
+  overrides?: Partial<InferInsertModel<typeof users>> & { password?: string },
+) {
+  const userService = new UserService({} as unknown as Context);
+  const role = (overrides?.role as 'USER' | 'ADMIN') ?? 'USER';
 
-  const userData = {
+  const user = await userService.create({
     email:
       overrides?.email ??
       `test-${Date.now()}-${Math.random().toString(36).substring(7)}@example.com`,
-    emailVerified: overrides?.emailVerified ?? true,
-    passwordHash: overrides?.passwordHash ?? null,
+    password: overrides?.password,
     firstName: overrides?.firstName ?? 'Test',
     lastName: overrides?.lastName ?? 'User',
-    role: overrides?.role ?? 'USER',
-    ...overrides,
-  };
+    role,
+    emailVerified: overrides?.emailVerified ?? true,
+  });
 
-  const [user] = await db.insert(users).values(userData).returning();
-
-  assertDefined(user);
+  const subject = { id: user.id, role };
+  if (role === 'ADMIN') {
+    setCurrentTestAdmin(subject);
+  } else {
+    setCurrentTestUser(subject);
+  }
 
   return user;
 }
@@ -123,7 +131,7 @@ export async function seedCatalogItems(
  * @returns The created pack template with id
  */
 export async function seedPackTemplate(
-  overrides?: Partial<InferInsertModel<typeof packTemplates>>,
+  overrides: Partial<InferInsertModel<typeof packTemplates>> & { userId: number },
 ) {
   const db = createDb({} as unknown as Context);
 
@@ -143,7 +151,7 @@ export async function seedPackTemplate(
 
 export async function seedPackTemplates(
   count: number,
-  overrides?: Partial<InferInsertModel<typeof packTemplates>>,
+  overrides: Partial<InferInsertModel<typeof packTemplates>> & { userId: number },
 ) {
   const db = createDb({} as unknown as Context);
 
@@ -166,7 +174,7 @@ export async function seedPackTemplates(
 
 export async function seedPackTemplateItem(
   packTemplateId: string,
-  overrides?: Partial<InferInsertModel<typeof packTemplateItems>>,
+  overrides: Partial<InferInsertModel<typeof packTemplateItems>> & { userId: number },
 ) {
   const db = createDb({} as unknown as Context);
 
@@ -186,7 +194,10 @@ export async function seedPackTemplateItem(
 
 export async function seedPackTemplateItems(
   packTemplateId: string,
-  opts: { count: number; overrides?: Partial<InferInsertModel<typeof packTemplateItems>> },
+  opts: {
+    count: number;
+    overrides: Partial<InferInsertModel<typeof packTemplateItems>> & { userId: number };
+  },
 ) {
   const { count, overrides } = opts;
   const db = createDb({} as unknown as Context);
@@ -207,7 +218,9 @@ export async function seedPackTemplateItems(
  * Seeds a pack into the test database
  * @returns The created pack with id
  */
-export async function seedPack(overrides?: Partial<InferInsertModel<typeof packs>>) {
+export async function seedPack(
+  overrides: Partial<InferInsertModel<typeof packs>> & { userId: number },
+) {
   const db = createDb({} as unknown as Context);
 
   const packData = createTestPack(overrides);
@@ -226,7 +239,7 @@ export async function seedPack(overrides?: Partial<InferInsertModel<typeof packs
 
 export async function seedPacks(
   count: number,
-  overrides?: Partial<InferInsertModel<typeof packs>>,
+  overrides: Partial<InferInsertModel<typeof packs>> & { userId: number },
 ) {
   const db = createDb({} as unknown as Context);
 
@@ -249,7 +262,7 @@ export async function seedPacks(
 
 export async function seedPackItem(
   packId: string,
-  overrides?: Partial<InferInsertModel<typeof packItems>>,
+  overrides: Partial<InferInsertModel<typeof packItems>> & { userId: number },
 ) {
   const db = createDb({} as unknown as Context);
 
@@ -269,7 +282,10 @@ export async function seedPackItem(
 
 export async function seedPackItems(
   packId: string,
-  opts: { count: number; overrides?: Partial<InferInsertModel<typeof packItems>> },
+  opts: {
+    count: number;
+    overrides: Partial<InferInsertModel<typeof packItems>> & { userId: number };
+  },
 ) {
   const { count, overrides } = opts;
   const db = createDb({} as unknown as Context);

--- a/packages/api/test/utils/test-helpers.ts
+++ b/packages/api/test/utils/test-helpers.ts
@@ -13,21 +13,23 @@ expect.extend({
   },
 });
 
-// Test user data for consistent testing
-export const TEST_USER = {
-  id: 1,
-  email: 'test@example.com',
-  firstName: 'Test',
-  lastName: 'User',
-  role: 'USER' as const,
+type AuthSubject = { id: number; role: 'USER' | 'ADMIN' };
+
+// Current test user for JWT signing. Set by seedTestUser (#2180) — no hardcoded id.
+let currentTestUser: AuthSubject | null = null;
+let currentTestAdmin: AuthSubject | null = null;
+
+export const setCurrentTestUser = (user: AuthSubject) => {
+  currentTestUser = user;
 };
 
-export const TEST_ADMIN = {
-  id: 2,
-  email: 'admin@example.com',
-  firstName: 'Admin',
-  lastName: 'User',
-  role: 'ADMIN' as const,
+export const setCurrentTestAdmin = (user: AuthSubject) => {
+  currentTestAdmin = user;
+};
+
+export const clearCurrentTestUsers = () => {
+  currentTestUser = null;
+  currentTestAdmin = null;
 };
 
 // Helper to create authenticated API requests
@@ -35,10 +37,7 @@ export const api = (path: string, init?: RequestInit) =>
   app.fetch(new Request(`http://localhost/api${path}`, init));
 
 // Internal: shared fetch with auth token for a specific user
-const fetchWithUser = async (
-  path: string,
-  opts: { user: typeof TEST_USER | typeof TEST_ADMIN; init?: RequestInit },
-) => {
+const fetchWithUser = async (path: string, opts: { user: AuthSubject; init?: RequestInit }) => {
   const { user, init } = opts;
   const token = await sign({ userId: user.id, role: user.role }, 'secret');
   return app.fetch(
@@ -53,19 +52,22 @@ const fetchWithUser = async (
   );
 };
 
-// Helper to create requests with authentication token (as TEST_USER by default)
-export const apiWithAuth = async (path: string, init?: RequestInit) =>
-  fetchWithUser(path, { user: TEST_USER, init });
+// Synthetic JWT subject for tests that sign a JWT but never touch users in DB
+// (e.g. catalog, guides, upload). Tests that need the user to exist in DB must
+// call seedTestUser() in beforeEach, which sets currentTestUser.
+const SYNTHETIC_USER: AuthSubject = { id: 0, role: 'USER' };
+const SYNTHETIC_ADMIN: AuthSubject = { id: 0, role: 'ADMIN' };
 
-// Helper to create requests authenticated as a specific user
+export const apiWithAuth = async (path: string, init?: RequestInit) =>
+  fetchWithUser(path, { user: currentTestUser ?? SYNTHETIC_USER, init });
+
 export const apiWithAuthAs = async (
   path: string,
-  opts: { user: typeof TEST_USER | typeof TEST_ADMIN; init?: RequestInit },
+  opts: { user: AuthSubject; init?: RequestInit },
 ) => fetchWithUser(path, opts);
 
-// Helper to create admin authenticated requests
 export const apiWithAdmin = async (path: string, init?: RequestInit) =>
-  fetchWithUser(path, { user: TEST_ADMIN, init });
+  fetchWithUser(path, { user: currentTestAdmin ?? SYNTHETIC_ADMIN, init });
 
 // Helper for admin routes (basic auth)
 export const apiWithBasicAuth = (path: string, init?: RequestInit) => {


### PR DESCRIPTION
## Summary

api-tests has been red on `development` since #2170 merged. Root cause: fixtures hardcode `userId: 1`, assuming `TRUNCATE ... RESTART IDENTITY` + serial column always produces user id=1. The wsproxy cutover broke that assumption.

Fix: extract `userService.createUser` from the inline `/auth/register` handler, seed test users through it, and remove the hardcoded `userId: 1` from fixtures and tests.

- Plan: [docs/plans/2026-04-14-fix-api-tests-user-seed-via-service-plan.md](../blob/fix/api-tests-user-seed-via-service/docs/plans/2026-04-14-fix-api-tests-user-seed-via-service-plan.md)
- Prior PR this follows up on: #2170

## Scope

- [ ] Extract `userService.createUser` from `packages/api/src/routes/auth/index.ts:231`
- [ ] Rewrite `seedTestUser` to call the service
- [ ] Remove `userId: 1` defaults from fixtures; tests read real id from seeded user
- [ ] `api-tests` green

## Out of scope

- `drizzle-seed` adoption for cleanup (follow-up)
- Extracting services for login/OTP/password-reset (separate refactor)

## Test plan

- [ ] api-tests CI green
- [ ] Non-api CI stays green (biome, check-types, Unit Tests)
- [ ] Grep confirms no remaining `TEST_USER.id`, `userId: 1`, `user_id=1` in `packages/api/test/` (except intentional negative cases)