### PR TITLE
refactor: use zod for CF Access payload validation

### DIFF
--- a/packages/api/src/middleware/cfAccess.ts
+++ b/packages/api/src/middleware/cfAccess.ts
@@ -1,10 +1,9 @@
 import { createRemoteJWKSet, jwtVerify } from 'jose';
+import { z } from 'zod';
 
-export type CFAccessIdentity = {
-  email: string;
-};
+const CFAccessPayloadSchema = z.object({ email: z.string().min(1) });
 
-type CFAccessJWTPayload = { email?: string };
+export type CFAccessIdentity = z.infer<typeof CFAccessPayloadSchema>;
 
 // Module-level singleton — survives across requests on warm isolates.
 // jose caches keys internally by kid; re-fetches only on unknown key rotation.
@@ -38,13 +37,12 @@ export async function verifyCFAccessRequest(
   const token = request.headers.get('cf-access-jwt-assertion');
   if (!token) return null;
   try {
-    const { payload } = await jwtVerify<CFAccessJWTPayload>(token, getJwks(teamDomain), {
+    const { payload } = await jwtVerify(token, getJwks(teamDomain), {
       audience: aud,
       issuer: teamDomain, // CF Access JWT iss == team domain URL
     });
-    const { email } = payload;
-    if (typeof email !== 'string' || email.length === 0) return null;
-    return { email };
+    const result = CFAccessPayloadSchema.safeParse(payload);
+    return result.success ? result.data : null;
   } catch {
     return null;
   }


### PR DESCRIPTION
## Summary

- Replaces manual `typeof` checks in `packages/api/src/middleware/cfAccess.ts` with a Zod schema (`CFAccessPayloadSchema`)
- `CFAccessIdentity` type is now derived from the schema via `z.infer<>`

Companion to the admin SPA change in #2300.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)