### PR TITLE
🐛 fix(admin): serve SPA fallback on deep links + bump compat date

### DIFF
--- a/apps/admin/wrangler.jsonc
+++ b/apps/admin/wrangler.jsonc
@@ -1,7 +1,7 @@
 {
   "$schema": "https://developers.cloudflare.com/schemas/wrangler.json",
   "name": "packrat-admin",
-  "compatibility_date": "2024-09-23",
+  "compatibility_date": "2026-04-15",
   "assets": {
     "directory": "./out",
     "not_found_handling": "single-page-application"

--- a/apps/admin/wrangler.jsonc
+++ b/apps/admin/wrangler.jsonc
@@ -4,6 +4,6 @@
   "compatibility_date": "2024-09-23",
   "assets": {
     "directory": "./out",
-    "not_found_handling": "404-page"
+    "not_found_handling": "single-page-application"
   }
 }


### PR DESCRIPTION
## Summary

- 🐛 Switch `not_found_handling` from `404-page` → `single-page-application` in `apps/admin/wrangler.jsonc` so client-routed deep links (e.g. hard refresh on `/users/123`) serve `index.html` and let the SPA router handle them instead of returning the 404 page.
- ⬆️ Bump Workers compatibility date `2024-09-23` → `2026-04-15` (cosmetic — no Worker script runs for this project, static assets only).

## Context

`packrat-admin` is deployed via Cloudflare's Workers Static Assets (the replacement for Pages for new SPA projects). With `404-page` handling, any URL that doesn't map to a built asset served the 404 page — which broke deep links for the client-routed admin SPA. `single-page-application` is the documented Workers Static Assets mode for SPAs.

Landing and guides were intentionally **not** changed — those are Next.js static exports with pre-rendered pages (not SPAs), their current Pages deploys are unaffected, and `404-page` behavior is actually correct for them.

## Test plan

- [ ] Verify admin deploys cleanly (Workers Static Assets picks up `wrangler.jsonc`)
- [ ] Hard-refresh a deep link in admin (e.g. `/users`, `/settings/something`) and confirm the SPA renders instead of the 404 page
- [ ] Navigate to a genuinely unknown path and confirm the SPA's in-app "not found" view renders (rather than Cloudflare's 404)
- [ ] Confirm root `/` still loads normally