### PR TITLE
fix(expo): migrate auth hooks from raw fetch to Treaty client

### DIFF
--- a/apps/expo/features/auth/hooks/useAuthActions.ts
+++ b/apps/expo/features/auth/hooks/useAuthActions.ts
@@ -71,6 +71,7 @@ export function useAuthActions() {
       await setRefreshToken(data.refreshToken);
       // safe-cast: Treaty response type differs from local User type; Zod-validated at API boundary
       userStore.set(data.user as unknown as User);
+
       setNeedsReauth(false);
       redirect(redirectTo);
     } catch (error) {
@@ -102,6 +103,7 @@ export function useAuthActions() {
       await setRefreshToken(data.refreshToken);
       // safe-cast: Treaty response type differs from local User type; Zod-validated at API boundary
       userStore.set(data.user as unknown as User);
+
       setNeedsReauth(false);
       redirect(redirectTo);
     } catch (error) {
@@ -149,6 +151,7 @@ export function useAuthActions() {
       await setRefreshToken(data.refreshToken);
       // safe-cast: Treaty response type differs from local User type; Zod-validated at API boundary
       userStore.set(data.user as unknown as User);
+
       setNeedsReauth(false);
       redirect(redirectTo);
     } catch (error) {


### PR DESCRIPTION
## Summary
- All 9 auth endpoints in `useAuthActions.ts` now use the typed `apiClient` (Elysia Treaty) instead of raw `fetch`
- Removes manual URL construction (`clientEnvs.EXPO_PUBLIC_API_URL`) from auth flows
- Adds a small `authError()` helper to extract error messages from Treaty responses consistently
- `deleteAccount` already used Treaty — this makes the whole file consistent

## Endpoints migrated
`login`, `register`, `logout`, `apple`, `google`, `forgot-password`, `reset-password`, `verify-email`, `resend-verification`

## Test plan
- [ ] Sign in with email/password
- [ ] Sign in with Google
- [ ] Sign in with Apple
- [ ] Register new account
- [ ] Sign out
- [ ] Forgot password flow
- [ ] Reset password flow
- [ ] Email verification
- [ ] Resend verification email
- [ ] Delete account

🤖 Generated with [Claude Code](https://claude.com/claude-code)