### PR TITLE
feat(api): AllTrails OG preview endpoint

### DIFF
--- a/packages/api/src/routes/alltrails.ts
+++ b/packages/api/src/routes/alltrails.ts
@@ -35,6 +35,7 @@ export const alltrailsRoutes = new Elysia({ prefix: '/alltrails' }).post(
     try {
       response = await fetch(url, {
         headers: { 'User-Agent': UA },
+        redirect: 'manual',
         signal: AbortSignal.timeout(8000),
       });
     } catch (e) {
@@ -44,18 +45,37 @@ export const alltrailsRoutes = new Elysia({ prefix: '/alltrails' }).post(
       return status(502, { error: 'Failed to fetch AllTrails URL' });
     }
 
-    if (!response.ok) {
-      return status(502, { error: `AllTrails returned status ${response.status}` });
-    }
-
-    const finalUrl = response.url || url;
-    try {
-      const finalHostname = new URL(finalUrl).hostname;
-      if (!ALLTRAILS_HOSTNAME_RE.test(finalHostname)) {
+    // Validate any redirect before following it (SSRF guard)
+    if (response.status >= 300 && response.status < 400) {
+      const location = response.headers.get('location');
+      if (!location) {
+        return status(502, { error: 'AllTrails redirected without a Location header' });
+      }
+      let redirectUrl: URL;
+      try {
+        redirectUrl = new URL(location, url);
+      } catch {
+        return status(502, { error: 'Invalid redirect URL from AllTrails' });
+      }
+      if (redirectUrl.protocol !== 'https:' || !ALLTRAILS_HOSTNAME_RE.test(redirectUrl.hostname)) {
         return status(400, { error: 'URL redirected outside alltrails.com' });
       }
-    } catch {
-      return status(502, { error: 'Could not parse redirect URL' });
+      try {
+        response = await fetch(redirectUrl.toString(), {
+          headers: { 'User-Agent': UA },
+          redirect: 'error',
+          signal: AbortSignal.timeout(8000),
+        });
+      } catch (e) {
+        if (e instanceof DOMException && e.name === 'TimeoutError') {
+          return status(504, { error: 'Request to AllTrails timed out' });
+        }
+        return status(502, { error: 'Failed to fetch AllTrails URL' });
+      }
+    }
+
+    if (!response.ok) {
+      return status(502, { error: `AllTrails returned status ${response.status}` });
     }
 
     const html = await response.text();
@@ -68,7 +88,7 @@ export const alltrailsRoutes = new Elysia({ prefix: '/alltrails' }).post(
     const description = extractOgTag(html, 'og:description');
     const image = extractOgTag(html, 'og:image');
 
-    return { title, description, image, url: finalUrl };
+    return { title, description, image, url: response.url || url };
   },
   {
     body: z.object({


### PR DESCRIPTION
## Summary

- Adds `POST /api/alltrails/preview` endpoint that server-side fetches an AllTrails URL and extracts OpenGraph metadata (title, description, image)
- Validates that only `https://alltrails.com` (and subdomains) URLs are accepted
- SSRF-safe: uses `redirect: 'manual'` and validates Location header hostname before following any redirect
- Includes integration tests for the happy path and all error cases

## Test plan

- [ ] `POST /api/alltrails/preview` with a valid AllTrails URL returns `{ title, description, image, url }`
- [ ] Returns 400 for non-alltrails.com URLs
- [ ] Returns 400 if redirect target is outside alltrails.com
- [ ] Returns 504 on timeout
- [ ] Returns 502 when AllTrails returns non-2xx

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * AllTrails URL preview: Preview metadata from AllTrails URLs
  * Admin dashboard search: Filter users, packs, and catalog items by name or email

* **Bug Fixes**
  * Fixed map provider behavior on mobile platforms
  * Improved weather data handling with safer optional chaining

* **Chores**
  * Centralized query key management for improved performance
  * Enhanced authentication flow and rate limiting

<!-- end of auto-generated comment: release notes by coderabbit.ai -->