### PR TITLE
ci: fix missing --frozen-lockfile and bun cache

### DIFF
--- a/.github/workflows/api-tests.yml
+++ b/.github/workflows/api-tests.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Install dependencies
         env:
           PACKRAT_NATIVEWIND_UI_GITHUB_TOKEN: ${{ secrets.PACKRAT_NATIVEWIND_UI_GITHUB_TOKEN }}
-        run: bun install
+        run: bun install --frozen-lockfile
 
       - name: Run API tests
         run: bun run --cwd packages/api test 2>&1 | tee /tmp/api-tests-output.log

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -27,6 +27,7 @@ jobs:
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
+          cache: true
       - name: Install dependencies
         env:
           PACKRAT_NATIVEWIND_UI_GITHUB_TOKEN: ${{ secrets.PACKRAT_NATIVEWIND_UI_GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- `api-tests.yml`: add `--frozen-lockfile` to `bun install` — was missing, allowing silent lockfile mutations in CI
- `checks.yml`: add `cache: true` to `setup-bun` — was missing, making `checks` slower than every other workflow

## Test plan
- [ ] Verify `api-tests` and `checks` jobs pass on this PR