### PR TITLE
fix(env): use explicit process.env.VAR_NAME in all env shims

### DIFF
--- a/packages/analytics/src/core/connection.ts
+++ b/packages/analytics/src/core/connection.ts
@@ -8,7 +8,7 @@
 import type { DuckDBConnection } from '@duckdb/node-api';
 import { DuckDBInstance } from '@duckdb/node-api';
 import { DBConfig } from './constants';
-import { env } from './env';
+import { analyticsEnv as env } from '@packrat/env/analytics';
 
 /** Configure S3/R2 credentials on a DuckDB connection. */
 export async function configureS3(conn: DuckDBConnection): Promise<void> {

--- a/packages/analytics/src/core/connection.ts
+++ b/packages/analytics/src/core/connection.ts
@@ -7,8 +7,8 @@
 
 import type { DuckDBConnection } from '@duckdb/node-api';
 import { DuckDBInstance } from '@duckdb/node-api';
-import { DBConfig } from './constants';
 import { analyticsEnv as env } from '@packrat/env/analytics';
+import { DBConfig } from './constants';
 
 /** Configure S3/R2 credentials on a DuckDB connection. */
 export async function configureS3(conn: DuckDBConnection): Promise<void> {

--- a/packages/analytics/src/core/env.ts
+++ b/packages/analytics/src/core/env.ts
@@ -101,7 +101,20 @@ let _cached: AnalyticsEnv | undefined;
 
 /** Lazily validates and returns analytics env vars. Throws on missing required vars. */
 export function env(): AnalyticsEnv {
-  if (!_cached) _cached = envSchema.parse(process.env);
+  if (!_cached)
+    _cached = envSchema.parse({
+      ANALYTICS_MODE: process.env.ANALYTICS_MODE,
+      R2_ACCESS_KEY_ID: process.env.R2_ACCESS_KEY_ID,
+      R2_SECRET_ACCESS_KEY: process.env.R2_SECRET_ACCESS_KEY,
+      PACKRAT_SCRAPY_BUCKET_R2_BUCKET_NAME: process.env.PACKRAT_SCRAPY_BUCKET_R2_BUCKET_NAME,
+      PACKRAT_ITEMS_BUCKET_R2_BUCKET_NAME: process.env.PACKRAT_ITEMS_BUCKET_R2_BUCKET_NAME,
+      R2_BUCKET_NAME: process.env.R2_BUCKET_NAME,
+      R2_ENDPOINT_URL: process.env.R2_ENDPOINT_URL,
+      CLOUDFLARE_ACCOUNT_ID: process.env.CLOUDFLARE_ACCOUNT_ID,
+      R2_CATALOG_TOKEN: process.env.R2_CATALOG_TOKEN,
+      R2_CATALOG_URI: process.env.R2_CATALOG_URI,
+      R2_WAREHOUSE_NAME: process.env.R2_WAREHOUSE_NAME,
+    });
   return _cached;
 }
 

--- a/packages/analytics/src/core/local-cache.ts
+++ b/packages/analytics/src/core/local-cache.ts
@@ -8,6 +8,7 @@
 import { mkdirSync } from 'node:fs';
 import type { DuckDBConnection } from '@duckdb/node-api';
 import { DuckDBInstance } from '@duckdb/node-api';
+import { analyticsEnv as env } from '@packrat/env/analytics';
 import { tryit } from 'radash';
 import type {
   BrandAnalysis,
@@ -27,7 +28,6 @@ import {
 } from './cache-metadata';
 import { configureS3 } from './connection';
 import { DBConfig } from './constants';
-import { analyticsEnv as env } from '@packrat/env/analytics';
 import { QueryBuilder, SQLFragments } from './query-builder';
 
 const TABLE_NAME = 'gear_data';

--- a/packages/analytics/src/core/local-cache.ts
+++ b/packages/analytics/src/core/local-cache.ts
@@ -27,7 +27,7 @@ import {
 } from './cache-metadata';
 import { configureS3 } from './connection';
 import { DBConfig } from './constants';
-import { env } from './env';
+import { analyticsEnv as env } from '@packrat/env/analytics';
 import { QueryBuilder, SQLFragments } from './query-builder';
 
 const TABLE_NAME = 'gear_data';

--- a/packages/analytics/src/index.ts
+++ b/packages/analytics/src/index.ts
@@ -1,3 +1,8 @@
+export {
+  type AnalyticsEnv,
+  analyticsEnv as env,
+  resetAnalyticsEnv as resetEnv,
+} from '@packrat/env/analytics';
 export * from './core/cache-metadata';
 export { CatalogCacheManager } from './core/catalog-cache';
 export { configureS3, createCatalogConnection } from './core/connection';
@@ -5,11 +10,6 @@ export * from './core/constants';
 export { DataExporter } from './core/data-export';
 export { Enrichment, normalizeImageUrl, rankImage } from './core/enrichment';
 export { EntityResolver } from './core/entity-resolver';
-export {
-  type AnalyticsEnv,
-  analyticsEnv as env,
-  resetAnalyticsEnv as resetEnv,
-} from '@packrat/env/analytics';
 export { LocalCacheManager } from './core/local-cache';
 export { QueryBuilder, SQLFragments } from './core/query-builder';
 export { SpecParser } from './core/spec-parser';

--- a/packages/analytics/src/index.ts
+++ b/packages/analytics/src/index.ts
@@ -5,7 +5,11 @@ export * from './core/constants';
 export { DataExporter } from './core/data-export';
 export { Enrichment, normalizeImageUrl, rankImage } from './core/enrichment';
 export { EntityResolver } from './core/entity-resolver';
-export { type AnalyticsEnv, env, resetEnv } from './core/env';
+export {
+  type AnalyticsEnv,
+  analyticsEnv as env,
+  resetAnalyticsEnv as resetEnv,
+} from '@packrat/env/analytics';
 export { LocalCacheManager } from './core/local-cache';
 export { QueryBuilder, SQLFragments } from './core/query-builder';
 export { SpecParser } from './core/spec-parser';

--- a/packages/analytics/test/core/env.test.ts
+++ b/packages/analytics/test/core/env.test.ts
@@ -1,4 +1,4 @@
-import { env, resetEnv } from '@packrat/analytics/core/env';
+import { analyticsEnv as env, resetAnalyticsEnv as resetEnv } from '@packrat/env/analytics';
 import { afterEach, describe, expect, it } from 'vitest';
 
 afterEach(() => resetEnv());

--- a/packages/env/package.json
+++ b/packages/env/package.json
@@ -8,7 +8,8 @@
     "./node": "./src/node.ts",
     "./next": "./src/next.ts",
     "./expo-client": "./src/expo-client.ts",
-    "./expo-server": "./src/expo-server.ts"
+    "./expo-server": "./src/expo-server.ts",
+    "./analytics": "./src/analytics.ts"
   },
   "main": "./src/index.ts",
   "types": "./src/index.ts",

--- a/packages/env/scripts/no-raw-process-env.ts
+++ b/packages/env/scripts/no-raw-process-env.ts
@@ -11,6 +11,7 @@
 //   - packages/env/src/next.ts          — the Next.js shim itself
 //   - packages/env/src/expo-client.ts   — the Expo client shim itself
 //   - packages/env/src/expo-server.ts   — the Expo server shim itself
+//   - packages/env/src/analytics.ts     — the analytics CLI shim itself
 //   - .github/scripts/configure-deps.ts — preinstall hook, runs before node_modules
 //   - .github/scripts/env.ts            — postinstall hook, runs before node_modules
 //   - packages/api/src/utils/env-validation.ts — Cloudflare Worker runtime (uses c.env)
@@ -34,6 +35,7 @@ const ALLOWED: string[] = [
   'packages/env/src/next.ts',
   'packages/env/src/expo-client.ts',
   'packages/env/src/expo-server.ts',
+  'packages/env/src/analytics.ts',
   '.github/scripts/configure-deps.ts',
   '.github/scripts/env.ts',
   'packages/api/src/utils/env-validation.ts',
@@ -44,8 +46,6 @@ const ALLOWED: string[] = [
   'packages/env/scripts/no-raw-process-env.ts',
   // Startup script — passes process.env to a validator; correct pattern for Node scripts
   'packages/api/scripts/validate-cloudflare-api-env.ts',
-  // Analytics env shim — this IS the shim, same as packages/env/src/*.ts above
-  'packages/analytics/src/core/env.ts',
   // One-off sync script, not app code
   'apps/guides/scripts/sync-to-r2.ts',
   // Test files that mutate process.env to exercise env-validation logic

--- a/packages/env/src/analytics.ts
+++ b/packages/env/src/analytics.ts
@@ -1,0 +1,131 @@
+/**
+ * Analytics CLI environment shim (`packages/analytics`).
+ * Parses `process.env` lazily on first call using Zod and exports typed
+ * accessors. Kept in `@packrat/env` so all env validation lives in one place.
+ *
+ * Adding a new variable: declare it on `analyticsEnvSchema`, mark it
+ * `.optional()` unless every caller genuinely requires it.
+ */
+
+import { z } from 'zod';
+
+const analyticsEnvSchema = z
+  .object({
+    ANALYTICS_MODE: z.enum(['local', 'catalog']).default('local'),
+
+    // S3 credentials (required for local mode + publish)
+    R2_ACCESS_KEY_ID: z.string().optional(),
+    R2_SECRET_ACCESS_KEY: z.string().optional(),
+    PACKRAT_SCRAPY_BUCKET_R2_BUCKET_NAME: z.string().optional(),
+    PACKRAT_ITEMS_BUCKET_R2_BUCKET_NAME: z.string().optional(),
+    R2_BUCKET_NAME: z.string().optional(),
+    R2_ENDPOINT_URL: z.string().url().optional(),
+    CLOUDFLARE_ACCOUNT_ID: z.string().optional(),
+
+    // Iceberg credentials (required for catalog mode + publish)
+    R2_CATALOG_TOKEN: z.string().optional(),
+    R2_CATALOG_URI: z.string().optional(),
+    R2_WAREHOUSE_NAME: z.string().optional(),
+  })
+  .transform((raw) => ({
+    ANALYTICS_MODE: raw.ANALYTICS_MODE,
+    R2_ACCESS_KEY_ID: raw.R2_ACCESS_KEY_ID ?? '',
+    R2_SECRET_ACCESS_KEY: raw.R2_SECRET_ACCESS_KEY ?? '',
+    R2_BUCKET_NAME:
+      raw.PACKRAT_SCRAPY_BUCKET_R2_BUCKET_NAME ??
+      raw.PACKRAT_ITEMS_BUCKET_R2_BUCKET_NAME ??
+      raw.R2_BUCKET_NAME ??
+      '',
+    R2_ENDPOINT_URL:
+      raw.R2_ENDPOINT_URL ??
+      (raw.CLOUDFLARE_ACCOUNT_ID
+        ? `https://${raw.CLOUDFLARE_ACCOUNT_ID}.r2.cloudflarestorage.com`
+        : ''),
+    R2_CATALOG_TOKEN: raw.R2_CATALOG_TOKEN ?? '',
+    R2_CATALOG_URI: raw.R2_CATALOG_URI ?? '',
+    R2_WAREHOUSE_NAME: raw.R2_WAREHOUSE_NAME ?? '',
+  }))
+  .superRefine((data, ctx) => {
+    if (data.ANALYTICS_MODE === 'local') {
+      if (!data.R2_ACCESS_KEY_ID) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: 'R2_ACCESS_KEY_ID is required for local mode',
+          path: ['R2_ACCESS_KEY_ID'],
+        });
+      }
+      if (!data.R2_SECRET_ACCESS_KEY) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: 'R2_SECRET_ACCESS_KEY is required for local mode',
+          path: ['R2_SECRET_ACCESS_KEY'],
+        });
+      }
+      if (!data.R2_BUCKET_NAME) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message:
+            'R2_BUCKET_NAME (or PACKRAT_SCRAPY_BUCKET_R2_BUCKET_NAME / PACKRAT_ITEMS_BUCKET_R2_BUCKET_NAME) is required for local mode',
+          path: ['R2_BUCKET_NAME'],
+        });
+      }
+      if (!data.R2_ENDPOINT_URL) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: 'R2_ENDPOINT_URL (or CLOUDFLARE_ACCOUNT_ID) is required for local mode',
+          path: ['R2_ENDPOINT_URL'],
+        });
+      }
+    }
+    if (data.ANALYTICS_MODE === 'catalog') {
+      if (!data.R2_CATALOG_TOKEN) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: 'R2_CATALOG_TOKEN is required for catalog mode',
+          path: ['R2_CATALOG_TOKEN'],
+        });
+      }
+      if (!data.R2_CATALOG_URI) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: 'R2_CATALOG_URI is required for catalog mode',
+          path: ['R2_CATALOG_URI'],
+        });
+      }
+      if (!data.R2_WAREHOUSE_NAME) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: 'R2_WAREHOUSE_NAME is required for catalog mode',
+          path: ['R2_WAREHOUSE_NAME'],
+        });
+      }
+    }
+  });
+
+export type AnalyticsEnv = z.output<typeof analyticsEnvSchema>;
+
+let _cached: AnalyticsEnv | undefined;
+
+/** Lazily validates and returns analytics env vars. Throws on missing required vars. */
+export function analyticsEnv(): AnalyticsEnv {
+  if (!_cached)
+    _cached = analyticsEnvSchema.parse({
+      ANALYTICS_MODE: process.env.ANALYTICS_MODE,
+      R2_ACCESS_KEY_ID: process.env.R2_ACCESS_KEY_ID,
+      R2_SECRET_ACCESS_KEY: process.env.R2_SECRET_ACCESS_KEY,
+      PACKRAT_SCRAPY_BUCKET_R2_BUCKET_NAME: process.env.PACKRAT_SCRAPY_BUCKET_R2_BUCKET_NAME,
+      PACKRAT_ITEMS_BUCKET_R2_BUCKET_NAME: process.env.PACKRAT_ITEMS_BUCKET_R2_BUCKET_NAME,
+      R2_BUCKET_NAME: process.env.R2_BUCKET_NAME,
+      R2_ENDPOINT_URL: process.env.R2_ENDPOINT_URL,
+      CLOUDFLARE_ACCOUNT_ID: process.env.CLOUDFLARE_ACCOUNT_ID,
+      R2_CATALOG_TOKEN: process.env.R2_CATALOG_TOKEN,
+      R2_CATALOG_URI: process.env.R2_CATALOG_URI,
+      R2_WAREHOUSE_NAME: process.env.R2_WAREHOUSE_NAME,
+    });
+  return _cached;
+}
+
+/** Reset cached env (for testing). */
+export function resetAnalyticsEnv(): void {
+  _cached = undefined;
+}

