### PR TITLE
fix(admin): wire CF Access two-factor auth for browser SPA login

### DIFF
--- a/apps/admin/app/login/page.tsx
+++ b/apps/admin/app/login/page.tsx
@@ -36,6 +36,7 @@ export default function LoginPage() {
     try {
       const res = await fetch(`${API_BASE}/api/admin/token`, {
         method: 'POST',
+        credentials: 'include',
         headers: {
           Authorization: `Basic ${btoa(`${username}:${password}`)}`,
         },

--- a/apps/admin/lib/api.ts
+++ b/apps/admin/lib/api.ts
@@ -13,6 +13,7 @@ const API_BASE = adminEnv.NEXT_PUBLIC_API_URL;
 async function adminFetch<T>(path: string, init?: RequestInit): Promise<T> {
   const authHeaders = getAuthHeader();
   const res = await fetch(`${API_BASE}/api/admin${path}`, {
+    credentials: 'include',
     ...init,
     headers: {
       'Content-Type': 'application/json',

--- a/packages/api/src/routes/admin/index.ts
+++ b/packages/api/src/routes/admin/index.ts
@@ -145,7 +145,8 @@ export const adminRoutes = new Elysia({ prefix: '/admin' })
     {
       detail: {
         tags: ['Admin'],
-        summary: 'Exchange Basic credentials for a short-lived admin JWT (CF JWT required when CF vars are set)',
+        summary:
+          'Exchange Basic credentials for a short-lived admin JWT (CF JWT required when CF vars are set)',
       },
     },
   )

--- a/packages/api/src/routes/admin/index.ts
+++ b/packages/api/src/routes/admin/index.ts
@@ -1,3 +1,4 @@
+import { cors } from '@elysiajs/cors';
 import { createDb } from '@packrat/api/db';
 import { catalogItems, packs, users } from '@packrat/api/db/schema';
 import { verifyCFAccessRequest } from '@packrat/api/middleware/cfAccess';
@@ -89,6 +90,17 @@ async function adminAuthGuard(request: Request): Promise<boolean> {
 // ---------------------------------------------------------------------------
 
 export const adminRoutes = new Elysia({ prefix: '/admin' })
+  // Scoped CORS: credentials: true lets the admin SPA send its CF Access session
+  // cookie cross-origin so CF Access can inject Cf-Access-Jwt-Assertion.
+  // allowedHeaders must list Authorization explicitly (wildcards + credentials
+  // is rejected by browsers per the CORS spec).
+  .use(
+    cors({
+      origin: 'https://admin.packratai.com',
+      credentials: true,
+      allowedHeaders: ['Authorization', 'Content-Type'],
+    }),
+  )
   // Token exchange — must be registered BEFORE the auth guard so the admin
   // SPA can exchange Basic credentials for a short-lived JWT.
   .post(
@@ -103,9 +115,10 @@ export const adminRoutes = new Elysia({ prefix: '/admin' })
 
       const { CF_ACCESS_TEAM_DOMAIN, CF_ACCESS_AUD } = env;
 
-      // CF JWT required when: CF vars are set OR running in production.
-      // The ENVIRONMENT check is a safety net — missing CF vars in prod must not
-      // silently downgrade to Basic-only.
+      // CF JWT is an optional extra layer: required only when both CF vars are set.
+      // The admin SPA sends credentials: 'include' so the CF Access session cookie
+      // travels cross-origin; the CF edge then injects Cf-Access-Jwt-Assertion.
+      // Basic credentials are always required and remain the primary gate.
       if (CF_ACCESS_TEAM_DOMAIN && CF_ACCESS_AUD) {
         const cfIdentity = await verifyCFAccessRequest(
           request,
@@ -113,9 +126,6 @@ export const adminRoutes = new Elysia({ prefix: '/admin' })
           CF_ACCESS_AUD,
         );
         if (!cfIdentity) return status(401, { error: 'CF Access authentication required' });
-      } else if (env.ENVIRONMENT === 'production') {
-        // CF vars missing but we're in production — refuse rather than fall back.
-        return status(503, { error: 'Server misconfiguration: CF Access not configured' });
       }
 
       const header = request.headers.get('authorization') ?? '';
@@ -135,7 +145,7 @@ export const adminRoutes = new Elysia({ prefix: '/admin' })
     {
       detail: {
         tags: ['Admin'],
-        summary: 'Exchange Basic credentials for a short-lived admin JWT (CF JWT required in prod)',
+        summary: 'Exchange Basic credentials for a short-lived admin JWT (CF JWT required when CF vars are set)',
       },
     },
   )

--- a/packages/api/test/admin-auth-guard.test.ts
+++ b/packages/api/test/admin-auth-guard.test.ts
@@ -3,8 +3,7 @@
  *
  * Auth model:
  *   - /token (CF configured):  CF JWT + Basic  → Bearer JWT
- *   - /token (dev, no CF vars): Basic only      → Bearer JWT
- *   - /token (prod, no CF vars): 503 misconfiguration
+ *   - /token (no CF vars, any env): Basic only → Bearer JWT
  *   - Protected routes: Bearer JWT always accepted; Basic only in dev (no CF vars)
  *
  * verifyCFAccessRequest is globally mocked in test/setup.ts (returns null by
@@ -236,18 +235,18 @@ describe('/api/admin/token — CF Access configured (two-factor)', () => {
 });
 
 // ---------------------------------------------------------------------------
-// /token — ENVIRONMENT=production, no CF vars: 503 misconfiguration guard
+// /token — no CF vars (any environment): Basic-only is accepted
 // ---------------------------------------------------------------------------
-describe('/api/admin/token — ENVIRONMENT=production, no CF vars', () => {
-  it('returns 503 instead of falling back to Basic-only', async () => {
+describe('/api/admin/token — no CF vars configured (any environment)', () => {
+  it('issues a JWT with Basic credentials when CF vars are absent in production', async () => {
     const envProd = withEnv({ ENVIRONMENT: 'production' }) as ReturnType<typeof getEnv>;
-    vi.mocked(getEnv).mockReturnValueOnce(envProd);
+    vi.mocked(getEnv).mockReturnValueOnce(envProd).mockReturnValueOnce(envProd);
 
     const credentials = btoa('admin:admin-password');
     const res = await app.fetch(tokenReq({ authorization: `Basic ${credentials}` }));
-    expect(res.status).toBe(503);
-    const body = (await res.json()) as { error: string };
-    expect(body.error).toContain('misconfiguration');
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { token: string };
+    expect(typeof body.token).toBe('string');
   });
 });
 


### PR DESCRIPTION
## Summary

- Removes the `ENVIRONMENT=production` 503 guard on `/token` — Basic-only auth remains valid when CF vars are absent (no CF account configured)
- Adds scoped CORS on `adminRoutes` (`origin: admin.packratai.com`, `credentials: true`) so the browser can send the CF Access session cookie cross-origin; CF edge then injects `Cf-Access-Jwt-Assertion`
- Adds `credentials: 'include'` to `adminFetch` and the login page fetch so the CF Access session cookie travels with every request to the API
- Fixes the auth loop introduced by the CF identity bypass in the previous PR

## Auth model after this PR

| Environment | `/token` accepts | Protected routes accept |
|---|---|---|
| CF vars set | CF JWT + Basic → Bearer | Bearer only |
| No CF vars, any env | Basic → Bearer | Bearer only (+ Basic in local dev) |

## Test plan

- [ ] Local dev: login with Basic credentials works, dashboard loads
- [ ] Production with CF vars: verify CF Access session cookie is sent cross-origin (check Network tab — response should have `Access-Control-Allow-Credentials: true`)
- [ ] Set Worker secrets: `CF_ACCESS_TEAM_DOMAIN=packratai.cloudflareaccess.com` and `CF_ACCESS_AUD=e20d5eb0fbeb3a16ddf92fc8dbedac4b68b234757f1e97afe68891ade5b60942`

🤖 Generated with [Claude Code](https://claude.com/claude-code)