### PR TITLE
fix(admin): remove CF identity bypass — always require Bearer JWT

### DIFF
--- a/apps/admin/app/login/page.tsx
+++ b/apps/admin/app/login/page.tsx
@@ -15,7 +15,7 @@ import { useCFAccessIdentity } from 'admin-app/lib/cfAccess';
 import { adminEnv } from 'admin-app/lib/env';
 import { Package, Shield } from 'lucide-react';
 import { useRouter } from 'next/navigation';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 
 const API_BASE = adminEnv.NEXT_PUBLIC_API_URL;
 
@@ -27,10 +27,6 @@ export default function LoginPage() {
   const [pending, setPending] = useState(false);
 
   const { data: cfIdentity, isPending: cfPending } = useCFAccessIdentity();
-
-  useEffect(() => {
-    if (!cfPending && cfIdentity) router.replace('/dashboard');
-  }, [cfPending, cfIdentity, router]);
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
@@ -64,9 +60,6 @@ export default function LoginPage() {
       setPending(false);
     }
   }
-
-  // Redirect in progress (behind CF Access) — show nothing while navigating
-  if (!cfPending && cfIdentity) return null;
 
   return (
     <div className="min-h-screen flex items-center justify-center bg-background px-4">

--- a/apps/admin/components/auth-guard.tsx
+++ b/apps/admin/components/auth-guard.tsx
@@ -1,21 +1,17 @@
 'use client';
 
 import { getStoredToken } from 'admin-app/lib/auth';
-import { useCFAccessIdentity } from 'admin-app/lib/cfAccess';
 import { useRouter } from 'next/navigation';
 import type React from 'react';
 import { useEffect } from 'react';
 
 export function AuthGuard({ children }: { children: React.ReactNode }) {
   const router = useRouter();
-  const { data: cfIdentity, isPending } = useCFAccessIdentity();
 
   useEffect(() => {
-    if (isPending) return;
-    if (cfIdentity) return; // CF Access session active — allow through
     if (!getStoredToken()) router.replace('/login');
-  }, [isPending, cfIdentity, router]);
+  }, [router]);
 
-  if (isPending || (!cfIdentity && !getStoredToken())) return null;
+  if (!getStoredToken()) return null;
   return <>{children}</>;
 }


### PR DESCRIPTION
## Root cause

`AuthGuard` was checking `cfIdentity || getStoredToken()` to decide whether to render the dashboard. When behind CF Access, `cfIdentity` is truthy so the dashboard rendered even with no stored Bearer token. Every API call then went out with no `Authorization` header → 401 → `clearToken()` + redirect to `/login` → CF identity detected → redirect to `/dashboard` → infinite loop.

`LoginPage` made it worse by auto-redirecting to `/dashboard` as soon as CF identity resolved, so the login form was never shown and no Bearer JWT was ever obtained.

## Fix

- `AuthGuard`: gates only on `getStoredToken()` — Bearer JWT is the single source of truth for "logged in". Removes `useCFAccessIdentity` dependency entirely.
- `LoginPage`: removes `useEffect` redirect and early-return on `cfIdentity`. User always sees the form and must submit credentials. The CF identity hint at the bottom still shows to signal they're behind CF Access.

## Why this is correct

The API requires `Authorization: Bearer <jwt>` on every protected route regardless of CF Access state. CF identity is only relevant at the `/token` endpoint (server-side verification). The client should not treat CF identity as a substitute for a Bearer token.

## Test plan
- [ ] Local dev: login form shows, credentials accepted, dashboard loads, no 401 loop
- [ ] Production (behind CF Access): login form shows (with "CF Access active" hint removed since we removed that logic — adjust if needed), credentials accepted, dashboard loads