### PR TITLE
feat(admin): rate-limit /api/admin/token to 5 req/60s per IP

### DIFF
--- a/apps/expo/features/packs/store/packWeightHistory.ts
+++ b/apps/expo/features/packs/store/packWeightHistory.ts
@@ -19,10 +19,11 @@ const listPackWeightHistories = async () => {
 };
 
 const createPackWeightHistoryEntry = async (packWeightHistoryEntry: PackWeightHistoryEntry) => {
-  const { data, error } = await apiClient.packs({ packId: String(packWeightHistoryEntry.packId) })[
-    // biome-ignore lint/suspicious/noExplicitAny: store shapes diverge from Treaty's strict schema
+  const endpoint = apiClient.packs({ packId: String(packWeightHistoryEntry.packId) })[
     'weight-history'
-  ].post(packWeightHistoryEntry as any);
+  ];
+  // biome-ignore lint/suspicious/noExplicitAny: Treaty client types diverge from actual API schema
+  const { data, error } = await endpoint.post(packWeightHistoryEntry as any);
   if (error) throw new Error(`Failed to create packWeightHistoryEntry: ${error.value}`);
   return data as object | null;
 };

--- a/apps/expo/features/trips/screens/TripWeatherDetailsScreen.tsx
+++ b/apps/expo/features/trips/screens/TripWeatherDetailsScreen.tsx
@@ -5,6 +5,11 @@ import {
   getWeatherData,
   searchLocationsByCoordinates,
 } from 'expo-app/features/weather/lib/weatherService';
+import type {
+  ForecastDay,
+  HourWeather,
+  WeatherApiForecastResponse,
+} from 'expo-app/features/weather/types';
 import { LinearGradient } from 'expo-linear-gradient';
 import { router, Stack, useLocalSearchParams } from 'expo-router';
 import { useEffect, useState } from 'react';
