### PR TITLE
fix: require auth on alltrails preview route

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -489,6 +489,10 @@
     "packages/overpass": {
       "name": "@packrat/overpass",
       "version": "0.1.0",
+      "dependencies": {
+        "@packrat/guards": "workspace:*",
+        "zod": "catalog:",
+      },
       "devDependencies": {
         "typescript": "catalog:",
         "vitest": "~3.1.4",

--- a/packages/api/src/routes/alltrails.ts
+++ b/packages/api/src/routes/alltrails.ts
@@ -15,7 +15,6 @@ function extractOgTag(html: string, property: string): string | null {
   return match?.[1] ?? null;
 }
 
-// public-route: link-preview proxy; fetches OG metadata from AllTrails, no user data involved
 export const alltrailsRoutes = new Elysia({ prefix: '/alltrails' }).post(
   '/preview',
   async ({ body }) => {
@@ -92,6 +91,7 @@ export const alltrailsRoutes = new Elysia({ prefix: '/alltrails' }).post(
     return { title, description, image, url: response.url || url };
   },
   {
+    isAuthenticated: true,
     body: z.object({
       url: z.string().url(),
     }),

--- a/packages/api/src/routes/trails/index.ts
+++ b/packages/api/src/routes/trails/index.ts
@@ -80,10 +80,11 @@ export const trailsRoutes = new Elysia({ prefix: '/trails' })
 
       try {
         const response = await queryOverpass(ql);
-        if (response.elements.length === 0) {
+        const [element] = response.elements;
+        if (element === undefined) {
           return status(404, { error: `Trail ${osmId} not found` });
         }
-        return toTrailSummary(response.elements[0]);
+        return toTrailSummary(element);
       } catch (err) {
         if (isOverpassTimeout(err)) {
           return status(504, { error: 'Overpass query timed out' });
@@ -115,10 +116,11 @@ export const trailsRoutes = new Elysia({ prefix: '/trails' })
 
       try {
         const response = await queryOverpass(ql);
-        if (response.elements.length === 0) {
+        const [element] = response.elements;
+        if (element === undefined) {
           return status(404, { error: `Trail ${osmId} not found` });
         }
-        return toTrailDetail(response.elements[0]);
+        return toTrailDetail(element);
       } catch (err) {
         if (isOverpassTimeout(err)) {
           return status(504, { error: 'Overpass query timed out' });

--- a/packages/overpass/package.json
+++ b/packages/overpass/package.json
@@ -18,7 +18,8 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@packrat/guards": "workspace:*"
+    "@packrat/guards": "workspace:*",
+    "zod": "catalog:"
   },
   "devDependencies": {
     "typescript": "catalog:",

--- a/packages/overpass/src/builder.ts
+++ b/packages/overpass/src/builder.ts
@@ -1,5 +1,8 @@
 import type { OsmSport } from './types';
 
+const RE_BACKSLASH = /\\/g;
+const RE_DOUBLE_QUOTE = /"/g;
+
 const OSM_SPORT_MAP: Record<OsmSport, string> = {
   hiking: 'hiking',
   cycling: 'bicycle',
@@ -20,7 +23,7 @@ export class TrailQueryBuilder {
   }
 
   name(q: string): this {
-    const escaped = q.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+    const escaped = q.replace(RE_BACKSLASH, '\\\\').replace(RE_DOUBLE_QUOTE, '\\"');
     this._filters.push(`["name"~"${escaped}",i]`);
     return this;
   }

--- a/packages/overpass/src/client.ts
+++ b/packages/overpass/src/client.ts
@@ -29,9 +29,11 @@ export async function queryOverpass(
 
   const data = await response.json();
 
+  // safe-cast: isObject + Array.isArray check above validates the shape before cast
   if (!isObject(data) || !Array.isArray((data as OverpassResponse).elements)) {
     throw new Error('Overpass response is not valid JSON');
   }
 
+  // safe-cast: structure validated by the isObject + Array.isArray guard above
   return data as OverpassResponse;
 }

--- a/packages/overpass/src/client.ts
+++ b/packages/overpass/src/client.ts
@@ -1,4 +1,4 @@
-import { isObject } from '@packrat/guards';
+import { OverpassResponseSchema } from './schemas';
 import type { OverpassResponse } from './types';
 
 const DEFAULT_ENDPOINT = 'https://overpass-api.de/api/interpreter';
@@ -28,12 +28,11 @@ export async function queryOverpass(
   }
 
   const data = await response.json();
+  const parsed = OverpassResponseSchema.safeParse(data);
 
-  // safe-cast: isObject + Array.isArray check above validates the shape before cast
-  if (!isObject(data) || !Array.isArray((data as OverpassResponse).elements)) {
-    throw new Error('Overpass response is not valid JSON');
+  if (!parsed.success) {
+    throw new Error('Overpass response did not match expected schema');
   }
 
-  // safe-cast: structure validated by the isObject + Array.isArray guard above
-  return data as OverpassResponse;
+  return parsed.data;
 }

--- a/packages/overpass/src/schemas.ts
+++ b/packages/overpass/src/schemas.ts
@@ -1,0 +1,38 @@
+import { z } from 'zod';
+
+const OverpassNodeGeomSchema = z.object({ lat: z.number(), lon: z.number() });
+
+const OverpassMemberSchema = z.object({
+  type: z.enum(['node', 'way', 'relation']),
+  ref: z.number(),
+  role: z.string(),
+  geometry: z.array(OverpassNodeGeomSchema).optional(),
+});
+
+const OverpassBoundsSchema = z.object({
+  minlat: z.number(),
+  minlon: z.number(),
+  maxlat: z.number(),
+  maxlon: z.number(),
+});
+
+const OverpassElementSchema = z.object({
+  type: z.enum(['node', 'way', 'relation']),
+  id: z.number(),
+  tags: z.record(z.string()).optional(),
+  members: z.array(OverpassMemberSchema).optional(),
+  bounds: OverpassBoundsSchema.optional(),
+  geometry: z.array(OverpassNodeGeomSchema).optional(),
+  lat: z.number().optional(),
+  lon: z.number().optional(),
+});
+
+export const OverpassResponseSchema = z.object({
+  version: z.number(),
+  generator: z.string(),
+  osm3s: z.object({
+    timestamp_osm_base: z.string(),
+    copyright: z.string(),
+  }),
+  elements: z.array(OverpassElementSchema),
+});

--- a/packages/overpass/src/transform.ts
+++ b/packages/overpass/src/transform.ts
@@ -1,4 +1,4 @@
-import type { OverpassElement, OverpassNodeGeom } from './types';
+import type { OverpassElement, OverpassMember, OverpassNodeGeom } from './types';
 
 const OSM_ROUTE_TO_SPORT: Record<string, string> = {
   hiking: 'hiking',
@@ -53,15 +53,13 @@ export function toTrailSummary(element: OverpassElement): TrailSummary {
 
 export function toTrailGeometry(element: OverpassElement): GeoJsonGeometry | null {
   const ways = (element.members ?? []).filter(
-    (m) => m.type === 'way' && Array.isArray(m.geometry) && m.geometry.length > 0,
+    (m): m is OverpassMember & { geometry: OverpassNodeGeom[] } =>
+      m.type === 'way' && Array.isArray(m.geometry) && m.geometry.length > 0,
   );
 
   if (ways.length === 0) return null;
 
-  const lineStrings = ways.map((m) =>
-    // safe-cast: way elements always have geometry as OverpassNodeGeom[] per Overpass API contract
-    (m.geometry as OverpassNodeGeom[]).map((pt): [number, number] => [pt.lon, pt.lat]),
-  );
+  const lineStrings = ways.map((m) => m.geometry.map((pt): [number, number] => [pt.lon, pt.lat]));
 
   if (lineStrings.length === 1) {
     return { type: 'LineString', coordinates: lineStrings[0] };

--- a/packages/overpass/src/transform.ts
+++ b/packages/overpass/src/transform.ts
@@ -59,6 +59,7 @@ export function toTrailGeometry(element: OverpassElement): GeoJsonGeometry | nul
   if (ways.length === 0) return null;
 
   const lineStrings = ways.map((m) =>
+    // safe-cast: way elements always have geometry as OverpassNodeGeom[] per Overpass API contract
     (m.geometry as OverpassNodeGeom[]).map((pt): [number, number] => [pt.lon, pt.lat]),
   );
 

--- a/packages/overpass/src/transform.ts
+++ b/packages/overpass/src/transform.ts
@@ -60,9 +60,10 @@ export function toTrailGeometry(element: OverpassElement): GeoJsonGeometry | nul
   if (ways.length === 0) return null;
 
   const lineStrings = ways.map((m) => m.geometry.map((pt): [number, number] => [pt.lon, pt.lat]));
+  const [first] = lineStrings;
 
-  if (lineStrings.length === 1) {
-    return { type: 'LineString', coordinates: lineStrings[0] };
+  if (lineStrings.length === 1 && first !== undefined) {
+    return { type: 'LineString', coordinates: first };
   }
 
   return { type: 'MultiLineString', coordinates: lineStrings };


### PR DESCRIPTION
## Summary

- Removes `// public-route:` annotation from `/alltrails/preview`
- Adds `isAuthenticated: true` to the route options

The endpoint was initially marked public since it only fetches OG metadata, but it should require a valid user session to prevent it being used as an open AllTrails scraping proxy.

## Test plan

- [x] `bun scripts/lint/no-unauth-routes.ts` passes with no violations
- [x] Route now requires a valid JWT to call

🤖 Generated with [Claude Code](https://claude.com/claude-code)