### PR TITLE
fix: revert ignoreDeprecations to "5.0" to fix TS5103 in CI

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "allowJs": true,
     "baseUrl": ".",
     "esModuleInterop": true,
-    "ignoreDeprecations": "6.0",
+    "ignoreDeprecations": "5.0",
     "jsx": "react-native",
     "lib": ["DOM", "ESNext"],
     "module": "preserve",


### PR DESCRIPTION
## Summary

- Reverts `ignoreDeprecations` in `tsconfig.json` from `"6.0"` back to `"5.0"`

## Root Cause

The `checks` CI job was failing with `TS5103: Invalid value for '--ignoreDeprecations'`. CI installs TypeScript **5.9.3** (pinned in `bun.lock`), and that version rejects `"6.0"` as a valid value for `ignoreDeprecations` — only TypeScript 6.x accepts it.

The `"6.0"` value was added to silence the `baseUrl` deprecation warning (TS5101), but that warning only appears in TypeScript 6.x. Since CI runs 5.9.3, the fix was unnecessary and broke the build.

## Test plan

- [ ] `bun check-types` passes in CI (no TS5103 error)
- [ ] Biome and other checks continue to pass

https://claude.ai/code/session_01SypcK5vavfiCGcM8BPtTmY

---
_Generated by [Claude Code](https://claude.ai/code/session_01SypcK5vavfiCGcM8BPtTmY)_