### PR TITLE
refactor(admin): migrate CF Access identity fetch to TanStack Query

### DIFF
--- a/apps/admin/app/dashboard/catalog/page.tsx
+++ b/apps/admin/app/dashboard/catalog/page.tsx
@@ -16,6 +16,7 @@ import { EditCatalogDialog } from 'admin-app/components/edit-catalog-dialog';
 import { SearchInput } from 'admin-app/components/search-input';
 import { type AdminCatalogItem, deleteCatalogItem, getCatalogItems } from 'admin-app/lib/api';
 import { formatDate } from 'admin-app/lib/date';
+import { queryKeys } from 'admin-app/lib/queryKeys';
 import { useSearchParams } from 'next/navigation';
 
 function TableSkeleton() {
@@ -45,7 +46,7 @@ function CatalogRow({ item }: { item: AdminCatalogItem }) {
   const { mutateAsync: handleDelete } = useMutation({
     mutationFn: () => deleteCatalogItem(item.id),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['admin', 'catalog'] });
+      queryClient.invalidateQueries({ queryKey: queryKeys.admin.catalog() });
     },
   });
 
@@ -115,7 +116,7 @@ export default function CatalogPage() {
     isLoading,
     isError,
   } = useQuery({
-    queryKey: ['admin', 'catalog', q],
+    queryKey: queryKeys.admin.catalog(q),
     queryFn: () => getCatalogItems({ q }),
   });
 

--- a/apps/admin/app/dashboard/packs/page.tsx
+++ b/apps/admin/app/dashboard/packs/page.tsx
@@ -15,6 +15,7 @@ import { DeleteButton } from 'admin-app/components/delete-button';
 import { SearchInput } from 'admin-app/components/search-input';
 import { type AdminPack, deletePack, getPacks } from 'admin-app/lib/api';
 import { formatDate } from 'admin-app/lib/date';
+import { queryKeys } from 'admin-app/lib/queryKeys';
 import { useSearchParams } from 'next/navigation';
 
 function TableSkeleton() {
@@ -44,7 +45,7 @@ function PackRow({ pack }: { pack: AdminPack }) {
   const { mutateAsync: handleDelete } = useMutation({
     mutationFn: () => deletePack(pack.id),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['admin', 'packs'] });
+      queryClient.invalidateQueries({ queryKey: queryKeys.admin.packs() });
     },
   });
 
@@ -100,7 +101,7 @@ export default function PacksPage() {
     isLoading,
     isError,
   } = useQuery({
-    queryKey: ['admin', 'packs', q],
+    queryKey: queryKeys.admin.packs(q),
     queryFn: () => getPacks({ q }),
   });
 

--- a/apps/admin/app/dashboard/page.tsx
+++ b/apps/admin/app/dashboard/page.tsx
@@ -6,6 +6,7 @@ import { useQuery } from '@tanstack/react-query';
 import { StatsCards } from 'admin-app/components/stats-cards';
 import { getCatalogItems, getPacks, getStats, getUsers } from 'admin-app/lib/api';
 import { formatDistanceToNow } from 'admin-app/lib/date';
