### PR TITLE
fix(analytics): correct two failing unit tests

### DIFF
--- a/packages/analytics/test/core/env.test.ts
+++ b/packages/analytics/test/core/env.test.ts
@@ -55,6 +55,8 @@ describe('env validation', () => {
         ANALYTICS_MODE: 'local',
         R2_ACCESS_KEY_ID: 'test-key',
         R2_SECRET_ACCESS_KEY: 'test-secret',
+        R2_BUCKET_NAME: 'test-bucket',
+        R2_ENDPOINT_URL: 'https://test.r2.cloudflarestorage.com',
       },
       () => {
         const config = env();
@@ -88,6 +90,8 @@ describe('env validation', () => {
         ANALYTICS_MODE: 'local',
         R2_ACCESS_KEY_ID: 'key',
         R2_SECRET_ACCESS_KEY: 'secret',
+        R2_BUCKET_NAME: 'test-bucket',
+        R2_ENDPOINT_URL: 'https://test.r2.cloudflarestorage.com',
         R2_CATALOG_TOKEN: undefined,
       },
       () => expect(() => env()).not.toThrow(),
@@ -114,6 +118,8 @@ describe('env validation', () => {
         ANALYTICS_MODE: undefined,
         R2_ACCESS_KEY_ID: 'key',
         R2_SECRET_ACCESS_KEY: 'secret',
+        R2_BUCKET_NAME: 'test-bucket',
+        R2_ENDPOINT_URL: 'https://test.r2.cloudflarestorage.com',
       },
       () => {
         const config = env();

--- a/packages/analytics/test/core/spec-parser.test.ts
+++ b/packages/analytics/test/core/spec-parser.test.ts
@@ -104,7 +104,7 @@ describe('parseWaterproofRating', () => {
   });
 
   it('parses K notation', () => {
-    expect(parseWaterproofRating('20k mm rating')).toBe(20);
+    expect(parseWaterproofRating('20k mm rating')).toBe(20000);
   });
 
   it('returns null for no rating', () => {


### PR DESCRIPTION
## Summary

- **spec-parser**: `parseWaterproofRating('20k mm rating')` returns `20000` — the implementation was correct (20k × 1000 = 20000mm), the test expectation of `20` was wrong
- **env.test.ts**: three local-mode tests were missing `R2_BUCKET_NAME` and `R2_ENDPOINT_URL`, which `superRefine` now requires for local mode — tests weren't updated when those fields were made required

## Test plan

- [ ] `bun test` in `packages/analytics` passes (112 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed waterproof rating calculations to properly scale K-notation values to millimeters.

* **Tests**
  * Updated test environment configuration for analytics validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->