### PR TITLE
fix(api): delete stale TikTokContainer DO to unblock deploy

### DIFF
--- a/packages/api/wrangler.jsonc
+++ b/packages/api/wrangler.jsonc
@@ -94,6 +94,12 @@
           "to": "AppContainer"
         }
       ]
+    },
+    {
+      // Delete the stale TikTokContainer class so its container app
+      // (packrat-api-tiktokcontainer) is removed, unblocking packrat-api-appcontainer
+      "tag": "v3",
+      "deleted_classes": ["TikTokContainer"]
     }
   ],
   "env": {


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- The v2 `renamed_classes` migration (TikTokContainer → AppContainer) left the old `TikTokContainer` DO namespace (`a03113d1...`) alive with its container application `packrat-api-tiktokcontainer`
- Cloudflare only allows one container application per worker, so every subsequent deploy failed with `DURABLE_OBJECT_ALREADY_HAS_APPLICATION`
- Added a v3 `deleted_classes: ["TikTokContainer"]` migration to remove the stale class and its associated container app, unblocking `packrat-api-appcontainer` from being registered

## Test plan

- [ ] Merge and trigger a deploy — should no longer error with `DURABLE_OBJECT_ALREADY_HAS_APPLICATION`
- [ ] Verify `packrat-api-appcontainer` is listed as the active container application in the Cloudflare dashboard

https://claude.ai/code/session_01RacesmaEi8r7ex3zi8qhsj
EOF
)