### PR TITLE
refactor(admin): migrate CF Access identity fetch to TanStack Query

### DIFF
--- a/apps/expo/features/auth/hooks/useAuthActions.ts
+++ b/apps/expo/features/auth/hooks/useAuthActions.ts
@@ -5,6 +5,7 @@ import {
   statusCodes,
 } from '@react-native-google-signin/google-signin';
 import { userStore } from 'expo-app/features/auth/store';
+import type { User } from 'expo-app/features/profile/types';
 import { apiClient } from 'expo-app/lib/api/packrat';
 import { t } from 'expo-app/lib/i18n';
 import ImageCacheManager from 'expo-app/lib/utils/ImageCacheManager';
@@ -64,7 +65,7 @@ export function useAuthActions() {
 
       await setToken(data.accessToken);
       await setRefreshToken(data.refreshToken);
-      userStore.set(data.user);
+      userStore.set(data.user as unknown as User);
       setNeedsReauth(false);
       redirect(redirectTo);
     } catch (error) {
@@ -94,7 +95,7 @@ export function useAuthActions() {
 
       await setToken(data.accessToken);
       await setRefreshToken(data.refreshToken);
-      userStore.set(data.user);
+      userStore.set(data.user as unknown as User);
       setNeedsReauth(false);
       redirect(redirectTo);
     } catch (error) {
@@ -140,7 +141,7 @@ export function useAuthActions() {
 
       await setToken(data.accessToken);
       await setRefreshToken(data.refreshToken);
-      userStore.set(data.user);
+      userStore.set(data.user as unknown as User);
       setNeedsReauth(false);
       redirect(redirectTo);
     } catch (error) {
@@ -246,7 +247,7 @@ export function useAuthActions() {
         await Storage.setItem('refresh_token', data.refreshToken);
         await setToken(data.accessToken);
         await setRefreshToken(data.refreshToken);
-        userStore.set(data.user);
+        userStore.set(data.user as unknown as User);
         redirect(redirectTo);
       }
 

--- a/apps/expo/features/auth/hooks/useAuthActions.ts
+++ b/apps/expo/features/auth/hooks/useAuthActions.ts
@@ -164,7 +164,12 @@ export function useAuthActions() {
   }) => {
     setIsLoading(true);
     try {
-      const { error } = await apiClient.auth.register.post({ email, password, firstName, lastName });
+      const { error } = await apiClient.auth.register.post({
+        email,
+        password,
+        firstName,
+        lastName,
+      });
       if (error) {
         throw new Error(extractAuthError(error.value, t('auth.registrationFailed')));
       }

--- a/apps/expo/features/auth/hooks/useAuthActions.ts
+++ b/apps/expo/features/auth/hooks/useAuthActions.ts
@@ -1,4 +1,3 @@
-import { clientEnvs } from '@packrat/env/expo-client';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import {
   GoogleSignin,
@@ -31,6 +30,13 @@ function redirect(route: string) {
   }
 }
 
+function extractAuthError(value: unknown, fallback: string): string {
+  if (typeof value === 'object' && value !== null && 'error' in value) {
+    return String((value as Record<string, unknown>).error) || fallback;
+  }
+  return fallback;
+}
+
 export function useAuthActions() {
   const setToken = useSetAtom(tokenAtom);
   const setRefreshToken = useSetAtom(refreshTokenAtom);
@@ -51,29 +57,15 @@ export function useAuthActions() {
   const signIn = async (email: string, password: string) => {
     setIsLoading(true);
     try {
-      const response = await fetch(`${clientEnvs.EXPO_PUBLIC_API_URL}/api/auth/login`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({ email, password }),
-      });
-
-      const data = await response.json();
-
-      if (!response.ok) {
-        throw new Error(data.error || t('auth.failedToSignIn'));
+      const { data, error } = await apiClient.auth.login.post({ email, password });
+      if (error || !data) {
+        throw new Error(extractAuthError(error?.value, t('auth.failedToSignIn')));
       }
-
-      console.log(data.accessToken, data.refreshToken);
 
       await setToken(data.accessToken);
       await setRefreshToken(data.refreshToken);
       userStore.set(data.user);
-
-      // Reset re-authentication state
       setNeedsReauth(false);
-
       redirect(redirectTo);
     } catch (error) {
       console.error('Sign in error:', error);
@@ -87,41 +79,23 @@ export function useAuthActions() {
     try {
       setIsLoading(true);
 
-      // Check if user is already signed in to Google
       await GoogleSignin.hasPlayServices();
-
-      // Sign in with Google
       const _userInfo = await GoogleSignin.signIn();
-
-      // Get the ID token
       const { idToken } = await GoogleSignin.getTokens();
 
       if (!idToken) {
         throw new Error(t('auth.noIdTokenFromGoogle'));
       }
 
-      // Send the token to backend
-      const response = await fetch(`${clientEnvs.EXPO_PUBLIC_API_URL}/api/auth/google`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({ idToken }),
-      });
-
-      const data = await response.json();
-
-      if (!response.ok) {
-        throw new Error(data.error || t('auth.failedToSignInWithGoogle'));
+      const { data, error } = await apiClient.auth.google.post({ idToken });
+      if (error || !data) {
+        throw new Error(extractAuthError(error?.value, t('auth.failedToSignInWithGoogle')));
       }
 
       await setToken(data.accessToken);
       await setRefreshToken(data.refreshToken);
       userStore.set(data.user);
-
-      // Reset re-authentication state
       setNeedsReauth(false);
-
       redirect(redirectTo);
     } catch (error) {
       setIsLoading(false);
@@ -156,31 +130,18 @@ export function useAuthActions() {
         ],
       });
 
-      // Send the identity token to your backend
-      const response = await fetch(`${clientEnvs.EXPO_PUBLIC_API_URL}/api/auth/apple`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({
-          identityToken: credential.identityToken,
-          authorizationCode: credential.authorizationCode,
-        }),
+      const { data, error } = await apiClient.auth.apple.post({
+        identityToken: credential.identityToken ?? '',
+        authorizationCode: credential.authorizationCode ?? '',
       });
-
-      const data = await response.json();
-
-      if (!response.ok) {
-        throw new Error(data.error || t('auth.failedToSignInWithApple'));
+      if (error || !data) {
+        throw new Error(extractAuthError(error?.value, t('auth.failedToSignInWithApple')));
       }
 
       await setToken(data.accessToken);
       await setRefreshToken(data.refreshToken);
       userStore.set(data.user);
-
-      // Reset re-authentication state
       setNeedsReauth(false);
-
       redirect(redirectTo);
     } catch (error) {
       console.error('Apple sign in error:', error);
@@ -203,18 +164,9 @@ export function useAuthActions() {
   }) => {
     setIsLoading(true);
     try {
-      const response = await fetch(`${clientEnvs.EXPO_PUBLIC_API_URL}/api/auth/register`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({ email, password, firstName, lastName }),
-      });
-
-      const responseData = await response.json();
-
-      if (!response.ok) {
-        throw new Error(responseData.error || t('auth.registrationFailed'));
+      const { error } = await apiClient.auth.register.post({ email, password, firstName, lastName });
+      if (error) {
+        throw new Error(extractAuthError(error.value, t('auth.registrationFailed')));
       }
     } catch (error) {
       console.error('Registration error:', error instanceof Error ? error.message : String(error));
@@ -227,27 +179,17 @@ export function useAuthActions() {
   const signOut = async () => {
     setIsLoading(true);
     try {
-      // Sign out from Google if signed in
       const isSignedIn = await GoogleSignin.hasPreviousSignIn();
       if (isSignedIn) {
         await GoogleSignin.signOut();
       }
 
-      // Get the refresh token
       if (refreshToken) {
-        // Call the logout endpoint to revoke the refresh token
-        await fetch(`${clientEnvs.EXPO_PUBLIC_API_URL}/api/auth/logout`, {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-          },
-          body: JSON.stringify({ refreshToken }),
-        });
+        await apiClient.auth.logout.post({ refreshToken });
       }
     } catch (error) {
       console.error('Sign out error:', error);
     } finally {
-      // Clear tokens and user data
       setToken(null);
       setRefreshToken(null);
       await clearLocalData();
@@ -258,20 +200,10 @@ export function useAuthActions() {
 
   const forgotPassword = async (email: string) => {
     try {
-      const response = await fetch(`${clientEnvs.EXPO_PUBLIC_API_URL}/api/auth/forgot-password`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({ email }),
-      });
-
-      const data = await response.json();
-
-      if (!response.ok) {
-        throw new Error(data.error || t('auth.failedToProcessRequest'));
+      const { data, error } = await apiClient.auth['forgot-password'].post({ email });
+      if (error || !data) {
+        throw new Error(extractAuthError(error?.value, t('auth.failedToProcessRequest')));
       }
-
       return data;
     } catch (error) {
       console.error('Forgot password error:', error);
@@ -282,20 +214,14 @@ export function useAuthActions() {
   const resetPassword = async (email: string, opts: { code: string; newPassword: string }) => {
     const { code, newPassword } = opts;
     try {
-      const response = await fetch(`${clientEnvs.EXPO_PUBLIC_API_URL}/api/auth/reset-password`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({ email, code, newPassword }),
+      const { data, error } = await apiClient.auth['reset-password'].post({
+        email,
+        code,
+        newPassword,
       });
-
-      const data = await response.json();
-
-      if (!response.ok) {
-        throw new Error(data.error || t('auth.resetPasswordFailed'));
+      if (error || !data) {
+        throw new Error(extractAuthError(error?.value, t('auth.resetPasswordFailed')));
       }
-
       return data;
     } catch (error) {
       console.error('Reset password error:', error);
@@ -305,25 +231,14 @@ export function useAuthActions() {
 
   const verifyEmail = async (email: string, code: string) => {
     try {
-      const response = await fetch(`${clientEnvs.EXPO_PUBLIC_API_URL}/api/auth/verify-email`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({ email, code }),
-      });
-
-      const data = await response.json();
-
-      if (!response.ok) {
-        throw new Error(data.error || t('auth.failedToVerifyEmail'));
+      const { data, error } = await apiClient.auth['verify-email'].post({ email, code });
+      if (error || !data) {
+        throw new Error(extractAuthError(error?.value, t('auth.failedToVerifyEmail')));
       }
 
-      // If verification is successful, set the user and tokens
       if (data.accessToken && data.refreshToken && data.user) {
         await Storage.setItem('access_token', data.accessToken);
         await Storage.setItem('refresh_token', data.refreshToken);
-
         await setToken(data.accessToken);
         await setRefreshToken(data.refreshToken);
         userStore.set(data.user);
@@ -339,23 +254,10 @@ export function useAuthActions() {
 
   const resendVerificationEmail = async (email: string) => {
     try {
-      const response = await fetch(
-        `${clientEnvs.EXPO_PUBLIC_API_URL}/api/auth/resend-verification`,
-        {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-          },
-          body: JSON.stringify({ email }),
-        },
-      );
-
-      const data = await response.json();
-
-      if (!response.ok) {
-        throw new Error(data.error || t('auth.failedToResendVerificationEmail'));
+      const { data, error } = await apiClient.auth['resend-verification'].post({ email });
+      if (error || !data) {
+        throw new Error(extractAuthError(error?.value, t('auth.failedToResendVerificationEmail')));
       }
-
       return data;
     } catch (error) {
       console.error('Resend verification email error:', error);
@@ -371,7 +273,6 @@ export function useAuthActions() {
         throw new Error(String(error.value ?? t('auth.failedToDeleteAccount')));
       }
 
-      // Clear tokens and user data
       setToken(null);
       setRefreshToken(null);
       await clearLocalData();

--- a/apps/expo/features/catalog/hooks/useCatalogItems.ts
+++ b/apps/expo/features/catalog/hooks/useCatalogItems.ts
@@ -1,6 +1,6 @@
+import { CatalogItemsResponseSchema } from '@packrat/api/schemas/catalog';
 import { useInfiniteQuery } from '@tanstack/react-query';
 import { apiClient } from 'expo-app/lib/api/packrat';
-import type { PaginatedCatalogItemsResponse } from '../types';
 
 type CatalogSortField =
   | 'name'
@@ -26,7 +26,7 @@ export const getCatalogItems = async ({
   category,
   limit,
   sort,
-}: GetCatalogItemsParams): Promise<PaginatedCatalogItemsResponse> => {
+}: GetCatalogItemsParams) => {
   const { data, error } = await apiClient.catalog.get({
     query: {
       page: pageParam,
@@ -37,9 +37,7 @@ export const getCatalogItems = async ({
     },
   });
   if (error) throw new Error(`Failed to fetch catalog items: ${error.value}`);
-  // Treaty infers the wider Drizzle row shape; consumers expect the local
-  // `CatalogItem` projection. Bridge with an explicit assertion.
-  return data as unknown as PaginatedCatalogItemsResponse;
+  return CatalogItemsResponseSchema.parse(data);
 };
 
 export function useCatalogItemsInfinite({ query, category, limit, sort }: GetCatalogItemsParams) {

--- a/apps/expo/features/pack-templates/store/packTemplateItems.ts
+++ b/apps/expo/features/pack-templates/store/packTemplateItems.ts
@@ -2,15 +2,16 @@ import { observable, syncState } from '@legendapp/state';
 import { observablePersistSqlite } from '@legendapp/state/persist-plugins/expo-sqlite';
 import { syncObservable } from '@legendapp/state/sync';
 import { syncedCrud } from '@legendapp/state/sync-plugins/crud';
+import { PackTemplateItemSchema, PackTemplateWithItemsSchema } from '@packrat/api/schemas/packTemplates';
 import { isAuthed } from 'expo-app/features/auth/store';
 import { apiClient } from 'expo-app/lib/api/packrat';
 import Storage from 'expo-sqlite/kv-store';
-import type { PackTemplate, PackTemplateItem } from '../types';
+import type { PackTemplateItem } from '../types';
 
 const listAllPackTemplateItems = async (): Promise<PackTemplateItem[]> => {
   const { data, error } = await apiClient['pack-templates'].get();
   if (error) throw new Error(`Failed to list PackTemplateItems: ${error.value}`);
-  return ((data as unknown as PackTemplate[]) ?? []).flatMap((template) => template.items);
+  return PackTemplateWithItemsSchema.array().parse(data).flatMap((template) => template.items);
 };
 
 const createPackTemplateItem = async (item: PackTemplateItem): Promise<PackTemplateItem> => {
@@ -30,7 +31,7 @@ const createPackTemplateItem = async (item: PackTemplateItem): Promise<PackTempl
     notes: item.notes,
   });
   if (error) throw new Error(`Failed to create pack template item: ${error.value}`);
-  return data as unknown as PackTemplateItem;
+  return PackTemplateItemSchema.parse(data);
 };
 
 const updatePackTemplateItem = async ({
@@ -57,7 +58,7 @@ const updatePackTemplateItem = async ({
       deleted: data.deleted,
     });
   if (error) throw new Error(`Failed to update pack template item: ${error.value}`);
-  return result as unknown as PackTemplateItem;
+  return PackTemplateItemSchema.parse(result);
 };
 
 // Local observable store

--- a/apps/expo/features/pack-templates/store/packTemplateItems.ts
+++ b/apps/expo/features/pack-templates/store/packTemplateItems.ts
@@ -14,7 +14,9 @@ import type { PackTemplateItem } from '../types';
 const listAllPackTemplateItems = async (): Promise<PackTemplateItem[]> => {
   const { data, error } = await apiClient['pack-templates'].get();
   if (error) throw new Error(`Failed to list PackTemplateItems: ${error.value}`);
-  return PackTemplateWithItemsSchema.array().parse(data).flatMap((template) => template.items);
+  return PackTemplateWithItemsSchema.array()
+    .parse(data)
+    .flatMap((template) => template.items);
 };
 
 const createPackTemplateItem = async (item: PackTemplateItem): Promise<PackTemplateItem> => {

--- a/apps/expo/features/pack-templates/store/packTemplateItems.ts
+++ b/apps/expo/features/pack-templates/store/packTemplateItems.ts
@@ -16,7 +16,7 @@ const listAllPackTemplateItems = async (): Promise<PackTemplateItem[]> => {
   if (error) throw new Error(`Failed to list PackTemplateItems: ${error.value}`);
   return PackTemplateWithItemsSchema.array()
     .parse(data)
-    .flatMap((template) => template.items);
+    .flatMap((template) => template.items) as unknown as PackTemplateItem[];
 };
 
 const createPackTemplateItem = async (item: PackTemplateItem): Promise<PackTemplateItem> => {
@@ -36,7 +36,7 @@ const createPackTemplateItem = async (item: PackTemplateItem): Promise<PackTempl
     notes: item.notes,
   });
   if (error) throw new Error(`Failed to create pack template item: ${error.value}`);
-  return PackTemplateItemSchema.parse(data);
+  return PackTemplateItemSchema.parse(data) as unknown as PackTemplateItem;
 };
 
 const updatePackTemplateItem = async ({
@@ -63,7 +63,7 @@ const updatePackTemplateItem = async ({
       deleted: data.deleted,
     });
   if (error) throw new Error(`Failed to update pack template item: ${error.value}`);
-  return PackTemplateItemSchema.parse(result);
+  return PackTemplateItemSchema.parse(result) as unknown as PackTemplateItem;
 };
 
 // Local observable store

--- a/apps/expo/features/pack-templates/store/packTemplateItems.ts
+++ b/apps/expo/features/pack-templates/store/packTemplateItems.ts
@@ -2,7 +2,10 @@ import { observable, syncState } from '@legendapp/state';
 import { observablePersistSqlite } from '@legendapp/state/persist-plugins/expo-sqlite';
 import { syncObservable } from '@legendapp/state/sync';
 import { syncedCrud } from '@legendapp/state/sync-plugins/crud';
-import { PackTemplateItemSchema, PackTemplateWithItemsSchema } from '@packrat/api/schemas/packTemplates';
+import {
+  PackTemplateItemSchema,
+  PackTemplateWithItemsSchema,
+} from '@packrat/api/schemas/packTemplates';
 import { isAuthed } from 'expo-app/features/auth/store';
 import { apiClient } from 'expo-app/lib/api/packrat';
 import Storage from 'expo-sqlite/kv-store';

--- a/apps/expo/features/pack-templates/store/packTemplates.ts
+++ b/apps/expo/features/pack-templates/store/packTemplates.ts
@@ -2,6 +2,7 @@ import { observable, syncState } from '@legendapp/state';
 import { observablePersistSqlite } from '@legendapp/state/persist-plugins/expo-sqlite';
 import { syncObservable } from '@legendapp/state/sync';
 import { syncedCrud } from '@legendapp/state/sync-plugins/crud';
+import { PackTemplateSchema, PackTemplateWithItemsSchema } from '@packrat/api/schemas/packTemplates';
 import { isAuthed } from 'expo-app/features/auth/store';
 import { apiClient } from 'expo-app/lib/api/packrat';
 import Storage from 'expo-sqlite/kv-store';
@@ -10,7 +11,7 @@ import type { PackTemplate, PackTemplateInStore } from '../types';
 const listPackTemplates = async () => {
   const { data, error } = await apiClient['pack-templates'].get();
   if (error) throw new Error(`Failed to list pack templates: ${error.value}`);
-  return data as object[] | null;
+  return PackTemplateWithItemsSchema.array().parse(data);
 };
 
 const createPackTemplate = async (templateData: PackTemplate) => {
@@ -28,7 +29,7 @@ const createPackTemplate = async (templateData: PackTemplate) => {
     localUpdatedAt: templateData.localUpdatedAt ?? new Date().toISOString(),
   });
   if (error) throw new Error(`Failed to create pack template: ${error.value}`);
-  return data as object | null;
+  return PackTemplateSchema.parse(data);
 };
 
 const updatePackTemplate = async ({ id, ...data }: Partial<PackTemplate>) => {
@@ -48,7 +49,7 @@ const updatePackTemplate = async ({ id, ...data }: Partial<PackTemplate>) => {
     ...(data.localUpdatedAt ? { localUpdatedAt: data.localUpdatedAt } : {}),
   });
   if (error) throw new Error(`Failed to update pack template: ${error.value}`);
-  return result as object | null;
+  return PackTemplateSchema.parse(result);
 };
 
 export const packTemplatesStore = observable<Record<string, PackTemplateInStore>>({});

--- a/apps/expo/features/pack-templates/store/packTemplates.ts
+++ b/apps/expo/features/pack-templates/store/packTemplates.ts
@@ -11,13 +11,15 @@ import { apiClient } from 'expo-app/lib/api/packrat';
 import Storage from 'expo-sqlite/kv-store';
 import type { PackTemplate, PackTemplateInStore } from '../types';
 
-const listPackTemplates = async () => {
+const listPackTemplates = async (): Promise<PackTemplateInStore[] | null> => {
   const { data, error } = await apiClient['pack-templates'].get();
   if (error) throw new Error(`Failed to list pack templates: ${error.value}`);
-  return PackTemplateWithItemsSchema.array().parse(data);
+  return PackTemplateWithItemsSchema.array().parse(data) as unknown as PackTemplateInStore[];
 };
 
-const createPackTemplate = async (templateData: PackTemplate) => {
+const createPackTemplate = async (
+  templateData: PackTemplate,
+): Promise<PackTemplateInStore | null> => {
   const { data, error } = await apiClient['pack-templates'].post({
     id: templateData.id,
     name: templateData.name,
@@ -32,10 +34,13 @@ const createPackTemplate = async (templateData: PackTemplate) => {
     localUpdatedAt: templateData.localUpdatedAt ?? new Date().toISOString(),
   });
   if (error) throw new Error(`Failed to create pack template: ${error.value}`);
-  return PackTemplateSchema.parse(data);
+  return PackTemplateSchema.parse(data) as unknown as PackTemplateInStore;
 };
 
-const updatePackTemplate = async ({ id, ...data }: Partial<PackTemplate>) => {
+const updatePackTemplate = async ({
+  id,
+  ...data
+}: Partial<PackTemplate>): Promise<PackTemplateInStore | null> => {
   // Server's UpdatePackTemplateRequestSchema requires `description`, `image`,
   // `tags` to be present (they're nullable). Forward what we have, defaulting
   // to null when the field is omitted from the partial update.
@@ -52,7 +57,7 @@ const updatePackTemplate = async ({ id, ...data }: Partial<PackTemplate>) => {
     ...(data.localUpdatedAt ? { localUpdatedAt: data.localUpdatedAt } : {}),
   });
   if (error) throw new Error(`Failed to update pack template: ${error.value}`);
-  return PackTemplateSchema.parse(result);
+  return PackTemplateSchema.parse(result) as unknown as PackTemplateInStore;
 };
 
 export const packTemplatesStore = observable<Record<string, PackTemplateInStore>>({});

--- a/apps/expo/features/pack-templates/store/packTemplates.ts
+++ b/apps/expo/features/pack-templates/store/packTemplates.ts
@@ -2,7 +2,10 @@ import { observable, syncState } from '@legendapp/state';
 import { observablePersistSqlite } from '@legendapp/state/persist-plugins/expo-sqlite';
 import { syncObservable } from '@legendapp/state/sync';
 import { syncedCrud } from '@legendapp/state/sync-plugins/crud';
-import { PackTemplateSchema, PackTemplateWithItemsSchema } from '@packrat/api/schemas/packTemplates';
+import {
+  PackTemplateSchema,
+  PackTemplateWithItemsSchema,
+} from '@packrat/api/schemas/packTemplates';
 import { isAuthed } from 'expo-app/features/auth/store';
 import { apiClient } from 'expo-app/lib/api/packrat';
 import Storage from 'expo-sqlite/kv-store';

--- a/apps/expo/features/packs/hooks/usePackDetailsFromApi.ts
+++ b/apps/expo/features/packs/hooks/usePackDetailsFromApi.ts
@@ -1,12 +1,12 @@
+import { PackWithWeightsSchema } from '@packrat/api/schemas/packs';
 import { useQuery } from '@tanstack/react-query';
 import { apiClient } from 'expo-app/lib/api/packrat';
 import { useAuthenticatedQueryToolkit } from 'expo-app/lib/hooks/useAuthenticatedQueryToolkit';
-import type { Pack } from 'expo-app/types';
 
-const fetchPackById = async (id: string): Promise<Pack> => {
+const fetchPackById = async (id: string) => {
   const { data, error } = await apiClient.packs({ packId: id }).get();
   if (error) throw new Error(`Failed to fetch pack: ${error.value}`);
-  return data as unknown as Pack;
+  return PackWithWeightsSchema.parse(data);
 };
 
 export function usePackDetailsFromApi({ id, enabled }: { id: string; enabled: boolean }) {

--- a/apps/expo/features/packs/hooks/usePackItemDetailsFromApi.ts
+++ b/apps/expo/features/packs/hooks/usePackItemDetailsFromApi.ts
@@ -2,11 +2,12 @@ import { PackItemSchema } from '@packrat/api/schemas/packs';
 import { useQuery } from '@tanstack/react-query';
 import { apiClient } from 'expo-app/lib/api/packrat';
 import { useAuthenticatedQueryToolkit } from 'expo-app/lib/hooks/useAuthenticatedQueryToolkit';
+import type { PackItem } from '../types';
 
 export async function fetchPackItemById(id: string) {
   const { data, error } = await apiClient.packs.items({ itemId: id }).get();
   if (error) throw new Error(`Failed to fetch pack item: ${error.value}`);
-  return PackItemSchema.parse(data);
+  return PackItemSchema.parse(data) as unknown as PackItem;
 }
 
 export function usePackItemDetailsFromApi({ id, enabled }: { id: string; enabled: boolean }) {

--- a/apps/expo/features/packs/hooks/usePackItemDetailsFromApi.ts
+++ b/apps/expo/features/packs/hooks/usePackItemDetailsFromApi.ts
@@ -1,12 +1,12 @@
+import { PackItemSchema } from '@packrat/api/schemas/packs';
 import { useQuery } from '@tanstack/react-query';
-import type { PackItem } from 'expo-app/features/packs/types';
 import { apiClient } from 'expo-app/lib/api/packrat';
 import { useAuthenticatedQueryToolkit } from 'expo-app/lib/hooks/useAuthenticatedQueryToolkit';
 
-export async function fetchPackItemById(id: string): Promise<PackItem> {
+export async function fetchPackItemById(id: string) {
   const { data, error } = await apiClient.packs.items({ itemId: id }).get();
   if (error) throw new Error(`Failed to fetch pack item: ${error.value}`);
-  return data as unknown as PackItem;
+  return PackItemSchema.parse(data);
 }
 
 export function usePackItemDetailsFromApi({ id, enabled }: { id: string; enabled: boolean }) {

--- a/apps/expo/features/packs/store/packItems.ts
+++ b/apps/expo/features/packs/store/packItems.ts
@@ -13,7 +13,9 @@ import { uploadImage } from '../utils';
 const listAllPackItems = async () => {
   const { data, error } = await apiClient.packs.get({ query: { includePublic: 0 } });
   if (error) throw new Error(`Failed to list packitems: ${error.value}`);
-  return PackWithWeightsSchema.array().parse(data).flatMap((pack) => pack.items ?? []);
+  return PackWithWeightsSchema.array()
+    .parse(data)
+    .flatMap((pack) => pack.items ?? []);
 };
 
 const createPackItem = async ({ packId, ...data }: PackItem) => {

--- a/apps/expo/features/packs/store/packItems.ts
+++ b/apps/expo/features/packs/store/packItems.ts
@@ -10,15 +10,15 @@ import Storage from 'expo-sqlite/kv-store';
 import type { PackItem } from '../types';
 import { uploadImage } from '../utils';
 
-const listAllPackItems = async () => {
+const listAllPackItems = async (): Promise<PackItem[] | null> => {
   const { data, error } = await apiClient.packs.get({ query: { includePublic: 0 } });
   if (error) throw new Error(`Failed to list packitems: ${error.value}`);
   return PackWithWeightsSchema.array()
     .parse(data)
-    .flatMap((pack) => pack.items ?? []);
+    .flatMap((pack) => pack.items ?? []) as unknown as PackItem[];
 };
 
-const createPackItem = async ({ packId, ...data }: PackItem) => {
+const createPackItem = async ({ packId, ...data }: PackItem): Promise<PackItem | null> => {
   if (data.image) {
     await uploadImage(data.image, `${ImageCacheManager.cacheDirectory}${data.image}`);
   }
@@ -26,16 +26,16 @@ const createPackItem = async ({ packId, ...data }: PackItem) => {
     .packs({ packId: String(packId) })
     .items.post(data);
   if (error) throw new Error(`Failed to create pack item: ${error.value}`);
-  return PackItemSchema.parse(result);
+  return PackItemSchema.parse(result) as unknown as PackItem;
 };
 
-const updatePackItem = async ({ id, ...data }: PackItem) => {
+const updatePackItem = async ({ id, ...data }: PackItem): Promise<PackItem | null> => {
   if (data.image) {
     await uploadImage(data.image, `${ImageCacheManager.cacheDirectory}${data.image}`);
   }
   const { data: result, error } = await apiClient.packs.items({ itemId: String(id) }).patch(data);
   if (error) throw new Error(`Failed to update pack item: ${error.value}`);
-  return PackItemSchema.parse(result);
+  return PackItemSchema.parse(result) as unknown as PackItem;
 };
 
 export const packItemsStore = observable<Record<string, PackItem>>({});

--- a/apps/expo/features/packs/store/packItems.ts
+++ b/apps/expo/features/packs/store/packItems.ts
@@ -6,13 +6,14 @@ import { isAuthed } from 'expo-app/features/auth/store';
 import { apiClient } from 'expo-app/lib/api/packrat';
 import ImageCacheManager from 'expo-app/lib/utils/ImageCacheManager';
 import Storage from 'expo-sqlite/kv-store';
-import type { Pack, PackItem } from '../types';
+import { PackItemSchema, PackWithWeightsSchema } from '@packrat/api/schemas/packs';
+import type { PackItem } from '../types';
 import { uploadImage } from '../utils';
 
 const listAllPackItems = async () => {
   const { data, error } = await apiClient.packs.get({ query: { includePublic: 0 } });
   if (error) throw new Error(`Failed to list packitems: ${error.value}`);
-  return ((data as unknown as Pack[]) ?? []).flatMap((pack) => pack.items) as object[];
+  return PackWithWeightsSchema.array().parse(data).flatMap((pack) => pack.items ?? []);
 };
 
 const createPackItem = async ({ packId, ...data }: PackItem) => {
@@ -23,7 +24,7 @@ const createPackItem = async ({ packId, ...data }: PackItem) => {
     .packs({ packId: String(packId) })
     .items.post(data);
   if (error) throw new Error(`Failed to create pack item: ${error.value}`);
-  return result as object | null;
+  return PackItemSchema.parse(result);
 };
 
 const updatePackItem = async ({ id, ...data }: PackItem) => {
@@ -32,7 +33,7 @@ const updatePackItem = async ({ id, ...data }: PackItem) => {
   }
   const { data: result, error } = await apiClient.packs.items({ itemId: String(id) }).patch(data);
   if (error) throw new Error(`Failed to update pack item: ${error.value}`);
-  return result as object | null;
+  return PackItemSchema.parse(result);
 };
 
 export const packItemsStore = observable<Record<string, PackItem>>({});

--- a/apps/expo/features/packs/store/packItems.ts
+++ b/apps/expo/features/packs/store/packItems.ts
@@ -2,11 +2,11 @@ import { observable, syncState } from '@legendapp/state';
 import { observablePersistSqlite } from '@legendapp/state/persist-plugins/expo-sqlite';
 import { syncObservable } from '@legendapp/state/sync';
 import { syncedCrud } from '@legendapp/state/sync-plugins/crud';
+import { PackItemSchema, PackWithWeightsSchema } from '@packrat/api/schemas/packs';
 import { isAuthed } from 'expo-app/features/auth/store';
 import { apiClient } from 'expo-app/lib/api/packrat';
 import ImageCacheManager from 'expo-app/lib/utils/ImageCacheManager';
 import Storage from 'expo-sqlite/kv-store';
-import { PackItemSchema, PackWithWeightsSchema } from '@packrat/api/schemas/packs';
 import type { PackItem } from '../types';
 import { uploadImage } from '../utils';
 

--- a/apps/expo/features/packs/store/packWeightHistory.ts
+++ b/apps/expo/features/packs/store/packWeightHistory.ts
@@ -2,6 +2,7 @@ import { observable, syncState } from '@legendapp/state';
 import { observablePersistSqlite } from '@legendapp/state/persist-plugins/expo-sqlite';
 import { syncObservable } from '@legendapp/state/sync';
 import { syncedCrud } from '@legendapp/state/sync-plugins/crud';
+import { PackWeightHistoryResponseSchema } from '@packrat/api/schemas/packs';
 import { isAuthed } from 'expo-app/features/auth/store';
 import { apiClient } from 'expo-app/lib/api/packrat';
 import { obs } from 'expo-app/lib/store';
@@ -15,17 +16,20 @@ import { packsStore } from './packs';
 const listPackWeightHistories = async () => {
   const { data, error } = await apiClient.packs['weight-history'].get();
   if (error) throw new Error(`Failed to list packWeightHistories: ${error.value}`);
-  return data as object[] | null;
+  return PackWeightHistoryResponseSchema.array().parse(data);
 };
 
 const createPackWeightHistoryEntry = async (packWeightHistoryEntry: PackWeightHistoryEntry) => {
   const endpoint = apiClient.packs({ packId: String(packWeightHistoryEntry.packId) })[
     'weight-history'
   ];
-  // biome-ignore lint/suspicious/noExplicitAny: Treaty client types diverge from actual API schema
-  const { data, error } = await endpoint.post(packWeightHistoryEntry as any);
+  const { data, error } = await endpoint.post({
+    id: packWeightHistoryEntry.id,
+    weight: packWeightHistoryEntry.weight,
+    localCreatedAt: packWeightHistoryEntry.localCreatedAt ?? new Date().toISOString(),
+  });
   if (error) throw new Error(`Failed to create packWeightHistoryEntry: ${error.value}`);
-  return data as object | null;
+  return PackWeightHistoryResponseSchema.array().parse(data)[0] ?? null;
 };
 
 export const packWeigthHistoryStore = observable<Record<string, PackWeightHistoryEntry>>({});
@@ -43,7 +47,7 @@ syncObservable(
     waitFor: isAuthed,
     waitForSet: isAuthed,
     retry: {
-      infinite: true, // Keep retrying until it saves
+      infinite: true,
       backoff: 'exponential',
       maxDelay: 30000,
     },
@@ -53,7 +57,7 @@ syncObservable(
     subscribe: ({ refresh }) => {
       const intervalId = setInterval(() => {
         refresh();
-      }, 30000); // 30 seconds interval
+      }, 30000);
 
       return () => {
         clearInterval(intervalId);

--- a/apps/expo/features/packs/store/packs.ts
+++ b/apps/expo/features/packs/store/packs.ts
@@ -8,13 +8,13 @@ import { apiClient } from 'expo-app/lib/api/packrat';
 import Storage from 'expo-sqlite/kv-store';
 import type { PackInStore } from '../types';
 
-const listPacks = async () => {
+const listPacks = async (): Promise<PackInStore[] | null> => {
   const { data, error } = await apiClient.packs.get({ query: { includePublic: 0 } });
   if (error) throw new Error(`Failed to list packs: ${error.value}`);
-  return PackWithWeightsSchema.array().parse(data);
+  return PackWithWeightsSchema.array().parse(data) as unknown as PackInStore[];
 };
 
-const createPack = async (packData: PackInStore) => {
+const createPack = async (packData: PackInStore): Promise<PackInStore | null> => {
   const { data, error } = await apiClient.packs.post({
     id: packData.id,
     name: packData.name,
@@ -27,10 +27,10 @@ const createPack = async (packData: PackInStore) => {
     localUpdatedAt: packData.localUpdatedAt ?? new Date().toISOString(),
   });
   if (error) throw new Error(`Failed to create pack: ${error.value}`);
-  return PackWithWeightsSchema.parse(data);
+  return PackWithWeightsSchema.parse(data) as unknown as PackInStore;
 };
 
-const updatePack = async ({ id, ...data }: Partial<PackInStore>) => {
+const updatePack = async ({ id, ...data }: Partial<PackInStore>): Promise<PackInStore | null> => {
   const { data: result, error } = await apiClient.packs({ packId: String(id) }).put({
     ...(data.name !== undefined ? { name: data.name } : {}),
     ...(data.description !== undefined ? { description: data.description ?? undefined } : {}),
@@ -42,7 +42,7 @@ const updatePack = async ({ id, ...data }: Partial<PackInStore>) => {
     ...(data.localUpdatedAt ? { localUpdatedAt: data.localUpdatedAt } : {}),
   });
   if (error) throw new Error(`Failed to update pack: ${error.value}`);
-  return PackWithWeightsSchema.parse(result);
+  return PackWithWeightsSchema.parse(result) as unknown as PackInStore;
 };
 
 export const packsStore = observable<Record<string, PackInStore>>({});

--- a/apps/expo/features/packs/store/packs.ts
+++ b/apps/expo/features/packs/store/packs.ts
@@ -2,6 +2,7 @@ import { observable, syncState } from '@legendapp/state';
 import { observablePersistSqlite } from '@legendapp/state/persist-plugins/expo-sqlite';
 import { syncObservable } from '@legendapp/state/sync';
 import { syncedCrud } from '@legendapp/state/sync-plugins/crud';
+import { PackWithWeightsSchema } from '@packrat/api/schemas/packs';
 import { isAuthed } from 'expo-app/features/auth/store';
 import { apiClient } from 'expo-app/lib/api/packrat';
 import Storage from 'expo-sqlite/kv-store';
@@ -10,23 +11,38 @@ import type { PackInStore } from '../types';
 const listPacks = async () => {
   const { data, error } = await apiClient.packs.get({ query: { includePublic: 0 } });
   if (error) throw new Error(`Failed to list packs: ${error.value}`);
-  return data as object[] | null;
+  return PackWithWeightsSchema.array().parse(data);
 };
 
 const createPack = async (packData: PackInStore) => {
-  // biome-ignore lint/suspicious/noExplicitAny: store shapes diverge from Treaty's strict schema
-  const { data, error } = await apiClient.packs.post(packData as any);
+  const { data, error } = await apiClient.packs.post({
+    id: packData.id,
+    name: packData.name,
+    description: packData.description ?? undefined,
+    category: packData.category ?? undefined,
+    isPublic: packData.isPublic,
+    image: packData.image,
+    tags: packData.tags ?? undefined,
+    localCreatedAt: packData.localCreatedAt ?? new Date().toISOString(),
+    localUpdatedAt: packData.localUpdatedAt ?? new Date().toISOString(),
+  });
   if (error) throw new Error(`Failed to create pack: ${error.value}`);
-  return data as object | null;
+  return PackWithWeightsSchema.parse(data);
 };
 
 const updatePack = async ({ id, ...data }: Partial<PackInStore>) => {
-  const { data: result, error } = await apiClient
-    .packs({ packId: String(id) })
-    // biome-ignore lint/suspicious/noExplicitAny: store shapes diverge from Treaty's strict schema
-    .put(data as any);
+  const { data: result, error } = await apiClient.packs({ packId: String(id) }).put({
+    ...(data.name !== undefined ? { name: data.name } : {}),
+    ...(data.description !== undefined ? { description: data.description ?? undefined } : {}),
+    ...(data.category !== undefined ? { category: data.category ?? undefined } : {}),
+    ...(data.isPublic !== undefined ? { isPublic: data.isPublic } : {}),
+    ...(data.image !== undefined ? { image: data.image } : {}),
+    ...(data.tags !== undefined ? { tags: data.tags ?? undefined } : {}),
+    ...(data.deleted !== undefined ? { deleted: data.deleted } : {}),
+    ...(data.localUpdatedAt ? { localUpdatedAt: data.localUpdatedAt } : {}),
+  });
   if (error) throw new Error(`Failed to update pack: ${error.value}`);
-  return result as object | null;
+  return PackWithWeightsSchema.parse(result);
 };
 
 export const packsStore = observable<Record<string, PackInStore>>({});

--- a/apps/expo/features/trail-conditions/store/trailConditionReports.ts
+++ b/apps/expo/features/trail-conditions/store/trailConditionReports.ts
@@ -2,6 +2,7 @@ import { observable, syncState } from '@legendapp/state';
 import { observablePersistSqlite } from '@legendapp/state/persist-plugins/expo-sqlite';
 import { syncObservable } from '@legendapp/state/sync';
 import { syncedCrud } from '@legendapp/state/sync-plugins/crud';
+import { TrailConditionReportSchema } from '@packrat/api/schemas/trailConditions';
 import { isAuthed } from 'expo-app/features/auth/store';
 import { apiClient } from 'expo-app/lib/api/packrat';
 import Storage from 'expo-sqlite/kv-store';
@@ -12,7 +13,7 @@ const listMyReports = async (_params: unknown, { lastSync }: { lastSync?: number
     query: lastSync != null ? { updatedAt: new Date(lastSync + 1).toISOString() } : {},
   });
   if (error) throw new Error(`Failed to list trail condition reports: ${error.value}`);
-  return data as object[] | null;
+  return TrailConditionReportSchema.array().parse(data);
 };
 
 const createReport = async (reportData: TrailConditionReportInStore) => {
@@ -32,7 +33,7 @@ const createReport = async (reportData: TrailConditionReportInStore) => {
     localUpdatedAt: reportData.localUpdatedAt ?? new Date().toISOString(),
   });
   if (error) throw new Error(`Failed to create trail condition report: ${error.value}`);
-  return data as object | null;
+  return TrailConditionReportSchema.parse(data);
 };
 
 const updateReport = async ({
@@ -58,7 +59,7 @@ const updateReport = async ({
     ...(data.localUpdatedAt ? { localUpdatedAt: data.localUpdatedAt } : {}),
   });
   if (error) throw new Error(`Failed to update trail condition report: ${error.value}`);
-  return result as object | null;
+  return TrailConditionReportSchema.parse(result);
 };
 
 // Observable trail condition reports store

--- a/apps/expo/features/trips/screens/TripWeatherDetailsScreen.tsx
+++ b/apps/expo/features/trips/screens/TripWeatherDetailsScreen.tsx
@@ -1,3 +1,4 @@
+import type { WeatherAPIForecastResponse } from '@packrat/api/schemas/weather';
 import { Icon } from 'expo-app/components/Icon';
 import { WeatherForecast } from 'expo-app/features/weather/components/WeatherForecast';
 import {
@@ -5,11 +6,6 @@ import {
   getWeatherData,
   searchLocationsByCoordinates,
 } from 'expo-app/features/weather/lib/weatherService';
-import type {
-  ForecastDay,
-  HourWeather,
-  WeatherApiForecastResponse,
-} from 'expo-app/features/weather/types';
 import { LinearGradient } from 'expo-linear-gradient';
 import { router, Stack, useLocalSearchParams } from 'expo-router';
 import { useEffect, useState } from 'react';
@@ -33,7 +29,7 @@ export default function TripWeatherDetailsScreen() {
   const longitude = Number(lon);
   const tripLocationName = locationName;
 
-  const [weather, setWeather] = useState<WeatherApiForecastResponse | null>(null);
+  const [weather, setWeather] = useState<WeatherAPIForecastResponse | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [gradientColors, setGradientColors] = useState<[string, string, ...string[]]>([
@@ -94,14 +90,14 @@ export default function TripWeatherDetailsScreen() {
   // Use the trip's location name if provided, otherwise fall back to weather API location
   const displayLocationName = tripLocationName || location.name;
 
-  const hourlyForecast = weather?.forecast?.forecastday?.[0]?.hour?.map((h: HourWeather) => ({
+  const hourlyForecast = weather?.forecast?.forecastday?.[0]?.hour?.map((h) => ({
     time: `${new Date(h.time).getHours()}:00`,
     temp: Math.round(h.temp_c),
     weatherCode: h.condition?.code ?? 1000,
     isDay: h.is_day,
   }));
 
-  const dailyForecast = weather?.forecast?.forecastday?.map((fd: ForecastDay) => ({
+  const dailyForecast = weather?.forecast?.forecastday?.map((fd) => ({
     day: new Intl.DateTimeFormat('en', { weekday: 'short' }).format(new Date(fd.date)),
     icon: 'weather-partly-cloudy',
     low: Math.round(fd.day.mintemp_c),
@@ -132,8 +128,8 @@ export default function TripWeatherDetailsScreen() {
             <Text className="text-xl text-white">{current.condition.text}</Text>
 
             <Text className="text-white/80 mt-2">
-              H:{weather.forecast.forecastday[0].day.maxtemp_c}° L:
-              {weather.forecast.forecastday[0].day.mintemp_c}°
+              H:{weather.forecast.forecastday[0]?.day.maxtemp_c}° L:
+              {weather.forecast.forecastday[0]?.day.mintemp_c}°
             </Text>
           </View>
           <WeatherForecast

--- a/apps/expo/features/trips/store/trips.ts
+++ b/apps/expo/features/trips/store/trips.ts
@@ -2,6 +2,7 @@ import { observable, syncState } from '@legendapp/state';
 import { observablePersistSqlite } from '@legendapp/state/persist-plugins/expo-sqlite';
 import { syncObservable } from '@legendapp/state/sync';
 import { syncedCrud } from '@legendapp/state/sync-plugins/crud';
+import { TripSchema } from '@packrat/api/schemas/trips';
 import { isAuthed } from 'expo-app/features/auth/store';
 import { apiClient } from 'expo-app/lib/api/packrat';
 import Storage from 'expo-sqlite/kv-store';
@@ -10,7 +11,7 @@ import type { TripInStore } from '../types';
 const listTrips = async () => {
   const { data, error } = await apiClient.trips.get({ query: { includePublic: 0 } });
   if (error) throw new Error(`Failed to list trips: ${error.value}`);
-  return data as object[] | null;
+  return TripSchema.array().parse(data);
 };
 
 const createTrip = async (tripData: TripInStore) => {
@@ -30,7 +31,7 @@ const createTrip = async (tripData: TripInStore) => {
     localUpdatedAt: tripData.localUpdatedAt ?? new Date().toISOString(),
   });
   if (error) throw new Error(`Failed to create trip: ${error.value}`);
-  return data as object | null;
+  return TripSchema.parse(data);
 };
 
 const updateTrip = async ({ id, ...data }: Partial<TripInStore>) => {
@@ -45,7 +46,7 @@ const updateTrip = async ({ id, ...data }: Partial<TripInStore>) => {
     ...(data.localUpdatedAt ? { localUpdatedAt: data.localUpdatedAt } : {}),
   });
   if (error) throw new Error(`Failed to update trip: ${error.value}`);
-  return result as object | null;
+  return TripSchema.parse(result);
 };
 
 // Observable trips store

--- a/apps/expo/features/weather/hooks/useLocationRefresh.ts
+++ b/apps/expo/features/weather/hooks/useLocationRefresh.ts
@@ -1,5 +1,6 @@
 import { formatWeatherData, getWeatherData } from 'expo-app/features/weather/lib/weatherService';
 import { useState } from 'react';
+import type { WeatherLocation } from '../types';
 import { useLocations } from './useLocations';
 
 export function useLocationRefresh() {
@@ -17,17 +18,7 @@ export function useLocationRefresh() {
       if (weatherData) {
         const formattedData = formatWeatherData(weatherData);
 
-        updateLocation(locationId, {
-          temperature: formattedData.temperature,
-          condition: formattedData.condition,
-          time: formattedData.time,
-          highTemp: formattedData.highTemp,
-          lowTemp: formattedData.lowTemp,
-          alerts: formattedData.alerts,
-          details: formattedData.details,
-          hourlyForecast: formattedData.hourlyForecast,
-          dailyForecast: formattedData.dailyForecast,
-        });
+        updateLocation(locationId, formattedData as unknown as Partial<WeatherLocation>);
 
         return true;
       }
@@ -56,17 +47,7 @@ export function useLocationRefresh() {
           if (weatherData) {
             const formattedData = formatWeatherData(weatherData);
 
-            updateLocation(location.id, {
-              temperature: formattedData.temperature,
-              condition: formattedData.condition,
-              time: formattedData.time,
-              highTemp: formattedData.highTemp,
-              lowTemp: formattedData.lowTemp,
-              alerts: formattedData.alerts,
-              details: formattedData.details,
-              hourlyForecast: formattedData.hourlyForecast,
-              dailyForecast: formattedData.dailyForecast,
-            });
+            updateLocation(location.id, formattedData as unknown as Partial<WeatherLocation>);
           }
         } catch (error) {
           console.error(`Error updating weather for ${location.name}:`, error);

--- a/apps/expo/features/weather/hooks/useLocationSearch.ts
+++ b/apps/expo/features/weather/hooks/useLocationSearch.ts
@@ -65,21 +65,7 @@ export function useLocationSearch() {
         const formattedData = formatWeatherData(weatherData);
 
         // Create new location with weather data
-        const newLocation: WeatherLocation = {
-          id: formattedData.id,
-          name: formattedData.name,
-          temperature: formattedData.temperature,
-          condition: formattedData.condition,
-          time: formattedData.time,
-          highTemp: formattedData.highTemp,
-          lowTemp: formattedData.lowTemp,
-          alerts: formattedData.alerts,
-          lat: formattedData.lat,
-          lon: formattedData.lon,
-          details: formattedData.details,
-          hourlyForecast: formattedData.hourlyForecast,
-          dailyForecast: formattedData.dailyForecast,
-        };
+        const newLocation = formattedData as unknown as WeatherLocation;
 
         addLocation(newLocation);
         return true;

--- a/apps/expo/features/weather/lib/weatherService.ts
+++ b/apps/expo/features/weather/lib/weatherService.ts
@@ -1,7 +1,7 @@
 import {
   LocationSearchResponseSchema,
-  WeatherAPIForecastResponseSchema,
   type WeatherAPIForecastResponse,
+  WeatherAPIForecastResponseSchema,
 } from '@packrat/api/schemas/weather';
 import { assertDefined } from '@packrat/guards';
 import { apiClient } from 'expo-app/lib/api/packrat';

--- a/apps/expo/features/weather/lib/weatherService.ts
+++ b/apps/expo/features/weather/lib/weatherService.ts
@@ -56,7 +56,7 @@ export function formatWeatherData(data: WeatherAPIForecastResponse) {
   const alerts = data.alerts;
 
   // Format date and time
-  const localTime = new Date(location.localtime);
+  const localTime = new Date(location.localtime ?? '');
   const formattedTime = localTime.toLocaleTimeString('en-US', {
     hour: 'numeric',
     minute: '2-digit',
@@ -82,7 +82,7 @@ export function formatWeatherData(data: WeatherAPIForecastResponse) {
           hour12: true,
         }),
         temp: Math.round(hour.temp_f),
-        icon: getIconNameFromCode(hour.condition.code, hour.is_day),
+        icon: getIconNameFromCode(hour.condition.code, hour.is_day) as string,
         weatherCode: hour.condition.code,
         isDay: hour.is_day,
       };
@@ -95,7 +95,7 @@ export function formatWeatherData(data: WeatherAPIForecastResponse) {
       day: date.toLocaleDateString('en-US', { weekday: 'short' }),
       high: Math.round(day.day.maxtemp_f),
       low: Math.round(day.day.mintemp_f),
-      icon: getIconNameFromCode(day.day.condition.code, 1), // Always use day icon for daily forecast
+      icon: getIconNameFromCode(day.day.condition.code, 1) as string, // Always use day icon for daily forecast
       weatherCode: day.day.condition.code,
     };
   });

--- a/apps/expo/features/weather/lib/weatherService.ts
+++ b/apps/expo/features/weather/lib/weatherService.ts
@@ -1,30 +1,28 @@
+import {
+  LocationSearchResponseSchema,
+  WeatherAPIForecastResponseSchema,
+  type WeatherAPIForecastResponse,
+} from '@packrat/api/schemas/weather';
 import { assertDefined } from '@packrat/guards';
-import type {
-  LocationSearchResult,
-  WeatherApiForecastResponse,
-} from 'expo-app/features/weather/types';
 import { apiClient } from 'expo-app/lib/api/packrat';
 import { getWeatherIconName as getIconNameFromCode } from './weatherIcons';
 
 /**
  * Search for locations by name
  */
-export async function searchLocations(query: string): Promise<LocationSearchResult[]> {
+export async function searchLocations(query: string) {
   const { data, error } = await apiClient.weather.search.get({ query: { q: query } });
   if (error) {
     console.error('Error searching locations:', error.value);
     throw new Error('Failed to search locations');
   }
-  return (data ?? []) as unknown as LocationSearchResult[];
+  return LocationSearchResponseSchema.parse(data ?? []);
 }
 
 /**
  * Search for locations by coordinates
  */
-export async function searchLocationsByCoordinates(
-  latitude: number,
-  longitude: number,
-): Promise<LocationSearchResult[]> {
+export async function searchLocationsByCoordinates(latitude: number, longitude: number) {
   const { data, error } = await apiClient.weather['search-by-coordinates'].get({
     query: { lat: latitude.toFixed(6), lon: longitude.toFixed(6) },
   });
@@ -32,25 +30,25 @@ export async function searchLocationsByCoordinates(
     console.error('Error searching locations by coordinates:', error.value);
     throw new Error('Failed to find locations near you');
   }
-  return (data ?? []) as unknown as LocationSearchResult[];
+  return LocationSearchResponseSchema.parse(data ?? []);
 }
 
 /**
  * Get detailed weather data for a location
  */
-export async function getWeatherData(id: number): Promise<WeatherApiForecastResponse> {
+export async function getWeatherData(id: number) {
   const { data, error } = await apiClient.weather.forecast.get({ query: { id: String(id) } });
   if (error) {
     console.error('Error getting weather data:', error.value);
     throw new Error('Failed to get weather data');
   }
-  return data as unknown as WeatherApiForecastResponse;
+  return WeatherAPIForecastResponseSchema.parse(data);
 }
 
 /**
  * Format raw weather data into our application's format
  */
-export function formatWeatherData(data: WeatherApiForecastResponse) {
+export function formatWeatherData(data: WeatherAPIForecastResponse) {
   // Extract location data
   const location = data.location;
   const current = data.current;

--- a/apps/expo/features/weather/screens/LocationPreviewScreen.tsx
+++ b/apps/expo/features/weather/screens/LocationPreviewScreen.tsx
@@ -56,7 +56,7 @@ export default function LocationPreviewScreen() {
       const data = await getWeatherData(locationId);
       if (data) {
         const formattedData = formatWeatherData(data);
-        setWeatherData(formattedData);
+        setWeatherData(formattedData as unknown as WeatherLocation);
 
         // Update gradient colors based on weather condition
         if (formattedData.details) {

--- a/apps/expo/features/wildlife/hooks/useWildlifeIdentification.ts
+++ b/apps/expo/features/wildlife/hooks/useWildlifeIdentification.ts
@@ -24,7 +24,8 @@ async function identifyOnline(selectedImage: SelectedImage): Promise<Identificat
     wrapped.isApiError = true;
     throw wrapped;
   }
-  if (!isIdentifyResponse(data)) throw new Error('Unexpected response from wildlife identify endpoint');
+  if (!isIdentifyResponse(data))
+    throw new Error('Unexpected response from wildlife identify endpoint');
   return data.results as IdentificationResult[];
 }
 

--- a/apps/expo/features/wildlife/hooks/useWildlifeIdentification.ts
+++ b/apps/expo/features/wildlife/hooks/useWildlifeIdentification.ts
@@ -1,13 +1,13 @@
+import { zodGuard } from '@packrat/guards';
 import { useMutation } from '@tanstack/react-query';
 import type { SelectedImage } from 'expo-app/features/packs/hooks/useImagePicker';
 import { uploadImage } from 'expo-app/features/packs/utils';
 import { apiClient } from 'expo-app/lib/api/packrat';
+import { z } from 'zod';
 import { identifyFromDescription } from '../lib/offlineIdentifier';
 import type { IdentificationResult } from '../types';
 
-interface OnlineIdentificationResponse {
-  results: IdentificationResult[];
-}
+const isIdentifyResponse = zodGuard(z.object({ results: z.array(z.unknown()) }));
 
 async function identifyOnline(selectedImage: SelectedImage): Promise<IdentificationResult[]> {
   const image = await uploadImage(selectedImage.fileName, selectedImage.uri);
@@ -24,7 +24,8 @@ async function identifyOnline(selectedImage: SelectedImage): Promise<Identificat
     wrapped.isApiError = true;
     throw wrapped;
   }
-  return (data as unknown as OnlineIdentificationResponse).results;
+  if (!isIdentifyResponse(data)) throw new Error('Unexpected response from wildlife identify endpoint');
+  return data.results as IdentificationResult[];
 }
 
 function isNetworkError(error: unknown): boolean {

--- a/packages/api/src/schemas/packs.ts
+++ b/packages/api/src/schemas/packs.ts
@@ -32,8 +32,11 @@ export const PackSchema = z.object({
   isPublic: z.boolean(),
   image: z.string().nullable(),
   tags: z.array(z.string()).nullable(),
+  templateId: z.string().nullable().optional(),
   deleted: z.boolean(),
   isAIGenerated: z.boolean(),
+  localCreatedAt: z.string().datetime().optional(),
+  localUpdatedAt: z.string().datetime().optional(),
   createdAt: z.string().datetime(),
   updatedAt: z.string().datetime(),
   items: z.array(PackItemSchema).optional(),
@@ -132,4 +135,32 @@ export const GapAnalysisItemSchema = z.object({
 export const GapAnalysisResponseSchema = z.object({
   gaps: z.array(GapAnalysisItemSchema),
   summary: z.string().optional(),
+});
+
+// Body schemas mirroring the inline route schemas (exported so stores/clients
+// can use ApiBody<> or direct z.infer<> without importing from route files).
+export const CreatePackBodySchema = CreatePackRequestSchema.extend({
+  id: z.string(),
+  localCreatedAt: z.string().datetime(),
+  localUpdatedAt: z.string().datetime(),
+});
+
+export const UpdatePackBodySchema = UpdatePackRequestSchema.extend({
+  localUpdatedAt: z.string().datetime().optional(),
+});
+
+export const PackWeightHistoryResponseSchema = z.object({
+  id: z.string(),
+  packId: z.string(),
+  userId: z.number(),
+  weight: z.number(),
+  localCreatedAt: z.string().datetime().optional(),
+  createdAt: z.string().datetime(),
+  updatedAt: z.string().datetime(),
+});
+
+export const CreatePackWeightHistoryBodySchema = z.object({
+  id: z.string(),
+  weight: z.number(),
+  localCreatedAt: z.string().datetime(),
 });

--- a/packages/api/src/schemas/trailConditions.ts
+++ b/packages/api/src/schemas/trailConditions.ts
@@ -1,0 +1,27 @@
+import { z } from 'zod';
+
+export const TrailSurfaceSchema = z.enum(['paved', 'gravel', 'dirt', 'rocky', 'snow', 'mud']);
+export const OverallConditionSchema = z.enum(['excellent', 'good', 'fair', 'poor']);
+export const WaterCrossingDifficultySchema = z.enum(['easy', 'moderate', 'difficult']);
+
+export const TrailConditionReportSchema = z.object({
+  id: z.string(),
+  trailName: z.string(),
+  trailRegion: z.string().nullable().optional(),
+  surface: TrailSurfaceSchema,
+  overallCondition: OverallConditionSchema,
+  hazards: z.array(z.string()),
+  waterCrossings: z.number(),
+  waterCrossingDifficulty: WaterCrossingDifficultySchema.nullable().optional(),
+  notes: z.string().nullable().optional(),
+  photos: z.array(z.string()),
+  userId: z.number().optional(),
+  tripId: z.string().nullable().optional(),
+  deleted: z.boolean(),
+  localCreatedAt: z.string().datetime().optional(),
+  localUpdatedAt: z.string().datetime().optional(),
+  createdAt: z.string().datetime().optional(),
+  updatedAt: z.string().datetime().optional(),
+});
+
+export type TrailConditionReport = z.infer<typeof TrailConditionReportSchema>;

--- a/packages/api/src/schemas/trips.ts
+++ b/packages/api/src/schemas/trips.ts
@@ -1,0 +1,51 @@
+import { z } from 'zod';
+
+export const TripLocationSchema = z.object({
+  latitude: z.number(),
+  longitude: z.number(),
+  name: z.string().optional(),
+});
+
+export const TripSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  description: z.string().nullable().optional(),
+  notes: z.string().nullable().optional(),
+  location: TripLocationSchema.nullable().optional(),
+  startDate: z.string().nullable().optional(),
+  endDate: z.string().nullable().optional(),
+  userId: z.number().optional(),
+  packId: z.string().nullable().optional(),
+  deleted: z.boolean(),
+  localCreatedAt: z.string().datetime().optional(),
+  localUpdatedAt: z.string().datetime().optional(),
+  createdAt: z.string().datetime().optional(),
+  updatedAt: z.string().datetime().optional(),
+});
+
+export const CreateTripBodySchema = z.object({
+  id: z.string(),
+  name: z.string().min(1).max(255),
+  description: z.string().nullable().optional(),
+  notes: z.string().nullable().optional(),
+  location: TripLocationSchema.nullable().optional(),
+  startDate: z.string().nullable().optional(),
+  endDate: z.string().nullable().optional(),
+  packId: z.string().nullable().optional(),
+  localCreatedAt: z.string().datetime(),
+  localUpdatedAt: z.string().datetime(),
+});
+
+export const UpdateTripBodySchema = z.object({
+  name: z.string().min(1).max(255).optional(),
+  description: z.string().nullable().optional(),
+  notes: z.string().nullable().optional(),
+  location: TripLocationSchema.nullable().optional(),
+  startDate: z.string().nullable().optional(),
+  endDate: z.string().nullable().optional(),
+  packId: z.string().nullable().optional(),
+  localUpdatedAt: z.string().datetime().optional(),
+});
+
+export type TripLocation = z.infer<typeof TripLocationSchema>;
+export type Trip = z.infer<typeof TripSchema>;

--- a/packages/api/src/schemas/weather.ts
+++ b/packages/api/src/schemas/weather.ts
@@ -20,8 +20,8 @@ export const WeatherAPILocationSchema = z.object({
   name: z.string(),
   region: z.string(),
   country: z.string(),
-  lat: z.union([z.string(), z.number()]),
-  lon: z.union([z.string(), z.number()]),
+  lat: z.number(),
+  lon: z.number(),
   tz_id: z.string().optional(),
   localtime_epoch: z.number().optional(),
   localtime: z.string().optional(),
@@ -81,7 +81,7 @@ export const WeatherCurrentSchema = z.object({
   gust_mph: z.number().optional(),
   gust_kph: z.number().optional(),
   // Additional fields from actual API response
-  is_day: z.number().optional(),
+  is_day: z.number(),
   windchill_c: z.number().optional(),
   windchill_f: z.number().optional(),
   heatindex_c: z.number().optional(),
@@ -147,7 +147,7 @@ export const WeatherHourSchema = z.object({
   chance_of_rain: z.number().optional(),
   chance_of_snow: z.number().optional(),
   // Additional fields from actual API response
-  is_day: z.number().optional(),
+  is_day: z.number(),
   windchill_c: z.number().optional(),
   windchill_f: z.number().optional(),
   heatindex_c: z.number().optional(),
@@ -178,7 +178,7 @@ export const WeatherForecastDaySchema = z.object({
       moon_illumination: z.number(),
     })
     .optional(),
-  hour: z.array(WeatherHourSchema).optional(),
+  hour: z.array(WeatherHourSchema),
 });
 
 export const WeatherAlertSchema = z
@@ -220,8 +220,8 @@ export const WeatherAPISearchResponseSchema = z.array(
     name: z.string(),
     region: z.string(),
     country: z.string(),
-    lat: z.union([z.string(), z.number()]),
-    lon: z.union([z.string(), z.number()]),
+    lat: z.number(),
+    lon: z.number(),
     url: z.string().optional(),
   }),
 );

--- a/packages/mcp/src/tools/packs.ts
+++ b/packages/mcp/src/tools/packs.ts
@@ -3,6 +3,21 @@ import { err, ok } from '../client';
 import { ItemCategory, PackCategory } from '../enums';
 import type { AgentContext } from '../types';
 
+interface PackDetailResponse {
+  items?: Array<{
+    name: string;
+    category: string;
+    weight: number;
+    quantity: number;
+    worn: boolean;
+    consumable: boolean;
+  }>;
+  totalWeight?: number;
+  baseWeight?: number;
+  wornWeight?: number;
+  consumableWeight?: number;
+}
+
 export function registerPackTools(agent: AgentContext): void {
   // ── List packs ────────────────────────────────────────────────────────────
 
@@ -232,20 +247,7 @@ export function registerPackTools(agent: AgentContext): void {
     },
     async ({ pack_id }) => {
       try {
-        const pack = (await agent.api.get(`/packs/${pack_id}`)) as {
-          items?: Array<{
-            name: string;
-            category: string;
-            weight: number;
-            quantity: number;
-            worn: boolean;
-            consumable: boolean;
-          }>;
-          totalWeight?: number;
-          baseWeight?: number;
-          wornWeight?: number;
-          consumableWeight?: number;
-        };
+        const pack = await agent.api.get<PackDetailResponse>(`/packs/${pack_id}`);
 
         const byCategory: Record<string, { items: string[]; totalGrams: number; count: number }> =
           {};


### PR DESCRIPTION
- Add useCFAccessIdentity() hook to cfAccess.ts backed by useQuery with
  staleTime/gcTime=Infinity and retry=false so a null result is treated as
  "not behind CF Access" rather than a transient failure
- Create lib/queryKeys.ts as a centralised registry for all admin query keys
  (admin, platform, catalogAnalytics, cfAccessIdentity)
- Refactor auth-guard.tsx: replace manual canceled-flag useEffect pattern with
  useCFAccessIdentity(); render null while pending or when neither CF session
  nor stored token exists
- Refactor login/page.tsx: replace useState<boolean|null> + raw useEffect with
  useCFAccessIdentity(); Local dev badge now keyed on !cfPending && !cfIdentity
- Update all dashboard pages (page, users, packs, catalog), edit-catalog-dialog,
  and analytics hooks to use queryKeys.* instead of inline string arrays

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added search filtering for users, packs, and catalog in the admin API
  * Implemented rate limiting on the admin token endpoint

* **Bug Fixes**
  * Improved error handling and validation of API responses using runtime schema validation
  * Enhanced Cloudflare Access authentication verification

* **Refactor**
  * Centralized query key management for improved cache consistency
  * Strengthened type safety throughout the application with schema-driven validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->