### PR TITLE
chore: bump version to v2.0.24

### DIFF
--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "packrat-admin-app",
-  "version": "2.0.23",
+  "version": "2.0.24",
   "private": true,
   "scripts": {
     "build": "next build",

--- a/apps/expo/app.config.ts
+++ b/apps/expo/app.config.ts
@@ -37,7 +37,7 @@ export default (): ExpoConfig =>
     {
       name: getAppName(),
       slug: 'packrat',
-      version: '2.0.23',
+      version: '2.0.24',
       scheme: 'packrat',
       web: {
         bundler: 'metro',

--- a/apps/expo/package.json
+++ b/apps/expo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "packrat-expo-app",
-  "version": "2.0.23",
+  "version": "2.0.24",
   "private": true,
   "main": "expo-router/entry",
   "scripts": {

--- a/apps/guides/package.json
+++ b/apps/guides/package.json
@@ -1,6 +1,6 @@
 {
   "name": "packrat-guides-app",
-  "version": "2.0.23",
+  "version": "2.0.24",
   "private": true,
   "scripts": {
     "build": "bun run build-content && next build",

--- a/apps/landing/package.json
+++ b/apps/landing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "packrat-landing-app",
-  "version": "2.0.23",
+  "version": "2.0.24",
   "private": true,
   "scripts": {
     "build": "next build",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "packrat-monorepo",
-  "version": "2.0.23",
+  "version": "2.0.24",
   "workspaces": [
     "apps/*",
     "packages/*"

--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@packrat/analytics",
-  "version": "2.0.23",
+  "version": "2.0.24",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@packrat/api-client",
-  "version": "2.0.23",
+  "version": "2.0.24",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/api/container_src/package.json
+++ b/packages/api/container_src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "container",
-  "version": "2.0.23",
+  "version": "2.0.24",
   "type": "module",
   "dependencies": {
     "@aws-sdk/client-s3": "^3.0.0",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@packrat/api",
-  "version": "2.0.23",
+  "version": "2.0.24",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/checks/package.json
+++ b/packages/checks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@packrat/checks",
-  "version": "2.0.23",
+  "version": "2.0.24",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@packrat/cli",
-  "version": "2.0.23",
+  "version": "2.0.24",
   "private": true,
   "type": "module",
   "bin": {

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@packrat/config",
-  "version": "2.0.23",
+  "version": "2.0.24",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/env/package.json
+++ b/packages/env/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@packrat/env",
-  "version": "2.0.23",
+  "version": "2.0.24",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/guards/package.json
+++ b/packages/guards/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@packrat/guards",
-  "version": "2.0.23",
+  "version": "2.0.24",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@packrat/mcp",
-  "version": "2.0.23",
+  "version": "2.0.24",
   "private": true,
   "description": "PackRat MCP Server — outdoor adventure planning via Model Context Protocol",
   "scripts": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@packrat/ui",
-  "version": "2.0.23",
+  "version": "2.0.24",
   "private": true,
   "dependencies": {
     "@packrat-ai/nativewindui": "^2.0.2"

--- a/packages/web-ui/package.json
+++ b/packages/web-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@packrat/web-ui",
-  "version": "2.0.23",
+  "version": "2.0.24",
   "private": true,
   "type": "module",
   "exports": {


### PR DESCRIPTION
## Summary

Patch version bump `2.0.23 → 2.0.24` ahead of the `development → main` merge.

Updates all `package.json` files and `apps/expo/app.config.ts` via the `bun bump` script.

> **Note:** The `v2.0.24` git tag was created locally — push it to origin after this PR merges to main with `git push --tags`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)