--- a/packages/env/src/next.ts
+++ b/packages/env/src/next.ts
@@ -24,4 +24,7 @@ export type GuideEnv = z.infer<typeof guideEnvSchema>;
  * Typed env parsed from `process.env` at module load. Throws a Zod
  * validation error if any value fails its schema constraint.
  */
-export const guideEnv = guideEnvSchema.parse(process.env);
+export const guideEnv = guideEnvSchema.parse({
+  NODE_ENV: process.env.NODE_ENV,
+  PACKRAT_API_KEY: process.env.PACKRAT_API_KEY,
+});

--- a/packages/env/src/node.ts
+++ b/packages/env/src/node.ts
@@ -70,4 +70,27 @@ export type NodeEnv = z.infer<typeof nodeEnvSchema>;
  * Typed env parsed from `process.env` at module load. Throws a Zod
  * validation error if any value fails its schema constraint.
  */
-export const nodeEnv = nodeEnvSchema.parse(process.env);
+export const nodeEnv = nodeEnvSchema.parse({
+  NODE_ENV: process.env.NODE_ENV,
+  CI: process.env.CI,
+  GITHUB_ACTIONS: process.env.GITHUB_ACTIONS,
+  PACKRAT_NATIVEWIND_UI_GITHUB_TOKEN: process.env.PACKRAT_NATIVEWIND_UI_GITHUB_TOKEN,
+  NEON_DATABASE_URL: process.env.NEON_DATABASE_URL,
+  NEON_DATABASE_URL_READONLY: process.env.NEON_DATABASE_URL_READONLY,
+  R2_ACCESS_KEY_ID: process.env.R2_ACCESS_KEY_ID,
+  R2_SECRET_ACCESS_KEY: process.env.R2_SECRET_ACCESS_KEY,
+  R2_ENDPOINT_URL: process.env.R2_ENDPOINT_URL,
+  R2_BUCKET_NAME: process.env.R2_BUCKET_NAME,
+  PACKRAT_SCRAPY_BUCKET_R2_BUCKET_NAME: process.env.PACKRAT_SCRAPY_BUCKET_R2_BUCKET_NAME,
+  PACKRAT_ITEMS_BUCKET_R2_BUCKET_NAME: process.env.PACKRAT_ITEMS_BUCKET_R2_BUCKET_NAME,
+  R2_CATALOG_TOKEN: process.env.R2_CATALOG_TOKEN,
+  R2_CATALOG_URI: process.env.R2_CATALOG_URI,
+  R2_WAREHOUSE_NAME: process.env.R2_WAREHOUSE_NAME,
+  GOOGLE_GENAI_API_KEY: process.env.GOOGLE_GENAI_API_KEY,
+  CLOUDFLARE_CONTAINER_ID: process.env.CLOUDFLARE_CONTAINER_ID,
+  PORT: process.env.PORT,
+  VITEST: process.env.VITEST,
+  DEBUG: process.env.DEBUG,
+  E2E_TEST_EMAIL: process.env.E2E_TEST_EMAIL,
+  E2E_TEST_PASSWORD: process.env.E2E_TEST_PASSWORD,
+});


### PR DESCRIPTION
## Summary

- `packages/env/src/next.ts`: replace `guideEnvSchema.parse(process.env)` with explicit key enumeration
- `packages/env/src/node.ts`: replace `nodeEnvSchema.parse(process.env)` with all 22 vars listed explicitly
- `packages/analytics/src/core/env.ts`: replace `envSchema.parse(process.env)` with all 11 vars listed explicitly

**Why:** Passing `process.env` as a whole object silently breaks Next.js / webpack static replacement — `DefinePlugin` only substitutes `process.env.FOO` at the call site, not when the full object is spread. Explicit access also makes the required var surface auditable at a glance and guards against future bundler surprises.

## Test plan
- [ ] `bun check-types` passes from repo root
- [ ] `apps/guides` and `apps/landing` build without ZodError (NEXT_PUBLIC / NODE_ENV now correctly inlined)
- [ ] Analytics CLI (`packages/analytics`) validates env on first call without error