@@ -28,7 +33,7 @@ export default function TripWeatherDetailsScreen() {
   const longitude = Number(lon);
   const tripLocationName = locationName;
 
-  const [weather, setWeather] = useState<any>(null);
+  const [weather, setWeather] = useState<WeatherApiForecastResponse | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [gradientColors, setGradientColors] = useState<[string, string, ...string[]]>([
@@ -89,14 +94,14 @@ export default function TripWeatherDetailsScreen() {
   // Use the trip's location name if provided, otherwise fall back to weather API location
   const displayLocationName = tripLocationName || location.name;
 
-  const hourlyForecast = weather?.forecast?.forecastday?.[0]?.hour?.map((h: any) => ({
+  const hourlyForecast = weather?.forecast?.forecastday?.[0]?.hour?.map((h: HourWeather) => ({
     time: `${new Date(h.time).getHours()}:00`,
     temp: Math.round(h.temp_c),
     weatherCode: h.condition?.code ?? 1000,
     isDay: h.is_day,
   }));
 
-  const dailyForecast = weather?.forecast?.forecastday?.map((fd: any) => ({
+  const dailyForecast = weather?.forecast?.forecastday?.map((fd: ForecastDay) => ({
     day: new Intl.DateTimeFormat('en', { weekday: 'short' }).format(new Date(fd.date)),
     icon: 'weather-partly-cloudy',
     low: Math.round(fd.day.mintemp_c),

--- a/packages/api/src/middleware/cfAccess.ts
+++ b/packages/api/src/middleware/cfAccess.ts
@@ -29,6 +29,7 @@ function getJwks(teamDomain: string): ReturnType<typeof createRemoteJWKSet> {
  * teamDomain must be the full URL: "https://<team>.cloudflareaccess.com"
  * aud is the CF Access Application Audience tag.
  */
+// biome-ignore lint/complexity/useMaxParams: three semantically distinct required params
 export async function verifyCFAccessRequest(
   request: Request,
   teamDomain: string,

--- a/packages/api/src/routes/admin/index.ts
+++ b/packages/api/src/routes/admin/index.ts
@@ -88,6 +88,13 @@ export const adminRoutes = new Elysia({ prefix: '/admin' })
   .post(
     '/token',
     async ({ request }) => {
+      const env = getEnv();
+      if (env.TOKEN_RATE_LIMITER) {
+        const ip = request.headers.get('cf-connecting-ip') ?? 'unknown';
+        const { success } = await env.TOKEN_RATE_LIMITER.limit({ key: ip });
+        if (!success) return status(429, { error: 'Too many requests' });
+      }
+
       const header = request.headers.get('authorization') ?? '';
       if (!header.startsWith('Basic ')) {
         return status(401, { error: 'Missing credentials' });

--- a/packages/api/src/utils/env-validation.ts
+++ b/packages/api/src/utils/env-validation.ts
@@ -22,7 +22,7 @@ export const apiEnvSchema = z.object({
 
   // Cloudflare Zero Trust / Access (optional — enables CF Access JWT verification for admin routes)
   CF_ACCESS_TEAM_DOMAIN: z.string().optional(), // e.g. "packrat.cloudflareaccess.com"
-  CF_ACCESS_AUD: z.string().optional(),          // CF Access policy Application Audience tag
+  CF_ACCESS_AUD: z.string().optional(), // CF Access policy Application Audience tag
 
   // Email Configuration
   EMAIL_PROVIDER: z.enum(['resend', 'sendgrid', 'ses']),
@@ -67,6 +67,8 @@ export const apiEnvSchema = z.object({
   EMBEDDINGS_QUEUE: z.unknown(),
   // App container Durable Object binding (APP_CONTAINER)
   APP_CONTAINER: z.unknown(),
+  // Rate limiting binding (optional — not present in local dev/test)
+  TOKEN_RATE_LIMITER: z.unknown().optional(),
 });
 
 // Relaxed schema for test environments
@@ -101,6 +103,7 @@ export type ValidatedEnv = Omit<
   | 'LOGS_QUEUE'
   | 'EMBEDDINGS_QUEUE'
   | 'APP_CONTAINER'
+  | 'TOKEN_RATE_LIMITER'
 > & {
   CF_VERSION_METADATA: WorkerVersionMetadata;
   AI: Ai;
@@ -111,6 +114,7 @@ export type ValidatedEnv = Omit<
   LOGS_QUEUE: Queue;
   EMBEDDINGS_QUEUE: Queue;
   APP_CONTAINER: DurableObjectNamespace<Container<unknown>>;
+  TOKEN_RATE_LIMITER?: { limit(opts: { key: string }): Promise<{ success: boolean }> };
 };
 
 // Cache for validated envs keyed by the raw env reference.
@@ -148,6 +152,7 @@ function validate(rawEnv: Record<string, unknown>): ValidatedEnv {
     APP_CONTAINER: (rawEnv.APP_CONTAINER ?? validated.data.APP_CONTAINER) as DurableObjectNamespace<
       Container<unknown>
     >,
+    TOKEN_RATE_LIMITER: rawEnv.TOKEN_RATE_LIMITER as ValidatedEnv['TOKEN_RATE_LIMITER'] | undefined,
   } as ValidatedEnv;
 }
 

--- a/packages/api/wrangler.jsonc
+++ b/packages/api/wrangler.jsonc
@@ -25,6 +25,16 @@
   // Cloudflare Zero Trust / Access (optional — set to enable JWT verification on /api/admin/*):
   //   CF_ACCESS_TEAM_DOMAIN=<team>.cloudflareaccess.com
   //   CF_ACCESS_AUD=<Application Audience tag from CF Access dashboard>
+  "rate_limiting": [
+    {
+      "binding": "TOKEN_RATE_LIMITER",
+      "namespace_id": "1",
+      "simple": {
+        "limit": 5,
+        "period": 60
+      }
+    }
+  ],
   "r2_buckets": [
     {
       "binding": "PACKRAT_BUCKET",
@@ -104,6 +114,16 @@
   ],
   "env": {
     "dev": {
+      "rate_limiting": [
+        {
+          "binding": "TOKEN_RATE_LIMITER",
+          "namespace_id": "1",
+          "simple": {
+            "limit": 5,
+            "period": 60
+          }
+        }
+      ],
       "version_metadata": {
         "binding": "CF_VERSION_METADATA"
       },


### PR DESCRIPTION
## Summary

- Adds the CF Workers built-in **Rate Limiting API** binding (`TOKEN_RATE_LIMITER`) to `wrangler.jsonc` (both top-level and `env.dev`)
- Checks the limiter at the start of `POST /api/admin/token` — returns **429** if the per-IP budget (5 req / 60s) is exhausted, before any credential evaluation happens
- Binding typed as optional in `ValidatedEnv` so local dev and tests work without a CF environment

## Why

`/api/admin/token` is the Basic-auth → JWT exchange endpoint. Without rate limiting it's wide open to brute-force. CF's native rate limiting enforces the cap at the edge for zero latency overhead.

## Testing

- `TOKEN_RATE_LIMITER` is absent in test env → rate-limit branch is skipped, no test changes required
- Manual: deploy + send 6 rapid POSTs to `/api/admin/token` → 6th returns 429

## Post-Deploy Monitoring & Validation

- **Logs**: search `"Too many requests"` in Cloudflare Workers tail logs on `packrat-api`
- **Expected healthy behavior**: 5 requests/60s per IP pass; 6th gets 429
- **Failure signal**: repeated 401s with no 429s after 6+ rapid attempts from the same IP → rate limiter binding may not be provisioned
- **Rollback**: remove `TOKEN_RATE_LIMITER` check in `admin/index.ts` and redeploy

---

[![Compound Engineered](https://img.shields.io/badge/Compound-Engineered-6366f1)](https://github.com/EveryInc/compound-engineering-plugin) 🤖 Generated with [Claude Code](https://claude.com/claude-code)