### PR TITLE
fix(api): remove invalid v3 DO migration blocking wrangler deploy

### DIFF
--- a/packages/api/wrangler.jsonc
+++ b/packages/api/wrangler.jsonc
@@ -96,12 +96,6 @@
           "to": "AppContainer"
         }
       ]
-    },
-    {
-      // Delete the stale TikTokContainer class so its container app
-      // (packrat-api-tiktokcontainer) is removed, unblocking packrat-api-appcontainer
-      "tag": "v3",
-      "deleted_classes": ["TikTokContainer"]
     }
   ],
   "env": {


### PR DESCRIPTION
## Summary

- Removes the invalid `v3` Durable Objects migration from production `wrangler.jsonc`
- `v3` tried to `deleted_classes: ["TikTokContainer"]`, but `v2`'s `renamed_classes` already removed that name from the namespace — you can't delete a class that was renamed away
- Every `wrangler deploy` was failing with: `Cannot apply deleted_classes migration to non-existent class TikTokContainer`

## Root Cause

Migration sequence in production:
- `v1`: creates `TikTokContainer`
- `v2`: **renames** `TikTokContainer` → `AppContainer` (class name is gone after this)
- `v3`: tries to delete `TikTokContainer` ← invalid, doesn't exist anymore

The dev environment was correctly structured (v2 creates `AppContainer` as a new class, leaving `TikTokContainer` intact for v3 to delete). Production used `renamed_classes` in v2, which implicitly removes the old name.

## Fix

Remove v3 from the top-level (production) migrations. The rename in v2 already handled the `TikTokContainer` cleanup.

## Test plan

- [ ] `cd packages/api && bun run deploy --dry-run` passes without migration error
- [ ] After unlocking keychain (Docker credentials), `bun run deploy` completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)