### PR TITLE
fix(api): harden knowledge-base reader auth, error handler, AI sources

### DIFF
--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -41,7 +41,7 @@ export const app = new Elysia({ adapter: CloudflareAdapter })
   .use(packratOpenApi)
   .onError(({ error, code }) => {
     console.error('Error occurred:', error);
-    if (code === 'VALIDATION') {
+    if (code === 'VALIDATION' || code === 'PARSE') {
       return new Response(JSON.stringify({ error: 'Validation failed' }), {
         status: 400,
         headers: { 'Content-Type': 'application/json' },

--- a/packages/api/src/routes/knowledgeBase/reader.ts
+++ b/packages/api/src/routes/knowledgeBase/reader.ts
@@ -98,6 +98,7 @@ export const readerRoutes = new Elysia({ prefix: '/reader' }).post(
   },
   {
     body: z.object({ url: z.string().url() }),
+    isAuthenticated: true,
     detail: {
       tags: ['Knowledge Base'],
       summary: 'Extract content from a URL',

--- a/packages/api/src/services/aiService.ts
+++ b/packages/api/src/services/aiService.ts
@@ -36,8 +36,7 @@ export class AIService {
         prompt: query,
       });
 
-      const { text, sources } = resp;
-      return { answer: text, sources };
+      return { answer: resp.text, sources: resp.sources ?? [] };
     } catch (error) {
       console.error('Search error:', error);
       throw new Error(`Search failed: ${error instanceof Error ? error.message : 'Unknown error'}`);


### PR DESCRIPTION
## Summary

- **Auth gap (HIGH):** `/knowledge-base/reader/extract` was open to unauthenticated requests — it fetches arbitrary user-supplied URLs via `@mozilla/readability`, making it a SSRF/DoS vector. Added `isAuthenticated: true`.
- **Error handler (MEDIUM):** `PARSE` errors (malformed request body) fell through to the 500 catch-all instead of returning 400. Added `PARSE` alongside `VALIDATION`.
- **AI sources guard (MEDIUM):** `perplexitySearch` destructured `sources` directly from `generateText` response; if the field is absent the caller crashes. Changed to `resp.sources ?? []`.

## Files changed

- `packages/api/src/routes/knowledgeBase/reader.ts` — add `isAuthenticated: true`
- `packages/api/src/index.ts` — handle `PARSE` as 400 in `onError`
- `packages/api/src/services/aiService.ts` — guard `sources` with nullish coalescing

## Test plan

- [ ] `POST /knowledge-base/reader/extract` without a Bearer token returns 401
- [ ] `POST /knowledge-base/reader/extract` with invalid JSON body returns 400 (not 500)
- [ ] Perplexity search still returns results; no crash if `sources` is empty/missing

🤖 Generated with [Claude Code](https://claude.com/claude-code)