### PR TITLE
🔥 fix(admin): require NEXT_PUBLIC_API_URL, no localhost fallback

### DIFF
--- a/apps/admin/app/login/page.tsx
+++ b/apps/admin/app/login/page.tsx
@@ -15,7 +15,10 @@ import { Package } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 import { useState } from 'react';
 
-const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:8787';
+const API_BASE = process.env.NEXT_PUBLIC_API_URL;
+if (!API_BASE) {
+  throw new Error('NEXT_PUBLIC_API_URL must be set (root .env.local → PUBLIC_API_URL)');
+}
 
 export default function LoginPage() {
   const router = useRouter();

--- a/apps/admin/lib/api.ts
+++ b/apps/admin/lib/api.ts
@@ -4,7 +4,10 @@
 
 import { clearToken, getAuthHeader } from './auth';
 
-const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:8787';
+const API_BASE = process.env.NEXT_PUBLIC_API_URL;
+if (!API_BASE) {
+  throw new Error('NEXT_PUBLIC_API_URL must be set (root .env.local → PUBLIC_API_URL)');
+}
 
 async function adminFetch<T>(path: string, init?: RequestInit): Promise<T> {
   const res = await fetch(`${API_BASE}/api/admin${path}`, {


### PR DESCRIPTION
## Problem

Prod admin login was failing with:

```
POST http://localhost:8787/api/admin/token net::ERR_CONNECTION_REFUSED
```

`NEXT_PUBLIC_API_URL` is inlined by Next.js at **`next build`** time. The Cloudflare Workers build for `packrat-admin` didn't have the env var set, so this hardcoded fallback in `apps/admin/lib/api.ts` and `apps/admin/app/login/page.tsx`:

```ts
const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:8787';
```

…silently baked `http://localhost:8787` into the shipped JS. The app built, deployed, and broke at runtime for real users instead of catching the misconfig at build/boot time.

## Fix

Throw a module-load error if `NEXT_PUBLIC_API_URL` isn't set. Misconfigured builds now fail fast and loud in both dev and prod.

```ts
const API_BASE = process.env.NEXT_PUBLIC_API_URL;
if (!API_BASE) {
  throw new Error('NEXT_PUBLIC_API_URL must be set (root .env.local → PUBLIC_API_URL)');
}
```

Local dev isn't broken — PR #2194 (env shim) makes the postinstall script write `NEXT_PUBLIC_API_URL` to `apps/admin/.env.local` from root `PUBLIC_API_URL`. If someone runs without the shim they get an obvious error message pointing at exactly what to set.

## Required follow-up (dashboard, not code)

Cloudflare dashboard → Workers & Pages → **packrat-admin** → Settings → Build → Variables and Secrets:

- `NEXT_PUBLIC_API_URL` = production API URL (`https://<api-worker>.workers.dev` or `https://api.packrat.world` if there's a custom domain)

Then trigger a redeploy. Without this, the build itself will now fail — which is intentional.

## Related

- #2192 — admin SPA fallback fix (independent)
- #2194 — env shim fans out root `.env.local` to Next.js apps (makes local dev Just Work for this)

## Test plan

- [ ] Local: `bun install && bun run admin` starts successfully (shim populates the var)
- [ ] Local without the shim: delete `apps/admin/.env.local`, `bun dev` in `apps/admin` — app should fail to load with a clear error rather than pointing at localhost invisibly
- [ ] Prod build with env var set in Cloudflare → admin loads and login hits the real API
- [ ] Prod build without env var set → build fails loudly (expected, not silent localhost fallback)