+import { queryKeys } from 'admin-app/lib/queryKeys';
 import { Backpack, Package, Users } from 'lucide-react';
 
 function OverviewSkeleton() {
@@ -47,22 +48,22 @@ function OverviewSkeleton() {
 
 export default function DashboardPage() {
   const { data: stats, isLoading: statsLoading } = useQuery({
-    queryKey: ['admin', 'stats'],
+    queryKey: queryKeys.admin.stats,
     queryFn: getStats,
   });
 
   const { data: users = [], isLoading: usersLoading } = useQuery({
-    queryKey: ['admin', 'users', 5],
+    queryKey: queryKeys.admin.users(5),
     queryFn: () => getUsers({ limit: 5 }),
   });
 
   const { data: packs = [], isLoading: packsLoading } = useQuery({
-    queryKey: ['admin', 'packs', 5],
+    queryKey: queryKeys.admin.packs(5),
     queryFn: () => getPacks({ limit: 5 }),
   });
 
   const { data: catalog = [], isLoading: catalogLoading } = useQuery({
-    queryKey: ['admin', 'catalog', 5],
+    queryKey: queryKeys.admin.catalog(5),
     queryFn: () => getCatalogItems({ limit: 5 }),
   });
 

--- a/apps/admin/app/dashboard/users/page.tsx
+++ b/apps/admin/app/dashboard/users/page.tsx
@@ -15,6 +15,7 @@ import { DeleteButton } from 'admin-app/components/delete-button';
 import { SearchInput } from 'admin-app/components/search-input';
 import { type AdminUser, deleteUser, getUsers } from 'admin-app/lib/api';
 import { formatDate } from 'admin-app/lib/date';
+import { queryKeys } from 'admin-app/lib/queryKeys';
 import { useSearchParams } from 'next/navigation';
 
 function TableSkeleton() {
@@ -43,7 +44,7 @@ function UserRow({ user }: { user: AdminUser }) {
   const { mutateAsync: handleDelete } = useMutation({
     mutationFn: () => deleteUser(user.id),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['admin', 'users'] });
+      queryClient.invalidateQueries({ queryKey: queryKeys.admin.users() });
     },
   });
 
@@ -100,7 +101,7 @@ export default function UsersPage() {
     isLoading,
     isError,
   } = useQuery({
-    queryKey: ['admin', 'users', q],
+    queryKey: queryKeys.admin.users(q),
     queryFn: () => getUsers({ q }),
   });
 

--- a/apps/admin/app/login/page.tsx
+++ b/apps/admin/app/login/page.tsx
@@ -11,7 +11,7 @@ import {
 import { Input } from '@packrat/web-ui/components/input';
 import { Label } from '@packrat/web-ui/components/label';
 import { storeToken } from 'admin-app/lib/auth';
-import { isBehindCFAccess } from 'admin-app/lib/cfAccess';
+import { useCFAccessIdentity } from 'admin-app/lib/cfAccess';
 import { Package, Shield } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
@@ -27,14 +27,12 @@ export default function LoginPage() {
   const [password, setPassword] = useState('');
   const [error, setError] = useState<string | null>(null);
   const [pending, setPending] = useState(false);
-  const [cfAccess, setCFAccess] = useState<boolean | null>(null);
+
+  const { data: cfIdentity, isPending: cfPending } = useCFAccessIdentity();
 
   useEffect(() => {
-    isBehindCFAccess().then((behind) => {
-      setCFAccess(behind);
-      if (behind) router.replace('/dashboard');
-    });
-  }, [router]);
+    if (!cfPending && cfIdentity) router.replace('/dashboard');
+  }, [cfPending, cfIdentity, router]);
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
@@ -70,7 +68,7 @@ export default function LoginPage() {
   }
 
   // Redirect in progress (behind CF Access) — show nothing while navigating
-  if (cfAccess === true) return null;
+  if (!cfPending && cfIdentity) return null;
 
   return (
     <div className="min-h-screen flex items-center justify-center bg-background px-4">
@@ -122,7 +120,7 @@ export default function LoginPage() {
           </CardContent>
         </Card>
 
-        {cfAccess === false && (
+        {!cfPending && !cfIdentity && (
           <p className="flex items-center justify-center gap-1.5 text-xs text-muted-foreground">
             <Shield className="w-3 h-3" />
             Local dev mode — Cloudflare Access not detected

--- a/apps/admin/components/auth-guard.tsx
+++ b/apps/admin/components/auth-guard.tsx
@@ -1,39 +1,21 @@
 'use client';
 
 import { getStoredToken } from 'admin-app/lib/auth';
-import { isBehindCFAccess } from 'admin-app/lib/cfAccess';
+import { useCFAccessIdentity } from 'admin-app/lib/cfAccess';
 import { useRouter } from 'next/navigation';
 import type React from 'react';
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 
 export function AuthGuard({ children }: { children: React.ReactNode }) {
   const router = useRouter();
-  const [ready, setReady] = useState(false);
+  const { data: cfIdentity, isPending } = useCFAccessIdentity();
 
   useEffect(() => {
-    let canceled = false;
+    if (isPending) return;
+    if (cfIdentity) return; // CF Access session active — allow through
+    if (!getStoredToken()) router.replace('/login');
+  }, [isPending, cfIdentity, router]);
 
-    async function check() {
-      if (await isBehindCFAccess()) {
-        if (!canceled) setReady(true);
-        return;
-      }
-      if (!getStoredToken()) {
-        if (!canceled) router.replace('/login');
-        return;
-      }
-      if (!canceled) setReady(true);
-    }
-
-    void check().catch(() => {
-      if (!canceled) router.replace('/login');
-    });
-
-    return () => {
-      canceled = true;
-    };
-  }, []); // router is stable in App Router
-
-  if (!ready) return null;
+  if (isPending || (!cfIdentity && !getStoredToken())) return null;
   return <>{children}</>;
 }

--- a/apps/admin/components/edit-catalog-dialog.tsx
+++ b/apps/admin/components/edit-catalog-dialog.tsx
@@ -14,6 +14,7 @@ import { Label } from '@packrat/web-ui/components/label';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import type { AdminCatalogItem } from 'admin-app/lib/api';
 import { updateCatalogItem } from 'admin-app/lib/api';
+import { queryKeys } from 'admin-app/lib/queryKeys';
 import { Pencil } from 'lucide-react';
 import { useState } from 'react';
 
@@ -28,7 +29,7 @@ export function EditCatalogDialog({ item }: EditCatalogDialogProps) {
   const { mutate, isPending } = useMutation({
     mutationFn: (data: Parameters<typeof updateCatalogItem>[1]) => updateCatalogItem(item.id, data),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['admin', 'catalog'] });
+      queryClient.invalidateQueries({ queryKey: queryKeys.admin.catalog() });
       setOpen(false);
     },
   });

--- a/apps/admin/hooks/use-catalog-analytics.ts
+++ b/apps/admin/hooks/use-catalog-analytics.ts
@@ -8,38 +8,39 @@ import {
   getCatalogOverview,
   getCatalogPrices,
 } from 'admin-app/lib/api';
+import { queryKeys } from 'admin-app/lib/queryKeys';
 
 export function useCatalogOverview() {
   return useQuery({
-    queryKey: ['catalog', 'overview'],
+    queryKey: queryKeys.catalogAnalytics.overview,
     queryFn: () => getCatalogOverview(),
   });
 }
 
 export function useCatalogBrands(limit = 20) {
   return useQuery({
-    queryKey: ['catalog', 'brands', limit],
+    queryKey: queryKeys.catalogAnalytics.brands(limit),
     queryFn: () => getCatalogBrands(limit),
   });
 }
 
 export function useCatalogPrices() {
   return useQuery({
-    queryKey: ['catalog', 'prices'],
+    queryKey: queryKeys.catalogAnalytics.prices,
     queryFn: () => getCatalogPrices(),
   });
 }
 
 export function useCatalogEtl(limit = 20) {
   return useQuery({
-    queryKey: ['catalog', 'etl', limit],
+    queryKey: queryKeys.catalogAnalytics.etl(limit),
     queryFn: () => getCatalogEtl(limit),
   });
 }
 
 export function useCatalogEmbeddings() {
   return useQuery({
-    queryKey: ['catalog', 'embeddings'],
+    queryKey: queryKeys.catalogAnalytics.embeddings,
     queryFn: () => getCatalogEmbeddings(),
   });
 }

--- a/apps/admin/hooks/use-platform-analytics.ts
+++ b/apps/admin/hooks/use-platform-analytics.ts
@@ -2,24 +2,25 @@
 
 import { useQuery } from '@tanstack/react-query';
 import { getPlatformActivity, getPlatformBreakdown, getPlatformGrowth } from 'admin-app/lib/api';
+import { queryKeys } from 'admin-app/lib/queryKeys';
 
 export function usePlatformGrowth(period: string) {
   return useQuery({
-    queryKey: ['platform', 'growth', period],
+    queryKey: queryKeys.platform.growth(period),
     queryFn: () => getPlatformGrowth(period),
   });
 }
 
 export function usePlatformActivity(period: string) {
   return useQuery({
-    queryKey: ['platform', 'activity', period],
+    queryKey: queryKeys.platform.activity(period),
     queryFn: () => getPlatformActivity(period),
   });
 }
 
 export function usePlatformBreakdown() {
   return useQuery({
-    queryKey: ['platform', 'breakdown'],
+    queryKey: queryKeys.platform.breakdown,
     queryFn: () => getPlatformBreakdown(),
   });
 }

--- a/apps/admin/lib/cfAccess.ts
+++ b/apps/admin/lib/cfAccess.ts
@@ -28,8 +28,8 @@ function fetchIdentity(): Promise<CFAccessIdentityResponse | null> {
       if (
         typeof data !== 'object' ||
         data === null ||
-        typeof (data as Record<string, unknown>)['email'] !== 'string' ||
-        typeof (data as Record<string, unknown>)['jwt'] !== 'string'
+        typeof (data as Record<string, unknown>).email !== 'string' ||
+        typeof (data as Record<string, unknown>).jwt !== 'string'
       ) {
         return null;
       }

--- a/apps/admin/lib/cfAccess.ts
+++ b/apps/admin/lib/cfAccess.ts
@@ -7,12 +7,15 @@
 
 import { useQuery } from '@tanstack/react-query';
 import { queryKeys } from 'admin-app/lib/queryKeys';
+import { z } from 'zod';
 
-export type CFAccessIdentityResponse = {
-  email: string;
-  name: string;
-  jwt: string;
-};
+const CFAccessIdentitySchema = z.object({
+  email: z.string(),
+  name: z.string().optional().default(''),
+  jwt: z.string(),
+});
+
+export type CFAccessIdentityResponse = z.infer<typeof CFAccessIdentitySchema>;
 
 // Cache the in-flight Promise — all concurrent callers share one network request.
 // Avoids thundering-herd on first render when multiple components call simultaneously.
@@ -22,19 +25,11 @@ function fetchIdentity(): Promise<CFAccessIdentityResponse | null> {
   return fetch('/cdn-cgi/access/get-identity', { credentials: 'include' })
     .then((res) => {
       if (!res.ok) return null;
-      return res.json() as Promise<unknown>;
+      return res.json();
     })
     .then((data) => {
-      if (
-        typeof data !== 'object' ||
-        data === null ||
-        typeof (data as Record<string, unknown>).email !== 'string' ||
-        typeof (data as Record<string, unknown>).jwt !== 'string'
-      ) {
-        return null;
-      }
-      const d = data as { email: string; name?: string; jwt: string };
-      return { email: d.email, name: d.name ?? '', jwt: d.jwt };
+      const result = CFAccessIdentitySchema.safeParse(data);
+      return result.success ? result.data : null;
     })
     .catch(() => null);
 }

--- a/apps/admin/lib/cfAccess.ts
+++ b/apps/admin/lib/cfAccess.ts
@@ -5,6 +5,9 @@
 // /cdn-cgi/access/get-identity returns the signed JWT assertion we can forward
 // to the API for cryptographic verification.
 
+import { useQuery } from '@tanstack/react-query';
+import { queryKeys } from 'admin-app/lib/queryKeys';
+
 export type CFAccessIdentityResponse = {
   email: string;
   name: string;
@@ -55,4 +58,23 @@ export async function getCFAccessJWT(): Promise<string | null> {
 /** True when the app is running behind CF Access (identity endpoint responds). */
 export async function isBehindCFAccess(): Promise<boolean> {
   return (await getCFAccessIdentity()) !== null;
+}
+
+/**
+ * TanStack Query hook for the CF Access identity.
+ * - staleTime: Infinity — identity is valid for the page lifetime, no re-fetch needed.
+ * - gcTime: Infinity — don't garbage-collect mid-session when AuthGuard unmounts during navigation.
+ * - retry: false — null means "not behind CF Access" (local dev), not a transient error.
+ *
+ * The underlying Promise memoization in getCFAccessIdentity() still applies — both
+ * layers complement each other during the window before TanStack's cache is populated.
+ */
+export function useCFAccessIdentity() {
+  return useQuery({
+    queryKey: queryKeys.cfAccessIdentity,
+    queryFn: getCFAccessIdentity,
+    staleTime: Infinity,
+    gcTime: Infinity,
+    retry: false,
+  });
 }

--- a/apps/admin/lib/queryKeys.ts
+++ b/apps/admin/lib/queryKeys.ts
@@ -1,0 +1,35 @@
+/**
+ * Centralised query key registry for the admin SPA.
+ *
+ * All useQuery / useInfiniteQuery / invalidateQueries call sites should
+ * reference these constants instead of inlining raw arrays. This makes
+ * key shape changes a one-place edit and prevents typo-driven cache misses.
+ */
+export const queryKeys = {
+  /** CF Access identity — fetched once per page lifetime. */
+  cfAccessIdentity: ['cf-access-identity'] as const,
+
+  /** Admin entity queries (dashboard pages). */
+  admin: {
+    stats: ['admin', 'stats'] as const,
+    users: (limitOrQuery?: number | string) => ['admin', 'users', limitOrQuery] as const,
+    packs: (limitOrQuery?: number | string) => ['admin', 'packs', limitOrQuery] as const,
+    catalog: (limitOrQuery?: number | string) => ['admin', 'catalog', limitOrQuery] as const,
+  },
+
+  /** Platform analytics queries. */
+  platform: {
+    growth: (period: string) => ['platform', 'growth', period] as const,
+    activity: (period: string) => ['platform', 'activity', period] as const,
+    breakdown: ['platform', 'breakdown'] as const,
+  },
+
+  /** Catalog analytics queries. */
+  catalogAnalytics: {
+    overview: ['catalog', 'overview'] as const,
+    brands: (limit?: number) => ['catalog', 'brands', limit] as const,
+    prices: ['catalog', 'prices'] as const,
+    etl: (limit?: number) => ['catalog', 'etl', limit] as const,
+    embeddings: ['catalog', 'embeddings'] as const,
+  },
+} as const;


### PR DESCRIPTION
## Summary

- **`useCFAccessIdentity()` hook** — added to `apps/admin/lib/cfAccess.ts`. Backed by `useQuery` with `staleTime: Infinity`, `gcTime: Infinity`, and `retry: false`. The existing Promise memoization in `getCFAccessIdentity()` is preserved and complements the TanStack cache layer.
- **`apps/admin/lib/queryKeys.ts`** — new centralised query key registry covering `cfAccessIdentity`, `admin.*`, `platform.*`, and `catalogAnalytics.*`. All `useQuery` / `invalidateQueries` call sites now reference `queryKeys.*` instead of inline string arrays.
- **`auth-guard.tsx`** — replaced the `canceled`-flag `useEffect` + `useState(false)` pattern with `useCFAccessIdentity()`. Component returns `null` while the identity is pending or when neither a CF session nor a stored token is present; otherwise renders children.
- **`login/page.tsx`** — replaced `useState<boolean | null>` + raw `useEffect` for CF detection with `useCFAccessIdentity()`. The "Local dev mode" badge is now conditioned on `!cfPending && !cfIdentity`.
- **Dashboard pages + analytics hooks** — updated to reference `queryKeys.*`.

## Zero-behaviour-change checklist

- CF Access session active → skip login page, allow through guard ✓
- Not behind CF Access (local dev) → fall back to stored token check in guard ✓
- Not behind CF Access → show Local dev mode badge on login ✓
- `getCFAccessIdentity()`, `getCFAccessJWT()`, and `isBehindCFAccess()` exports preserved ✓

## Test plan

- [ ] Local dev (`bun dev` in `apps/admin`): login page shows "Local dev mode" badge; login with credentials works; dashboard loads
- [ ] Type-check passes: `bun check-types` from repo root
- [ ] Build passes: `bun build` in `apps/admin`
- [ ] (Production) Behind CF Access: login page redirects immediately to dashboard; guard allows authenticated session through without a stored token

🤖 Generated with [Claude Code](https://claude.com/claude-code)