### PR TITLE
feat(admin): pagination, search debounce, reset-stuck UI, error boundaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ report.[0-9]_.[0-9]_.[0-9]_.[0-9]_.json
 
 # Git worktrees
 .worktrees/
+.worktrees

--- a/apps/admin/app/dashboard/catalog/page.tsx
+++ b/apps/admin/app/dashboard/catalog/page.tsx
@@ -14,12 +14,13 @@ import {
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { DeleteButton } from 'admin-app/components/delete-button';
 import { EditCatalogDialog } from 'admin-app/components/edit-catalog-dialog';
+import { RawObjectDialog } from 'admin-app/components/raw-object-dialog';
 import { SearchInput } from 'admin-app/components/search-input';
 import { usePaginatedSearch } from 'admin-app/hooks/use-paginated-search';
 import { type AdminCatalogItem, deleteCatalogItem, getCatalogItems } from 'admin-app/lib/api';
 import { formatDate } from 'admin-app/lib/date';
 import { queryKeys } from 'admin-app/lib/queryKeys';
-import { ChevronLeft, ChevronRight } from 'lucide-react';
+import { ChevronLeft, ChevronRight, ExternalLink, Star } from 'lucide-react';
 
 const PAGE_SIZE = 50;
 
@@ -36,12 +37,19 @@ function TableSkeleton() {
           <Skeleton className="h-4 w-24" />
           <Skeleton className="h-4 w-16" />
           <Skeleton className="h-4 w-16" />
+          <Skeleton className="h-4 w-20" />
           <Skeleton className="h-4 w-24" />
-          <Skeleton className="h-4 w-12" />
+          <Skeleton className="h-4 w-16" />
         </div>
       ))}
     </div>
   );
+}
+
+function availabilityColor(availability: string | null) {
+  if (availability === 'InStock') return 'text-green-500';
+  if (availability === 'OutOfStock') return 'text-destructive';
+  return 'text-muted-foreground';
 }
 
 function CatalogRow({ item }: { item: AdminCatalogItem }) {
@@ -58,8 +66,26 @@ function CatalogRow({ item }: { item: AdminCatalogItem }) {
     <TableRow className="hover:bg-muted/20">
       <TableCell>
         <div>
-          <p className="text-sm font-medium">{item.name}</p>
-          {item.brand && <p className="text-xs text-muted-foreground">{item.brand}</p>}
+          <div className="flex items-center gap-1.5">
+            <p className="text-sm font-medium">{item.name}</p>
+            {item.productUrl && (
+              <a
+                href={item.productUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-muted-foreground hover:text-foreground"
+              >
+                <ExternalLink className="h-3 w-3" />
+              </a>
+            )}
+          </div>
+          <div className="flex items-center gap-2 mt-0.5">
+            {item.brand && <span className="text-xs text-muted-foreground">{item.brand}</span>}
+            {item.model && <span className="text-xs text-muted-foreground/60">{item.model}</span>}
+          </div>
+          {item.description && (
+            <p className="text-xs text-muted-foreground line-clamp-1 mt-0.5">{item.description}</p>
+          )}
         </div>
       </TableCell>
       <TableCell>
@@ -87,8 +113,26 @@ function CatalogRow({ item }: { item: AdminCatalogItem }) {
       </TableCell>
       <TableCell>
         <span className="text-sm text-muted-foreground">
-          {item.price != null ? `$${item.price.toFixed(2)}` : '—'}
+          {item.price != null
+            ? `${item.currency && item.currency !== 'USD' ? item.currency + ' ' : '$'}${item.price.toFixed(2)}`
+            : '—'}
         </span>
+      </TableCell>
+      <TableCell>
+        <div className="space-y-0.5">
+          <span className={`text-xs font-medium ${availabilityColor(item.availability)}`}>
+            {item.availability ?? '—'}
+          </span>
+          {item.ratingValue != null && (
+            <div className="flex items-center gap-1">
+              <Star className="h-3 w-3 fill-amber-400 text-amber-400" />
+              <span className="text-xs text-muted-foreground">
+                {item.ratingValue.toFixed(1)}
+                {item.reviewCount != null && ` (${item.reviewCount})`}
+              </span>
+            </div>
+          )}
+        </div>
       </TableCell>
       <TableCell>
         <span className="text-sm text-muted-foreground">
@@ -97,6 +141,7 @@ function CatalogRow({ item }: { item: AdminCatalogItem }) {
       </TableCell>
       <TableCell>
         <div className="flex items-center gap-1">
+          <RawObjectDialog label={`item:${item.id}`} data={item} />
           <EditCatalogDialog item={item} />
           <DeleteButton
             label={item.name}
@@ -162,15 +207,18 @@ export default function CatalogPage() {
                       Price
                     </TableHead>
                     <TableHead className="font-medium text-xs uppercase tracking-wide">
+                      Status
+                    </TableHead>
+                    <TableHead className="font-medium text-xs uppercase tracking-wide">
                       Added
                     </TableHead>
-                    <TableHead className="font-medium text-xs uppercase tracking-wide w-20" />
+                    <TableHead className="font-medium text-xs uppercase tracking-wide w-24" />
                   </TableRow>
                 </TableHeader>
                 <TableBody>
                   {items.length === 0 ? (
                     <TableRow>
-                      <TableCell colSpan={6} className="text-center text-muted-foreground py-8">
+                      <TableCell colSpan={7} className="text-center text-muted-foreground py-8">
                         No catalog items found{q ? ` matching "${q}"` : ''}.
                       </TableCell>
                     </TableRow>

--- a/apps/admin/app/dashboard/catalog/page.tsx
+++ b/apps/admin/app/dashboard/catalog/page.tsx
@@ -114,7 +114,7 @@ function CatalogRow({ item }: { item: AdminCatalogItem }) {
       <TableCell>
         <span className="text-sm text-muted-foreground">
           {item.price != null
-            ? `${item.currency && item.currency !== 'USD' ? item.currency + ' ' : '$'}${item.price.toFixed(2)}`
+            ? `${item.currency && item.currency !== 'USD' ? `${item.currency} ` : '$'}${item.price.toFixed(2)}`
             : '—'}
         </span>
       </TableCell>

--- a/apps/admin/app/dashboard/catalog/page.tsx
+++ b/apps/admin/app/dashboard/catalog/page.tsx
@@ -50,7 +50,7 @@ function CatalogRow({ item }: { item: AdminCatalogItem }) {
   const { mutateAsync: handleDelete } = useMutation({
     mutationFn: () => deleteCatalogItem(item.id),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: queryKeys.admin.catalog.all });
+      queryClient.invalidateQueries({ queryKey: queryKeys.admin.catalog.all() });
     },
   });
 

--- a/apps/admin/app/dashboard/catalog/page.tsx
+++ b/apps/admin/app/dashboard/catalog/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { Badge } from '@packrat/web-ui/components/badge';
+import { Button } from '@packrat/web-ui/components/button';
 import { Skeleton } from '@packrat/web-ui/components/skeleton';
 import {
   Table,
@@ -17,7 +18,11 @@ import { SearchInput } from 'admin-app/components/search-input';
 import { type AdminCatalogItem, deleteCatalogItem, getCatalogItems } from 'admin-app/lib/api';
 import { formatDate } from 'admin-app/lib/date';
 import { queryKeys } from 'admin-app/lib/queryKeys';
-import { useSearchParams } from 'next/navigation';
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { useTransition } from 'react';
+
+const PAGE_SIZE = 50;
 
 function TableSkeleton() {
   return (
@@ -108,17 +113,37 @@ function CatalogRow({ item }: { item: AdminCatalogItem }) {
 }
 
 export default function CatalogPage() {
+  const router = useRouter();
   const searchParams = useSearchParams();
+  const [, startTransition] = useTransition();
+
   const q = searchParams?.get('q') ?? undefined;
+  const page = Math.max(0, Number(searchParams?.get('page') ?? '0'));
+  const offset = page * PAGE_SIZE;
 
   const {
     data: items = [],
     isLoading,
     isError,
   } = useQuery({
-    queryKey: queryKeys.admin.catalog(q),
-    queryFn: () => getCatalogItems({ q }),
+    queryKey: queryKeys.admin.catalog({ q, page }),
+    queryFn: () => getCatalogItems({ q, limit: PAGE_SIZE, offset }),
   });
+
+  function setPage(next: number) {
+    const params = new URLSearchParams(searchParams?.toString() ?? '');
+    if (next === 0) {
+      params.delete('page');
+    } else {
+      params.set('page', String(next));
+    }
+    startTransition(() => {
+      router.replace(`?${params.toString()}`, { scroll: false });
+    });
+  }
+
+  const hasPrev = page > 0;
+  const hasNext = items.length === PAGE_SIZE;
 
   return (
     <div>
@@ -173,10 +198,34 @@ export default function CatalogPage() {
                 </TableBody>
               </Table>
             </div>
-            <p className="text-xs text-muted-foreground">
-              {items.length.toLocaleString()} item{items.length !== 1 ? 's' : ''}
-              {q ? ` matching "${q}"` : ''}
-            </p>
+            <div className="flex items-center justify-between">
+              <p className="text-xs text-muted-foreground">
+                {items.length === 0
+                  ? `No items${q ? ` matching "${q}"` : ''}`
+                  : `${(offset + 1).toLocaleString()}–${(offset + items.length).toLocaleString()} items${q ? ` matching "${q}"` : ''}`}
+              </p>
+              <div className="flex items-center gap-2">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => setPage(page - 1)}
+                  disabled={!hasPrev}
+                >
+                  <ChevronLeft className="h-4 w-4" />
+                  Prev
+                </Button>
+                <span className="text-xs text-muted-foreground">Page {page + 1}</span>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => setPage(page + 1)}
+                  disabled={!hasNext}
+                >
+                  Next
+                  <ChevronRight className="h-4 w-4" />
+                </Button>
+              </div>
+            </div>
           </>
         )}
       </div>

--- a/apps/admin/app/dashboard/catalog/page.tsx
+++ b/apps/admin/app/dashboard/catalog/page.tsx
@@ -19,8 +19,7 @@ import { type AdminCatalogItem, deleteCatalogItem, getCatalogItems } from 'admin
 import { formatDate } from 'admin-app/lib/date';
 import { queryKeys } from 'admin-app/lib/queryKeys';
 import { ChevronLeft, ChevronRight } from 'lucide-react';
-import { useRouter, useSearchParams } from 'next/navigation';
-import { useTransition } from 'react';
+import { parseAsInteger, parseAsString, useQueryState } from 'nuqs';
 
 const PAGE_SIZE = 50;
 
@@ -51,7 +50,7 @@ function CatalogRow({ item }: { item: AdminCatalogItem }) {
   const { mutateAsync: handleDelete } = useMutation({
     mutationFn: () => deleteCatalogItem(item.id),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: queryKeys.admin.catalog() });
+      queryClient.invalidateQueries({ queryKey: queryKeys.admin.catalog.all });
     },
   });
 
@@ -113,12 +112,8 @@ function CatalogRow({ item }: { item: AdminCatalogItem }) {
 }
 
 export default function CatalogPage() {
-  const router = useRouter();
-  const searchParams = useSearchParams();
-  const [, startTransition] = useTransition();
-
-  const q = searchParams?.get('q') ?? undefined;
-  const page = Math.max(0, Number(searchParams?.get('page') ?? '0'));
+  const [q] = useQueryState('q', parseAsString.withDefault(''));
+  const [page, setPage] = useQueryState('page', parseAsInteger.withDefault(0));
   const offset = page * PAGE_SIZE;
 
   const {
@@ -126,21 +121,9 @@ export default function CatalogPage() {
     isLoading,
     isError,
   } = useQuery({
-    queryKey: queryKeys.admin.catalog({ q, page }),
-    queryFn: () => getCatalogItems({ q, limit: PAGE_SIZE, offset }),
+    queryKey: queryKeys.admin.catalog.list({ q: q || undefined, page }),
+    queryFn: () => getCatalogItems({ q: q || undefined, limit: PAGE_SIZE, offset }),
   });
-
-  function setPage(next: number) {
-    const params = new URLSearchParams(searchParams?.toString() ?? '');
-    if (next === 0) {
-      params.delete('page');
-    } else {
-      params.set('page', String(next));
-    }
-    startTransition(() => {
-      router.replace(`?${params.toString()}`, { scroll: false });
-    });
-  }
 
   const hasPrev = page > 0;
   const hasNext = items.length === PAGE_SIZE;

--- a/apps/admin/app/dashboard/catalog/page.tsx
+++ b/apps/admin/app/dashboard/catalog/page.tsx
@@ -15,11 +15,11 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { DeleteButton } from 'admin-app/components/delete-button';
 import { EditCatalogDialog } from 'admin-app/components/edit-catalog-dialog';
 import { SearchInput } from 'admin-app/components/search-input';
+import { usePaginatedSearch } from 'admin-app/hooks/use-paginated-search';
 import { type AdminCatalogItem, deleteCatalogItem, getCatalogItems } from 'admin-app/lib/api';
 import { formatDate } from 'admin-app/lib/date';
 import { queryKeys } from 'admin-app/lib/queryKeys';
 import { ChevronLeft, ChevronRight } from 'lucide-react';
-import { parseAsInteger, parseAsString, useQueryState } from 'nuqs';
 
 const PAGE_SIZE = 50;
 
@@ -112,8 +112,7 @@ function CatalogRow({ item }: { item: AdminCatalogItem }) {
 }
 
 export default function CatalogPage() {
-  const [q] = useQueryState('q', parseAsString.withDefault(''));
-  const [page, setPage] = useQueryState('page', parseAsInteger.withDefault(0));
+  const { q, setSearch, page, setPage } = usePaginatedSearch();
   const offset = page * PAGE_SIZE;
 
   const {
@@ -137,7 +136,7 @@ export default function CatalogPage() {
         </p>
       </div>
       <div className="space-y-4">
-        <SearchInput placeholder="Search by name, brand, or category…" />
+        <SearchInput placeholder="Search by name, brand, or category…" onSearch={setSearch} />
         {isError ? (
           <p className="text-sm text-destructive py-4">
             Failed to load catalog. Check that the API is reachable.

--- a/apps/admin/app/dashboard/error.tsx
+++ b/apps/admin/app/dashboard/error.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import { Button } from '@packrat/web-ui/components/button';
+import { useEffect } from 'react';
+
+export default function DashboardError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error('Dashboard error:', error);
+  }, [error]);
+
+  return (
+    <div className="flex flex-col items-center justify-center gap-4 py-20 text-center">
+      <h2 className="text-lg font-semibold">Failed to load</h2>
+      <p className="text-sm text-muted-foreground max-w-sm">
+        {error.message || 'Something went wrong loading this page.'}
+      </p>
+      <Button onClick={reset} variant="outline" size="sm">
+        Try again
+      </Button>
+    </div>
+  );
+}

--- a/apps/admin/app/dashboard/layout.tsx
+++ b/apps/admin/app/dashboard/layout.tsx
@@ -5,10 +5,13 @@ import { AppSidebar } from 'admin-app/components/app-sidebar';
 import { AuthGuard } from 'admin-app/components/auth-guard';
 import { DashboardHeader } from 'admin-app/components/dashboard-header';
 import { ErrorFallback } from 'admin-app/components/error-fallback';
+import { usePathname } from 'next/navigation';
 import type React from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
 
 export default function DashboardLayout({ children }: { children: React.ReactNode }) {
+  const pathname = usePathname();
+
   return (
     <AuthGuard>
       <SidebarProvider>
@@ -16,7 +19,9 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
         <SidebarInset>
           <DashboardHeader />
           <main className="flex-1 overflow-auto p-6">
-            <ErrorBoundary FallbackComponent={ErrorFallback}>{children}</ErrorBoundary>
+            <ErrorBoundary FallbackComponent={ErrorFallback} resetKeys={[pathname]}>
+              {children}
+            </ErrorBoundary>
           </main>
         </SidebarInset>
       </SidebarProvider>

--- a/apps/admin/app/dashboard/layout.tsx
+++ b/apps/admin/app/dashboard/layout.tsx
@@ -1,8 +1,12 @@
+'use client';
+
 import { SidebarInset, SidebarProvider } from '@packrat/web-ui/components/sidebar';
 import { AppSidebar } from 'admin-app/components/app-sidebar';
 import { AuthGuard } from 'admin-app/components/auth-guard';
 import { DashboardHeader } from 'admin-app/components/dashboard-header';
+import { ErrorFallback } from 'admin-app/components/error-fallback';
 import type React from 'react';
+import { ErrorBoundary } from 'react-error-boundary';
 
 export default function DashboardLayout({ children }: { children: React.ReactNode }) {
   return (
@@ -11,7 +15,9 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
         <AppSidebar />
         <SidebarInset>
           <DashboardHeader />
-          <main className="flex-1 overflow-auto p-6">{children}</main>
+          <main className="flex-1 overflow-auto p-6">
+            <ErrorBoundary FallbackComponent={ErrorFallback}>{children}</ErrorBoundary>
+          </main>
         </SidebarInset>
       </SidebarProvider>
     </AuthGuard>

--- a/apps/admin/app/dashboard/packs/page.tsx
+++ b/apps/admin/app/dashboard/packs/page.tsx
@@ -49,7 +49,7 @@ function PackRow({ pack }: { pack: AdminPack }) {
   const { mutateAsync: handleDelete } = useMutation({
     mutationFn: () => deletePack(pack.id),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: queryKeys.admin.packs.all });
+      queryClient.invalidateQueries({ queryKey: queryKeys.admin.packs.all() });
     },
   });
 

--- a/apps/admin/app/dashboard/packs/page.tsx
+++ b/apps/admin/app/dashboard/packs/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { Badge } from '@packrat/web-ui/components/badge';
+import { Button } from '@packrat/web-ui/components/button';
 import { Skeleton } from '@packrat/web-ui/components/skeleton';
 import {
   Table,
@@ -16,7 +17,11 @@ import { SearchInput } from 'admin-app/components/search-input';
 import { type AdminPack, deletePack, getPacks } from 'admin-app/lib/api';
 import { formatDate } from 'admin-app/lib/date';
 import { queryKeys } from 'admin-app/lib/queryKeys';
-import { useSearchParams } from 'next/navigation';
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { useTransition } from 'react';
+
+const PAGE_SIZE = 50;
 
 function TableSkeleton() {
   return (
@@ -93,17 +98,37 @@ function PackRow({ pack }: { pack: AdminPack }) {
 }
 
 export default function PacksPage() {
+  const router = useRouter();
   const searchParams = useSearchParams();
+  const [, startTransition] = useTransition();
+
   const q = searchParams?.get('q') ?? undefined;
+  const page = Math.max(0, Number(searchParams?.get('page') ?? '0'));
+  const offset = page * PAGE_SIZE;
 
   const {
     data: packs = [],
     isLoading,
     isError,
   } = useQuery({
-    queryKey: queryKeys.admin.packs(q),
-    queryFn: () => getPacks({ q }),
+    queryKey: queryKeys.admin.packs({ q, page }),
+    queryFn: () => getPacks({ q, limit: PAGE_SIZE, offset }),
   });
+
+  function setPage(next: number) {
+    const params = new URLSearchParams(searchParams?.toString() ?? '');
+    if (next === 0) {
+      params.delete('page');
+    } else {
+      params.set('page', String(next));
+    }
+    startTransition(() => {
+      router.replace(`?${params.toString()}`, { scroll: false });
+    });
+  }
+
+  const hasPrev = page > 0;
+  const hasNext = packs.length === PAGE_SIZE;
 
   return (
     <div>
@@ -158,10 +183,34 @@ export default function PacksPage() {
                 </TableBody>
               </Table>
             </div>
-            <p className="text-xs text-muted-foreground">
-              {packs.length.toLocaleString()} pack{packs.length !== 1 ? 's' : ''}
-              {q ? ` matching "${q}"` : ''}
-            </p>
+            <div className="flex items-center justify-between">
+              <p className="text-xs text-muted-foreground">
+                {packs.length === 0
+                  ? `No packs${q ? ` matching "${q}"` : ''}`
+                  : `${(offset + 1).toLocaleString()}–${(offset + packs.length).toLocaleString()} packs${q ? ` matching "${q}"` : ''}`}
+              </p>
+              <div className="flex items-center gap-2">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => setPage(page - 1)}
+                  disabled={!hasPrev}
+                >
+                  <ChevronLeft className="h-4 w-4" />
+                  Prev
+                </Button>
+                <span className="text-xs text-muted-foreground">Page {page + 1}</span>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => setPage(page + 1)}
+                  disabled={!hasNext}
+                >
+                  Next
+                  <ChevronRight className="h-4 w-4" />
+                </Button>
+              </div>
+            </div>
           </>
         )}
       </div>

--- a/apps/admin/app/dashboard/packs/page.tsx
+++ b/apps/admin/app/dashboard/packs/page.tsx
@@ -13,6 +13,7 @@ import {
 } from '@packrat/web-ui/components/table';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { DeleteButton } from 'admin-app/components/delete-button';
+import { RawObjectDialog } from 'admin-app/components/raw-object-dialog';
 import { SearchInput } from 'admin-app/components/search-input';
 import { usePaginatedSearch } from 'admin-app/hooks/use-paginated-search';
 import { type AdminPack, deletePack, getPacks } from 'admin-app/lib/api';
@@ -57,9 +58,28 @@ function PackRow({ pack }: { pack: AdminPack }) {
     <TableRow className="hover:bg-muted/20">
       <TableCell>
         <div>
-          <p className="text-sm font-medium">{pack.name}</p>
+          <div className="flex items-center gap-1.5">
+            <p className="text-sm font-medium">{pack.name}</p>
+            {pack.isAIGenerated && (
+              <Badge variant="secondary" className="text-[10px] px-1 py-0">
+                AI
+              </Badge>
+            )}
+          </div>
           {pack.description && (
             <p className="text-xs text-muted-foreground line-clamp-1">{pack.description}</p>
+          )}
+          {pack.tags && pack.tags.length > 0 && (
+            <div className="flex flex-wrap gap-1 mt-1">
+              {pack.tags.slice(0, 3).map((tag) => (
+                <span key={tag} className="text-[10px] text-muted-foreground bg-muted px-1 rounded">
+                  {tag}
+                </span>
+              ))}
+              {pack.tags.length > 3 && (
+                <span className="text-[10px] text-muted-foreground">+{pack.tags.length - 3}</span>
+              )}
+            </div>
           )}
         </div>
       </TableCell>
@@ -84,13 +104,16 @@ function PackRow({ pack }: { pack: AdminPack }) {
         </span>
       </TableCell>
       <TableCell>
-        <DeleteButton
-          label={pack.name}
-          description="The pack will be soft-deleted and hidden from all users."
-          onConfirm={async () => {
-            await handleDelete();
-          }}
-        />
+        <div className="flex items-center gap-1">
+          <RawObjectDialog label={`pack:${pack.id}`} data={pack} />
+          <DeleteButton
+            label={pack.name}
+            description="The pack will be soft-deleted and hidden from all users."
+            onConfirm={async () => {
+              await handleDelete();
+            }}
+          />
+        </div>
       </TableCell>
     </TableRow>
   );

--- a/apps/admin/app/dashboard/packs/page.tsx
+++ b/apps/admin/app/dashboard/packs/page.tsx
@@ -18,8 +18,7 @@ import { type AdminPack, deletePack, getPacks } from 'admin-app/lib/api';
 import { formatDate } from 'admin-app/lib/date';
 import { queryKeys } from 'admin-app/lib/queryKeys';
 import { ChevronLeft, ChevronRight } from 'lucide-react';
-import { useRouter, useSearchParams } from 'next/navigation';
-import { useTransition } from 'react';
+import { parseAsInteger, parseAsString, useQueryState } from 'nuqs';
 
 const PAGE_SIZE = 50;
 
@@ -50,7 +49,7 @@ function PackRow({ pack }: { pack: AdminPack }) {
   const { mutateAsync: handleDelete } = useMutation({
     mutationFn: () => deletePack(pack.id),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: queryKeys.admin.packs() });
+      queryClient.invalidateQueries({ queryKey: queryKeys.admin.packs.all });
     },
   });
 
@@ -98,12 +97,8 @@ function PackRow({ pack }: { pack: AdminPack }) {
 }
 
 export default function PacksPage() {
-  const router = useRouter();
-  const searchParams = useSearchParams();
-  const [, startTransition] = useTransition();
-
-  const q = searchParams?.get('q') ?? undefined;
-  const page = Math.max(0, Number(searchParams?.get('page') ?? '0'));
+  const [q] = useQueryState('q', parseAsString.withDefault(''));
+  const [page, setPage] = useQueryState('page', parseAsInteger.withDefault(0));
   const offset = page * PAGE_SIZE;
 
   const {
@@ -111,21 +106,9 @@ export default function PacksPage() {
     isLoading,
     isError,
   } = useQuery({
-    queryKey: queryKeys.admin.packs({ q, page }),
-    queryFn: () => getPacks({ q, limit: PAGE_SIZE, offset }),
+    queryKey: queryKeys.admin.packs.list({ q: q || undefined, page }),
+    queryFn: () => getPacks({ q: q || undefined, limit: PAGE_SIZE, offset }),
   });
-
-  function setPage(next: number) {
-    const params = new URLSearchParams(searchParams?.toString() ?? '');
-    if (next === 0) {
-      params.delete('page');
-    } else {
-      params.set('page', String(next));
-    }
-    startTransition(() => {
-      router.replace(`?${params.toString()}`, { scroll: false });
-    });
-  }
 
   const hasPrev = page > 0;
   const hasNext = packs.length === PAGE_SIZE;

--- a/apps/admin/app/dashboard/packs/page.tsx
+++ b/apps/admin/app/dashboard/packs/page.tsx
@@ -14,11 +14,11 @@ import {
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { DeleteButton } from 'admin-app/components/delete-button';
 import { SearchInput } from 'admin-app/components/search-input';
+import { usePaginatedSearch } from 'admin-app/hooks/use-paginated-search';
 import { type AdminPack, deletePack, getPacks } from 'admin-app/lib/api';
 import { formatDate } from 'admin-app/lib/date';
 import { queryKeys } from 'admin-app/lib/queryKeys';
 import { ChevronLeft, ChevronRight } from 'lucide-react';
-import { parseAsInteger, parseAsString, useQueryState } from 'nuqs';
 
 const PAGE_SIZE = 50;
 
@@ -97,8 +97,7 @@ function PackRow({ pack }: { pack: AdminPack }) {
 }
 
 export default function PacksPage() {
-  const [q] = useQueryState('q', parseAsString.withDefault(''));
-  const [page, setPage] = useQueryState('page', parseAsInteger.withDefault(0));
+  const { q, setSearch, page, setPage } = usePaginatedSearch();
   const offset = page * PAGE_SIZE;
 
   const {
@@ -122,7 +121,7 @@ export default function PacksPage() {
         </p>
       </div>
       <div className="space-y-4">
-        <SearchInput placeholder="Search by name, owner, or category…" />
+        <SearchInput placeholder="Search by name, owner, or category…" onSearch={setSearch} />
         {isError ? (
           <p className="text-sm text-destructive py-4">
             Failed to load packs. Check that the API is reachable.

--- a/apps/admin/app/dashboard/page.tsx
+++ b/apps/admin/app/dashboard/page.tsx
@@ -53,17 +53,17 @@ export default function DashboardPage() {
   });
 
   const { data: users = [], isLoading: usersLoading } = useQuery({
-    queryKey: queryKeys.admin.users(5),
+    queryKey: queryKeys.admin.users({ limit: 5 }),
     queryFn: () => getUsers({ limit: 5 }),
   });
 
   const { data: packs = [], isLoading: packsLoading } = useQuery({
-    queryKey: queryKeys.admin.packs(5),
+    queryKey: queryKeys.admin.packs({ limit: 5 }),
     queryFn: () => getPacks({ limit: 5 }),
   });
 
   const { data: catalog = [], isLoading: catalogLoading } = useQuery({
-    queryKey: queryKeys.admin.catalog(5),
+    queryKey: queryKeys.admin.catalog({ limit: 5 }),
     queryFn: () => getCatalogItems({ limit: 5 }),
   });
 

--- a/apps/admin/app/dashboard/page.tsx
+++ b/apps/admin/app/dashboard/page.tsx
@@ -53,17 +53,17 @@ export default function DashboardPage() {
   });
 
   const { data: users = [], isLoading: usersLoading } = useQuery({
-    queryKey: queryKeys.admin.users({ limit: 5 }),
+    queryKey: queryKeys.admin.users.list({ limit: 5 }),
     queryFn: () => getUsers({ limit: 5 }),
   });
 
   const { data: packs = [], isLoading: packsLoading } = useQuery({
-    queryKey: queryKeys.admin.packs({ limit: 5 }),
+    queryKey: queryKeys.admin.packs.list({ limit: 5 }),
     queryFn: () => getPacks({ limit: 5 }),
   });
 
   const { data: catalog = [], isLoading: catalogLoading } = useQuery({
-    queryKey: queryKeys.admin.catalog({ limit: 5 }),
+    queryKey: queryKeys.admin.catalog.list({ limit: 5 }),
     queryFn: () => getCatalogItems({ limit: 5 }),
   });
 

--- a/apps/admin/app/dashboard/page.tsx
+++ b/apps/admin/app/dashboard/page.tsx
@@ -48,7 +48,7 @@ function OverviewSkeleton() {
 
 export default function DashboardPage() {
   const { data: stats, isLoading: statsLoading } = useQuery({
-    queryKey: queryKeys.admin.stats,
+    queryKey: queryKeys.admin.stats(),
     queryFn: getStats,
   });
 

--- a/apps/admin/app/dashboard/users/page.tsx
+++ b/apps/admin/app/dashboard/users/page.tsx
@@ -14,11 +14,11 @@ import {
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { DeleteButton } from 'admin-app/components/delete-button';
 import { SearchInput } from 'admin-app/components/search-input';
+import { usePaginatedSearch } from 'admin-app/hooks/use-paginated-search';
 import { type AdminUser, deleteUser, getUsers } from 'admin-app/lib/api';
 import { formatDate } from 'admin-app/lib/date';
 import { queryKeys } from 'admin-app/lib/queryKeys';
 import { ChevronLeft, ChevronRight } from 'lucide-react';
-import { parseAsInteger, parseAsString, useQueryState } from 'nuqs';
 
 const PAGE_SIZE = 50;
 
@@ -97,8 +97,7 @@ function UserRow({ user }: { user: AdminUser }) {
 }
 
 export default function UsersPage() {
-  const [q] = useQueryState('q', parseAsString.withDefault(''));
-  const [page, setPage] = useQueryState('page', parseAsInteger.withDefault(0));
+  const { q, setSearch, page, setPage } = usePaginatedSearch();
   const offset = page * PAGE_SIZE;
 
   const {
@@ -122,7 +121,7 @@ export default function UsersPage() {
         </p>
       </div>
       <div className="space-y-4">
-        <SearchInput placeholder="Search by email or name…" />
+        <SearchInput placeholder="Search by email or name…" onSearch={setSearch} />
         {isError ? (
           <p className="text-sm text-destructive py-4">
             Failed to load users. Check that the API is reachable.

--- a/apps/admin/app/dashboard/users/page.tsx
+++ b/apps/admin/app/dashboard/users/page.tsx
@@ -48,7 +48,7 @@ function UserRow({ user }: { user: AdminUser }) {
   const { mutateAsync: handleDelete } = useMutation({
     mutationFn: () => deleteUser(user.id),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: queryKeys.admin.users.all });
+      queryClient.invalidateQueries({ queryKey: queryKeys.admin.users.all() });
     },
   });
 

--- a/apps/admin/app/dashboard/users/page.tsx
+++ b/apps/admin/app/dashboard/users/page.tsx
@@ -13,6 +13,7 @@ import {
 } from '@packrat/web-ui/components/table';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { DeleteButton } from 'admin-app/components/delete-button';
+import { RawObjectDialog } from 'admin-app/components/raw-object-dialog';
 import { SearchInput } from 'admin-app/components/search-input';
 import { usePaginatedSearch } from 'admin-app/hooks/use-paginated-search';
 import { type AdminUser, deleteUser, getUsers } from 'admin-app/lib/api';
@@ -35,7 +36,7 @@ function TableSkeleton() {
           <Skeleton className="h-4 w-16" />
           <Skeleton className="h-4 w-12" />
           <Skeleton className="h-4 w-24" />
-          <Skeleton className="h-4 w-8" />
+          <Skeleton className="h-4 w-16" />
         </div>
       ))}
     </div>
@@ -55,15 +56,30 @@ function UserRow({ user }: { user: AdminUser }) {
   return (
     <TableRow className="hover:bg-muted/20">
       <TableCell>
-        <div>
-          <p className="text-sm font-medium">
-            {user.firstName || user.lastName
-              ? [user.firstName, user.lastName].filter(Boolean).join(' ')
-              : user.email}
-          </p>
-          {(user.firstName || user.lastName) && (
-            <p className="text-xs text-muted-foreground">{user.email}</p>
+        <div className="flex items-center gap-2">
+          {user.avatarUrl ? (
+            <img
+              src={user.avatarUrl}
+              alt=""
+              className="h-6 w-6 rounded-full object-cover shrink-0"
+            />
+          ) : (
+            <div className="h-6 w-6 rounded-full bg-muted flex items-center justify-center shrink-0">
+              <span className="text-[10px] font-medium text-muted-foreground uppercase">
+                {user.firstName?.[0] ?? user.email[0] ?? '?'}
+              </span>
+            </div>
           )}
+          <div>
+            <p className="text-sm font-medium">
+              {user.firstName || user.lastName
+                ? [user.firstName, user.lastName].filter(Boolean).join(' ')
+                : user.email}
+            </p>
+            {(user.firstName || user.lastName) && (
+              <p className="text-xs text-muted-foreground">{user.email}</p>
+            )}
+          </div>
         </div>
       </TableCell>
       <TableCell>
@@ -84,13 +100,16 @@ function UserRow({ user }: { user: AdminUser }) {
         </span>
       </TableCell>
       <TableCell>
-        <DeleteButton
-          label={user.email}
-          description="The user account and all associated data will be permanently deleted."
-          onConfirm={async () => {
-            await handleDelete();
-          }}
-        />
+        <div className="flex items-center gap-1">
+          <RawObjectDialog label={`user:${user.id}`} data={user} />
+          <DeleteButton
+            label={user.email}
+            description="The user account and all associated data will be permanently deleted."
+            onConfirm={async () => {
+              await handleDelete();
+            }}
+          />
+        </div>
       </TableCell>
     </TableRow>
   );
@@ -146,7 +165,7 @@ export default function UsersPage() {
                     <TableHead className="font-medium text-xs uppercase tracking-wide">
                       Joined
                     </TableHead>
-                    <TableHead className="font-medium text-xs uppercase tracking-wide w-16" />
+                    <TableHead className="font-medium text-xs uppercase tracking-wide w-20" />
                   </TableRow>
                 </TableHeader>
                 <TableBody>

--- a/apps/admin/app/dashboard/users/page.tsx
+++ b/apps/admin/app/dashboard/users/page.tsx
@@ -18,8 +18,7 @@ import { type AdminUser, deleteUser, getUsers } from 'admin-app/lib/api';
 import { formatDate } from 'admin-app/lib/date';
 import { queryKeys } from 'admin-app/lib/queryKeys';
 import { ChevronLeft, ChevronRight } from 'lucide-react';
-import { useRouter, useSearchParams } from 'next/navigation';
-import { useTransition } from 'react';
+import { parseAsInteger, parseAsString, useQueryState } from 'nuqs';
 
 const PAGE_SIZE = 50;
 
@@ -49,7 +48,7 @@ function UserRow({ user }: { user: AdminUser }) {
   const { mutateAsync: handleDelete } = useMutation({
     mutationFn: () => deleteUser(user.id),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: queryKeys.admin.users() });
+      queryClient.invalidateQueries({ queryKey: queryKeys.admin.users.all });
     },
   });
 
@@ -98,12 +97,8 @@ function UserRow({ user }: { user: AdminUser }) {
 }
 
 export default function UsersPage() {
-  const router = useRouter();
-  const searchParams = useSearchParams();
-  const [, startTransition] = useTransition();
-
-  const q = searchParams?.get('q') ?? undefined;
-  const page = Math.max(0, Number(searchParams?.get('page') ?? '0'));
+  const [q] = useQueryState('q', parseAsString.withDefault(''));
+  const [page, setPage] = useQueryState('page', parseAsInteger.withDefault(0));
   const offset = page * PAGE_SIZE;
 
   const {
@@ -111,21 +106,9 @@ export default function UsersPage() {
     isLoading,
     isError,
   } = useQuery({
-    queryKey: queryKeys.admin.users({ q, page }),
-    queryFn: () => getUsers({ q, limit: PAGE_SIZE, offset }),
+    queryKey: queryKeys.admin.users.list({ q: q || undefined, page }),
+    queryFn: () => getUsers({ q: q || undefined, limit: PAGE_SIZE, offset }),
   });
-
-  function setPage(next: number) {
-    const params = new URLSearchParams(searchParams?.toString() ?? '');
-    if (next === 0) {
-      params.delete('page');
-    } else {
-      params.set('page', String(next));
-    }
-    startTransition(() => {
-      router.replace(`?${params.toString()}`, { scroll: false });
-    });
-  }
 
   const hasPrev = page > 0;
   const hasNext = users.length === PAGE_SIZE;

--- a/apps/admin/app/dashboard/users/page.tsx
+++ b/apps/admin/app/dashboard/users/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { Badge } from '@packrat/web-ui/components/badge';
+import { Button } from '@packrat/web-ui/components/button';
 import { Skeleton } from '@packrat/web-ui/components/skeleton';
 import {
   Table,
@@ -16,7 +17,11 @@ import { SearchInput } from 'admin-app/components/search-input';
 import { type AdminUser, deleteUser, getUsers } from 'admin-app/lib/api';
 import { formatDate } from 'admin-app/lib/date';
 import { queryKeys } from 'admin-app/lib/queryKeys';
-import { useSearchParams } from 'next/navigation';
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { useTransition } from 'react';
+
+const PAGE_SIZE = 50;
 
 function TableSkeleton() {
   return (
@@ -93,17 +98,37 @@ function UserRow({ user }: { user: AdminUser }) {
 }
 
 export default function UsersPage() {
+  const router = useRouter();
   const searchParams = useSearchParams();
+  const [, startTransition] = useTransition();
+
   const q = searchParams?.get('q') ?? undefined;
+  const page = Math.max(0, Number(searchParams?.get('page') ?? '0'));
+  const offset = page * PAGE_SIZE;
 
   const {
     data: users = [],
     isLoading,
     isError,
   } = useQuery({
-    queryKey: queryKeys.admin.users(q),
-    queryFn: () => getUsers({ q }),
+    queryKey: queryKeys.admin.users({ q, page }),
+    queryFn: () => getUsers({ q, limit: PAGE_SIZE, offset }),
   });
+
+  function setPage(next: number) {
+    const params = new URLSearchParams(searchParams?.toString() ?? '');
+    if (next === 0) {
+      params.delete('page');
+    } else {
+      params.set('page', String(next));
+    }
+    startTransition(() => {
+      router.replace(`?${params.toString()}`, { scroll: false });
+    });
+  }
+
+  const hasPrev = page > 0;
+  const hasNext = users.length === PAGE_SIZE;
 
   return (
     <div>
@@ -155,10 +180,34 @@ export default function UsersPage() {
                 </TableBody>
               </Table>
             </div>
-            <p className="text-xs text-muted-foreground">
-              {users.length.toLocaleString()} user{users.length !== 1 ? 's' : ''}
-              {q ? ` matching "${q}"` : ''}
-            </p>
+            <div className="flex items-center justify-between">
+              <p className="text-xs text-muted-foreground">
+                {users.length === 0
+                  ? `No users${q ? ` matching "${q}"` : ''}`
+                  : `${(offset + 1).toLocaleString()}–${(offset + users.length).toLocaleString()} users${q ? ` matching "${q}"` : ''}`}
+              </p>
+              <div className="flex items-center gap-2">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => setPage(page - 1)}
+                  disabled={!hasPrev}
+                >
+                  <ChevronLeft className="h-4 w-4" />
+                  Prev
+                </Button>
+                <span className="text-xs text-muted-foreground">Page {page + 1}</span>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => setPage(page + 1)}
+                  disabled={!hasNext}
+                >
+                  Next
+                  <ChevronRight className="h-4 w-4" />
+                </Button>
+              </div>
+            </div>
           </>
         )}
       </div>

--- a/apps/admin/app/dashboard/users/page.tsx
+++ b/apps/admin/app/dashboard/users/page.tsx
@@ -20,6 +20,7 @@ import { type AdminUser, deleteUser, getUsers } from 'admin-app/lib/api';
 import { formatDate } from 'admin-app/lib/date';
 import { queryKeys } from 'admin-app/lib/queryKeys';
 import { ChevronLeft, ChevronRight } from 'lucide-react';
+import Image from 'next/image';
 
 const PAGE_SIZE = 50;
 
@@ -58,10 +59,12 @@ function UserRow({ user }: { user: AdminUser }) {
       <TableCell>
         <div className="flex items-center gap-2">
           {user.avatarUrl ? (
-            <img
+            <Image
               src={user.avatarUrl}
               alt=""
-              className="h-6 w-6 rounded-full object-cover shrink-0"
+              width={24}
+              height={24}
+              className="rounded-full object-cover shrink-0"
             />
           ) : (
             <div className="h-6 w-6 rounded-full bg-muted flex items-center justify-center shrink-0">

--- a/apps/admin/app/error.tsx
+++ b/apps/admin/app/error.tsx
@@ -3,7 +3,7 @@
 import { Button } from '@packrat/web-ui/components/button';
 import { useEffect } from 'react';
 
-export default function GlobalError({
+export default function RootError({
   error,
   reset,
 }: {

--- a/apps/admin/app/error.tsx
+++ b/apps/admin/app/error.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import { Button } from '@packrat/web-ui/components/button';
+import { useEffect } from 'react';
+
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error('App error:', error);
+  }, [error]);
+
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center gap-4 p-8 text-center">
+      <h2 className="text-xl font-semibold">Something went wrong</h2>
+      <p className="text-sm text-muted-foreground max-w-sm">
+        {error.message || 'An unexpected error occurred.'}
+      </p>
+      <Button onClick={reset} variant="outline" size="sm">
+        Try again
+      </Button>
+    </div>
+  );
+}

--- a/apps/admin/app/global-error.tsx
+++ b/apps/admin/app/global-error.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import { useEffect } from 'react';
+
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error('Global error:', error);
+  }, [error]);
+
+  return (
+    <html lang="en">
+      <body
+        style={{
+          display: 'flex',
+          minHeight: '100vh',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+          gap: '1rem',
+          padding: '2rem',
+          textAlign: 'center',
+          fontFamily: 'system-ui, sans-serif',
+        }}
+      >
+        <h2 style={{ fontSize: '1.25rem', fontWeight: 600, margin: 0 }}>Something went wrong</h2>
+        <p style={{ fontSize: '0.875rem', color: '#6b7280', maxWidth: '24rem', margin: 0 }}>
+          {error.message || 'An unexpected error occurred.'}
+        </p>
+        <button
+          type="button"
+          onClick={reset}
+          style={{
+            padding: '0.375rem 0.875rem',
+            fontSize: '0.875rem',
+            border: '1px solid #d1d5db',
+            borderRadius: '0.375rem',
+            background: 'transparent',
+            cursor: 'pointer',
+          }}
+        >
+          Try again
+        </button>
+      </body>
+    </html>
+  );
+}

--- a/apps/admin/app/global-error.tsx
+++ b/apps/admin/app/global-error.tsx
@@ -30,7 +30,7 @@ export default function GlobalError({
       >
         <h2 style={{ fontSize: '1.25rem', fontWeight: 600, margin: 0 }}>Something went wrong</h2>
         <p style={{ fontSize: '0.875rem', color: '#6b7280', maxWidth: '24rem', margin: 0 }}>
-          {error.message || 'An unexpected error occurred.'}
+          An unexpected error occurred.
         </p>
         <button
           type="button"

--- a/apps/admin/app/layout.tsx
+++ b/apps/admin/app/layout.tsx
@@ -3,6 +3,7 @@ import { QueryProvider } from 'admin-app/components/query-provider';
 import { ThemeProvider } from 'admin-app/components/theme-provider';
 import type { Metadata } from 'next';
 import { Mona_Sans as FontSans } from 'next/font/google';
+import { NuqsAdapter } from 'nuqs/adapters/next/app';
 import type React from 'react';
 import './globals.css';
 
@@ -29,16 +30,18 @@ export default function RootLayout({
   return (
     <html lang="en" suppressHydrationWarning>
       <body className={cn('min-h-screen bg-background font-sans antialiased', fontSans.variable)}>
-        <QueryProvider>
-          <ThemeProvider
-            attribute="class"
-            defaultTheme="dark"
-            enableSystem
-            disableTransitionOnChange
-          >
-            {children}
-          </ThemeProvider>
-        </QueryProvider>
+        <NuqsAdapter>
+          <QueryProvider>
+            <ThemeProvider
+              attribute="class"
+              defaultTheme="dark"
+              enableSystem
+              disableTransitionOnChange
+            >
+              {children}
+            </ThemeProvider>
+          </QueryProvider>
+        </NuqsAdapter>
       </body>
     </html>
   );

--- a/apps/admin/components/analytics/catalog-analytics.tsx
+++ b/apps/admin/components/analytics/catalog-analytics.tsx
@@ -64,6 +64,7 @@ export function CatalogAnalytics() {
   const {
     mutate: resetStuck,
     isPending: isResetting,
+    isError: resetFailed,
     data: resetResult,
   } = useMutation({
     mutationFn: resetStuckEtlJobs,
@@ -274,10 +275,14 @@ export function CatalogAnalytics() {
                   {etl.summary.totalRuns} total runs &mdash; {etl.summary.completed} completed,{' '}
                   {etl.summary.failed} failed &mdash;{' '}
                   {etl.summary.totalItemsIngested.toLocaleString()} items ingested
-                  {resetResult && resetResult.reset > 0 && (
+                  {resetFailed && <span className="ml-2 text-destructive">— reset failed</span>}
+                  {!resetFailed && resetResult && resetResult.reset > 0 && (
                     <span className="ml-2 text-green-600 dark:text-green-400">
                       — reset {resetResult.reset} stuck job{resetResult.reset !== 1 ? 's' : ''}
                     </span>
+                  )}
+                  {!resetFailed && resetResult && resetResult.reset === 0 && (
+                    <span className="ml-2 text-muted-foreground">— no stuck jobs found</span>
                   )}
                 </CardDescription>
               </div>

--- a/apps/admin/components/analytics/catalog-analytics.tsx
+++ b/apps/admin/components/analytics/catalog-analytics.tsx
@@ -18,6 +18,7 @@ import {
   ChartTooltipContent,
 } from '@packrat/web-ui/components/chart';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { RawObjectDialog } from 'admin-app/components/raw-object-dialog';
 import {
   useCatalogBrands,
   useCatalogEmbeddings,
@@ -307,8 +308,11 @@ export function CatalogAnalytics() {
                     <th className="pb-2 text-left font-medium">Status</th>
                     <th className="pb-2 text-right font-medium">Processed</th>
                     <th className="pb-2 text-right font-medium">Valid</th>
+                    <th className="pb-2 text-right font-medium">Invalid</th>
                     <th className="pb-2 text-right font-medium">Success %</th>
                     <th className="pb-2 text-left font-medium">Started</th>
+                    <th className="pb-2 text-left font-medium">Completed</th>
+                    <th className="pb-2 w-8" />
                   </tr>
                 </thead>
                 <tbody>
@@ -327,10 +331,25 @@ export function CatalogAnalytics() {
                         {job.totalValid?.toLocaleString() ?? '—'}
                       </td>
                       <td className="py-2 pr-4 text-right">
+                        {job.totalInvalid != null ? (
+                          <span className={job.totalInvalid > 0 ? 'text-destructive' : ''}>
+                            {job.totalInvalid.toLocaleString()}
+                          </span>
+                        ) : (
+                          '—'
+                        )}
+                      </td>
+                      <td className="py-2 pr-4 text-right">
                         {job.successRate != null ? `${job.successRate}%` : '—'}
                       </td>
-                      <td className="py-2 text-muted-foreground">
+                      <td className="py-2 pr-4 text-muted-foreground">
                         {new Date(job.startedAt).toLocaleDateString()}
+                      </td>
+                      <td className="py-2 pr-4 text-muted-foreground">
+                        {job.completedAt ? new Date(job.completedAt).toLocaleDateString() : '—'}
+                      </td>
+                      <td className="py-2">
+                        <RawObjectDialog label={`job:${job.id}`} data={job} />
                       </td>
                     </tr>
                   ))}

--- a/apps/admin/components/analytics/catalog-analytics.tsx
+++ b/apps/admin/components/analytics/catalog-analytics.tsx
@@ -68,7 +68,7 @@ export function CatalogAnalytics() {
   } = useMutation({
     mutationFn: resetStuckEtlJobs,
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: queryKeys.catalogAnalytics.etl.all });
+      queryClient.invalidateQueries({ queryKey: queryKeys.catalogAnalytics.etl.all() });
     },
   });
 

--- a/apps/admin/components/analytics/catalog-analytics.tsx
+++ b/apps/admin/components/analytics/catalog-analytics.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { Badge } from '@packrat/web-ui/components/badge';
+import { Button } from '@packrat/web-ui/components/button';
 import {
   Card,
   CardContent,
@@ -16,6 +17,7 @@ import {
   ChartTooltip,
   ChartTooltipContent,
 } from '@packrat/web-ui/components/chart';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import {
   useCatalogBrands,
   useCatalogEmbeddings,
@@ -23,6 +25,9 @@ import {
   useCatalogOverview,
   useCatalogPrices,
 } from 'admin-app/hooks/use-catalog-analytics';
+import { resetStuckEtlJobs } from 'admin-app/lib/api';
+import { queryKeys } from 'admin-app/lib/queryKeys';
+import { RotateCcw } from 'lucide-react';
 import { Bar, BarChart, CartesianGrid, Cell, Pie, PieChart, XAxis, YAxis } from 'recharts';
 
 const priceConfig: ChartConfig = {
@@ -49,11 +54,23 @@ function statusBadgeVariant(status: string): 'default' | 'secondary' | 'destruct
 }
 
 export function CatalogAnalytics() {
+  const queryClient = useQueryClient();
   const { data: overview } = useCatalogOverview();
   const { data: brands } = useCatalogBrands(15);
   const { data: prices } = useCatalogPrices();
   const { data: etl } = useCatalogEtl(15);
   const { data: embeddings } = useCatalogEmbeddings();
+
+  const {
+    mutate: resetStuck,
+    isPending: isResetting,
+    data: resetResult,
+  } = useMutation({
+    mutationFn: resetStuckEtlJobs,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.catalogAnalytics.etl() });
+    },
+  });
 
   const availConfig: ChartConfig = Object.fromEntries(
     (overview?.availability ?? []).map((a, i) => [
@@ -250,12 +267,31 @@ export function CatalogAnalytics() {
       {etl && (
         <Card>
           <CardHeader>
-            <CardTitle>ETL Pipeline</CardTitle>
-            <CardDescription>
-              {etl.summary.totalRuns} total runs &mdash; {etl.summary.completed} completed,{' '}
-              {etl.summary.failed} failed &mdash; {etl.summary.totalItemsIngested.toLocaleString()}{' '}
-              items ingested
-            </CardDescription>
+            <div className="flex items-start justify-between gap-4">
+              <div>
+                <CardTitle>ETL Pipeline</CardTitle>
+                <CardDescription>
+                  {etl.summary.totalRuns} total runs &mdash; {etl.summary.completed} completed,{' '}
+                  {etl.summary.failed} failed &mdash;{' '}
+                  {etl.summary.totalItemsIngested.toLocaleString()} items ingested
+                  {resetResult && resetResult.reset > 0 && (
+                    <span className="ml-2 text-green-600 dark:text-green-400">
+                      — reset {resetResult.reset} stuck job{resetResult.reset !== 1 ? 's' : ''}
+                    </span>
+                  )}
+                </CardDescription>
+              </div>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => resetStuck()}
+                disabled={isResetting}
+                className="shrink-0"
+              >
+                <RotateCcw className={`h-3.5 w-3.5 mr-1.5 ${isResetting ? 'animate-spin' : ''}`} />
+                Reset Stuck
+              </Button>
+            </div>
           </CardHeader>
           <CardContent>
             <div className="overflow-x-auto">

--- a/apps/admin/components/analytics/catalog-analytics.tsx
+++ b/apps/admin/components/analytics/catalog-analytics.tsx
@@ -68,7 +68,7 @@ export function CatalogAnalytics() {
   } = useMutation({
     mutationFn: resetStuckEtlJobs,
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: queryKeys.catalogAnalytics.etl() });
+      queryClient.invalidateQueries({ queryKey: queryKeys.catalogAnalytics.etl.all });
     },
   });
 

--- a/apps/admin/components/edit-catalog-dialog.tsx
+++ b/apps/admin/components/edit-catalog-dialog.tsx
@@ -29,7 +29,7 @@ export function EditCatalogDialog({ item }: EditCatalogDialogProps) {
   const { mutate, isPending } = useMutation({
     mutationFn: (data: Parameters<typeof updateCatalogItem>[1]) => updateCatalogItem(item.id, data),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: queryKeys.admin.catalog.all });
+      queryClient.invalidateQueries({ queryKey: queryKeys.admin.catalog.all() });
       setOpen(false);
     },
   });

--- a/apps/admin/components/edit-catalog-dialog.tsx
+++ b/apps/admin/components/edit-catalog-dialog.tsx
@@ -29,7 +29,7 @@ export function EditCatalogDialog({ item }: EditCatalogDialogProps) {
   const { mutate, isPending } = useMutation({
     mutationFn: (data: Parameters<typeof updateCatalogItem>[1]) => updateCatalogItem(item.id, data),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: queryKeys.admin.catalog() });
+      queryClient.invalidateQueries({ queryKey: queryKeys.admin.catalog.all });
       setOpen(false);
     },
   });

--- a/apps/admin/components/error-fallback.tsx
+++ b/apps/admin/components/error-fallback.tsx
@@ -1,15 +1,18 @@
 'use client';
 
 import { Button } from '@packrat/web-ui/components/button';
+import { useEffect } from 'react';
 import type { FallbackProps } from 'react-error-boundary';
 
 export function ErrorFallback({ error, resetErrorBoundary }: FallbackProps) {
+  useEffect(() => {
+    console.error('Dashboard error:', error);
+  }, [error]);
+
   return (
     <div className="flex flex-col items-center justify-center gap-4 py-20 text-center">
       <h2 className="text-lg font-semibold">Something went wrong</h2>
-      <p className="text-sm text-muted-foreground max-w-sm">
-        {error instanceof Error ? error.message : 'An unexpected error occurred.'}
-      </p>
+      <p className="text-sm text-muted-foreground max-w-sm">An unexpected error occurred.</p>
       <Button onClick={resetErrorBoundary} variant="outline" size="sm">
         Try again
       </Button>

--- a/apps/admin/components/error-fallback.tsx
+++ b/apps/admin/components/error-fallback.tsx
@@ -1,0 +1,18 @@
+'use client';
+
+import { Button } from '@packrat/web-ui/components/button';
+import type { FallbackProps } from 'react-error-boundary';
+
+export function ErrorFallback({ error, resetErrorBoundary }: FallbackProps) {
+  return (
+    <div className="flex flex-col items-center justify-center gap-4 py-20 text-center">
+      <h2 className="text-lg font-semibold">Something went wrong</h2>
+      <p className="text-sm text-muted-foreground max-w-sm">
+        {error instanceof Error ? error.message : 'An unexpected error occurred.'}
+      </p>
+      <Button onClick={resetErrorBoundary} variant="outline" size="sm">
+        Try again
+      </Button>
+    </div>
+  );
+}

--- a/apps/admin/components/raw-object-dialog.tsx
+++ b/apps/admin/components/raw-object-dialog.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import { Button } from '@packrat/web-ui/components/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@packrat/web-ui/components/dialog';
+import { Braces } from 'lucide-react';
+
+interface RawObjectDialogProps {
+  label: string;
+  data: unknown;
+}
+
+export function RawObjectDialog({ label, data }: RawObjectDialogProps) {
+  return (
+    <Dialog>
+      <DialogTrigger asChild>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-7 w-7 text-muted-foreground hover:text-foreground"
+        >
+          <Braces className="h-3.5 w-3.5" />
+          <span className="sr-only">View raw {label}</span>
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="max-w-2xl">
+        <DialogHeader>
+          <DialogTitle className="font-mono text-sm">{label}</DialogTitle>
+        </DialogHeader>
+        <div className="max-h-[60vh] overflow-auto rounded-md bg-muted p-4">
+          <pre className="text-xs leading-relaxed text-foreground whitespace-pre-wrap break-all">
+            {JSON.stringify(data, null, 2)}
+          </pre>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/admin/components/raw-object-dialog.tsx
+++ b/apps/admin/components/raw-object-dialog.tsx
@@ -4,6 +4,7 @@ import { Button } from '@packrat/web-ui/components/button';
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogHeader,
   DialogTitle,
   DialogTrigger,
@@ -31,6 +32,7 @@ export function RawObjectDialog({ label, data }: RawObjectDialogProps) {
       <DialogContent className="max-w-2xl">
         <DialogHeader>
           <DialogTitle className="font-mono text-sm">{label}</DialogTitle>
+          <DialogDescription className="sr-only">Raw JSON data for {label}</DialogDescription>
         </DialogHeader>
         <div className="max-h-[60vh] overflow-auto rounded-md bg-muted p-4">
           <pre className="text-xs leading-relaxed text-foreground whitespace-pre-wrap break-all">

--- a/apps/admin/components/search-input.tsx
+++ b/apps/admin/components/search-input.tsx
@@ -7,9 +7,14 @@ import { parseAsString, useQueryState } from 'nuqs';
 interface SearchInputProps {
   placeholder?: string;
   paramKey?: string;
+  onSearch?: (value: string) => void;
 }
 
-export function SearchInput({ placeholder = 'Search…', paramKey = 'q' }: SearchInputProps) {
+export function SearchInput({
+  placeholder = 'Search…',
+  paramKey = 'q',
+  onSearch,
+}: SearchInputProps) {
   const [value, setValue] = useQueryState(
     paramKey,
     parseAsString
@@ -17,15 +22,18 @@ export function SearchInput({ placeholder = 'Search…', paramKey = 'q' }: Searc
       .withOptions({ shallow: false, throttleMs: 300, clearOnDefault: true }),
   );
 
+  function handleChange(e: React.ChangeEvent<HTMLInputElement>) {
+    if (onSearch) {
+      onSearch(e.target.value);
+    } else {
+      void setValue(e.target.value || null);
+    }
+  }
+
   return (
     <div className="relative max-w-sm">
       <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground pointer-events-none" />
-      <Input
-        value={value}
-        onChange={(e) => setValue(e.target.value)}
-        placeholder={placeholder}
-        className="pl-9"
-      />
+      <Input value={value} onChange={handleChange} placeholder={placeholder} className="pl-9" />
     </div>
   );
 }

--- a/apps/admin/components/search-input.tsx
+++ b/apps/admin/components/search-input.tsx
@@ -3,32 +3,46 @@
 import { Input } from '@packrat/web-ui/components/input';
 import { Search } from 'lucide-react';
 import { useRouter, useSearchParams } from 'next/navigation';
-import { Suspense, useCallback, useTransition } from 'react';
+import { Suspense, useCallback, useEffect, useRef, useState, useTransition } from 'react';
 
 interface SearchInputProps {
   placeholder?: string;
   paramKey?: string;
 }
 
-// Inner component — must be inside <Suspense> because it calls useSearchParams()
 function SearchInputInner({ placeholder = 'Search…', paramKey = 'q' }: SearchInputProps) {
   const router = useRouter();
   const searchParams = useSearchParams();
   const [, startTransition] = useTransition();
 
-  const value = searchParams?.get(paramKey) ?? '';
+  const urlValue = searchParams?.get(paramKey) ?? '';
+  const [inputValue, setInputValue] = useState(urlValue);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Keep input in sync if URL changes externally (e.g. browser back)
+  useEffect(() => {
+    setInputValue(urlValue);
+  }, [urlValue]);
 
   const handleChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
-      const next = new URLSearchParams(searchParams?.toString() ?? '');
-      if (e.target.value) {
-        next.set(paramKey, e.target.value);
-      } else {
-        next.delete(paramKey);
-      }
-      startTransition(() => {
-        router.replace(`?${next.toString()}`, { scroll: false });
-      });
+      const next = e.target.value;
+      setInputValue(next);
+
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+      debounceRef.current = setTimeout(() => {
+        const params = new URLSearchParams(searchParams?.toString() ?? '');
+        if (next) {
+          params.set(paramKey, next);
+        } else {
+          params.delete(paramKey);
+        }
+        // Also reset pagination when search changes
+        params.delete('page');
+        startTransition(() => {
+          router.replace(`?${params.toString()}`, { scroll: false });
+        });
+      }, 300);
     },
     [router, searchParams, paramKey],
   );
@@ -36,12 +50,16 @@ function SearchInputInner({ placeholder = 'Search…', paramKey = 'q' }: SearchI
   return (
     <div className="relative max-w-sm">
       <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground pointer-events-none" />
-      <Input value={value} onChange={handleChange} placeholder={placeholder} className="pl-9" />
+      <Input
+        value={inputValue}
+        onChange={handleChange}
+        placeholder={placeholder}
+        className="pl-9"
+      />
     </div>
   );
 }
 
-// Fallback shown while the inner component suspends
 function SearchInputFallback({ placeholder }: Pick<SearchInputProps, 'placeholder'>) {
   return (
     <div className="relative max-w-sm">

--- a/apps/admin/components/search-input.tsx
+++ b/apps/admin/components/search-input.tsx
@@ -2,77 +2,30 @@
 
 import { Input } from '@packrat/web-ui/components/input';
 import { Search } from 'lucide-react';
-import { useRouter, useSearchParams } from 'next/navigation';
-import { Suspense, useCallback, useEffect, useRef, useState, useTransition } from 'react';
+import { parseAsString, useQueryState } from 'nuqs';
 
 interface SearchInputProps {
   placeholder?: string;
   paramKey?: string;
 }
 
-function SearchInputInner({ placeholder = 'Search…', paramKey = 'q' }: SearchInputProps) {
-  const router = useRouter();
-  const searchParams = useSearchParams();
-  const [, startTransition] = useTransition();
-
-  const urlValue = searchParams?.get(paramKey) ?? '';
-  const [inputValue, setInputValue] = useState(urlValue);
-  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  // Keep input in sync if URL changes externally (e.g. browser back)
-  useEffect(() => {
-    setInputValue(urlValue);
-  }, [urlValue]);
-
-  const handleChange = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) => {
-      const next = e.target.value;
-      setInputValue(next);
-
-      if (debounceRef.current) clearTimeout(debounceRef.current);
-      debounceRef.current = setTimeout(() => {
-        const params = new URLSearchParams(searchParams?.toString() ?? '');
-        if (next) {
-          params.set(paramKey, next);
-        } else {
-          params.delete(paramKey);
-        }
-        // Also reset pagination when search changes
-        params.delete('page');
-        startTransition(() => {
-          router.replace(`?${params.toString()}`, { scroll: false });
-        });
-      }, 300);
-    },
-    [router, searchParams, paramKey],
+export function SearchInput({ placeholder = 'Search…', paramKey = 'q' }: SearchInputProps) {
+  const [value, setValue] = useQueryState(
+    paramKey,
+    parseAsString
+      .withDefault('')
+      .withOptions({ shallow: false, throttleMs: 300, clearOnDefault: true }),
   );
 
   return (
     <div className="relative max-w-sm">
       <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground pointer-events-none" />
       <Input
-        value={inputValue}
-        onChange={handleChange}
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
         placeholder={placeholder}
         className="pl-9"
       />
     </div>
-  );
-}
-
-function SearchInputFallback({ placeholder }: Pick<SearchInputProps, 'placeholder'>) {
-  return (
-    <div className="relative max-w-sm">
-      <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground pointer-events-none" />
-      <Input placeholder={placeholder ?? 'Search…'} className="pl-9" disabled />
-    </div>
-  );
-}
-
-export function SearchInput(props: SearchInputProps) {
-  return (
-    <Suspense fallback={<SearchInputFallback placeholder={props.placeholder} />}>
-      <SearchInputInner {...props} />
-    </Suspense>
   );
 }

--- a/apps/admin/hooks/use-catalog-analytics.ts
+++ b/apps/admin/hooks/use-catalog-analytics.ts
@@ -33,7 +33,7 @@ export function useCatalogPrices() {
 
 export function useCatalogEtl(limit = 20) {
   return useQuery({
-    queryKey: queryKeys.catalogAnalytics.etl(limit),
+    queryKey: queryKeys.catalogAnalytics.etl.list(limit),
     queryFn: () => getCatalogEtl(limit),
   });
 }

--- a/apps/admin/hooks/use-catalog-analytics.ts
+++ b/apps/admin/hooks/use-catalog-analytics.ts
@@ -12,7 +12,7 @@ import { queryKeys } from 'admin-app/lib/queryKeys';
 
 export function useCatalogOverview() {
   return useQuery({
-    queryKey: queryKeys.catalogAnalytics.overview,
+    queryKey: queryKeys.catalogAnalytics.overview(),
     queryFn: () => getCatalogOverview(),
   });
 }
@@ -26,7 +26,7 @@ export function useCatalogBrands(limit = 20) {
 
 export function useCatalogPrices() {
   return useQuery({
-    queryKey: queryKeys.catalogAnalytics.prices,
+    queryKey: queryKeys.catalogAnalytics.prices(),
     queryFn: () => getCatalogPrices(),
   });
 }
@@ -40,7 +40,7 @@ export function useCatalogEtl(limit = 20) {
 
 export function useCatalogEmbeddings() {
   return useQuery({
-    queryKey: queryKeys.catalogAnalytics.embeddings,
+    queryKey: queryKeys.catalogAnalytics.embeddings(),
     queryFn: () => getCatalogEmbeddings(),
   });
 }

--- a/apps/admin/hooks/use-paginated-search.ts
+++ b/apps/admin/hooks/use-paginated-search.ts
@@ -1,0 +1,26 @@
+'use client';
+
+import { parseAsInteger, parseAsString, useQueryStates } from 'nuqs';
+import { useCallback } from 'react';
+
+const parsers = {
+  q: parseAsString.withDefault(''),
+  page: parseAsInteger.withDefault(0),
+};
+
+export function usePaginatedSearch() {
+  const [{ q, page }, setParams] = useQueryStates(parsers, { shallow: false });
+
+  // Setting q resets page atomically so users never land on a stale page.
+  const setSearch = useCallback(
+    (next: string) => setParams({ q: next || null, page: null }),
+    [setParams],
+  );
+
+  return {
+    q,
+    setSearch,
+    page: Math.max(0, page),
+    setPage: (next: number) => setParams({ page: next > 0 ? next : null }),
+  };
+}

--- a/apps/admin/hooks/use-platform-analytics.ts
+++ b/apps/admin/hooks/use-platform-analytics.ts
@@ -20,7 +20,7 @@ export function usePlatformActivity(period: 'day' | 'week' | 'month') {
 
 export function usePlatformBreakdown() {
   return useQuery({
-    queryKey: queryKeys.platform.breakdown,
+    queryKey: queryKeys.platform.breakdown(),
     queryFn: () => getPlatformBreakdown(),
   });
 }

--- a/apps/admin/lib/api.ts
+++ b/apps/admin/lib/api.ts
@@ -57,7 +57,9 @@ export interface AdminUser {
   lastName: string | null;
   role: string | null;
   emailVerified: boolean | null;
+  avatarUrl: string | null;
   createdAt: string | null;
+  updatedAt: string | null;
 }
 
 export function getUsers({
@@ -86,7 +88,11 @@ export interface AdminPack {
   description: string | null;
   category: string;
   isPublic: boolean | null;
+  isAIGenerated: boolean;
+  tags: string[] | null;
+  image: string | null;
   createdAt: string | null;
+  updatedAt: string | null;
   userEmail: string | null;
 }
 
@@ -113,11 +119,27 @@ export function deletePack(id: string): Promise<{ success: boolean }> {
 export interface AdminCatalogItem {
   id: number;
   name: string;
+  description: string | null;
   categories: string[] | null;
   brand: string | null;
+  model: string | null;
+  sku: string | null;
   price: number | null;
+  currency: string | null;
   weight: number | null;
   weightUnit: string;
+  availability: string | null;
+  ratingValue: number | null;
+  reviewCount: number | null;
+  color: string | null;
+  size: string | null;
+  material: string | null;
+  seller: string | null;
+  productUrl: string | null;
+  images: string[] | null;
+  variants: Array<{ attribute: string; values: string[] }> | null;
+  techs: Record<string, string> | null;
+  links: Array<{ title: string; url: string }> | null;
   createdAt: string | null;
 }
 

--- a/apps/admin/lib/api.ts
+++ b/apps/admin/lib/api.ts
@@ -246,3 +246,7 @@ export function getCatalogEtl(limit = 20): Promise<EtlResponse> {
 export function getCatalogEmbeddings(): Promise<EmbeddingStats> {
   return adminFetch('/analytics/catalog/embeddings');
 }
+
+export function resetStuckEtlJobs(): Promise<{ reset: number; ids: string[] }> {
+  return adminFetch('/analytics/catalog/etl/reset-stuck', { method: 'POST' });
+}

--- a/apps/admin/lib/cfAccess.ts
+++ b/apps/admin/lib/cfAccess.ts
@@ -60,7 +60,7 @@ export async function isBehindCFAccess(): Promise<boolean> {
  */
 export function useCFAccessIdentity() {
   return useQuery({
-    queryKey: queryKeys.cfAccessIdentity,
+    queryKey: queryKeys.cfAccessIdentity(),
     queryFn: getCFAccessIdentity,
     staleTime: Infinity,
     gcTime: Infinity,

--- a/apps/admin/lib/queryKeys.ts
+++ b/apps/admin/lib/queryKeys.ts
@@ -1,54 +1,57 @@
 /**
  * Centralised query key registry for the admin SPA.
  *
- * All useQuery / useInfiniteQuery / invalidateQueries call sites should
- * reference these constants instead of inlining raw arrays. This makes
- * key shape changes a one-place edit and prevents typo-driven cache misses.
+ * All keys are functions so that:
+ *   - invalidateQueries({ queryKey: queryKeys.admin.users.all() }) uses prefix matching
+ *   - specific keys compose from their parent (e.g. list builds on all)
  *
- * Pattern:
- *   queryKeys.admin.users.list({ q, page })  — for useQuery queryKey
- *   queryKeys.admin.users.all                — for invalidateQueries (prefix match)
+ * Usage:
+ *   queryKey: queryKeys.admin.users.list({ q, page })  — in useQuery
+ *   queryKey: queryKeys.admin.users.all()              — in invalidateQueries
  */
 export const queryKeys = {
-  /** CF Access identity — fetched once per page lifetime. */
-  cfAccessIdentity: ['cf-access-identity'] as const,
+  cfAccessIdentity: () => ['cf-access-identity'] as const,
 
-  /** Admin entity queries (dashboard pages). */
   admin: {
-    stats: ['admin', 'stats'] as const,
+    all: () => ['admin'] as const,
+    stats: () => ['admin', 'stats'] as const,
+
     users: {
-      all: ['admin', 'users'] as const,
+      all: () => ['admin', 'users'] as const,
       list: (params?: { q?: string; page?: number; limit?: number }) =>
         ['admin', 'users', params] as const,
     },
+
     packs: {
-      all: ['admin', 'packs'] as const,
+      all: () => ['admin', 'packs'] as const,
       list: (params?: { q?: string; page?: number; limit?: number }) =>
         ['admin', 'packs', params] as const,
     },
+
     catalog: {
-      all: ['admin', 'catalog'] as const,
+      all: () => ['admin', 'catalog'] as const,
       list: (params?: { q?: string; page?: number; limit?: number }) =>
         ['admin', 'catalog', params] as const,
     },
   },
 
-  /** Platform analytics queries. */
   platform: {
+    all: () => ['platform'] as const,
     growth: (period: string) => ['platform', 'growth', period] as const,
     activity: (period: string) => ['platform', 'activity', period] as const,
-    breakdown: ['platform', 'breakdown'] as const,
+    breakdown: () => ['platform', 'breakdown'] as const,
   },
 
-  /** Catalog analytics queries. */
   catalogAnalytics: {
-    overview: ['catalog', 'overview'] as const,
+    all: () => ['catalog'] as const,
+    overview: () => ['catalog', 'overview'] as const,
     brands: (limit?: number) => ['catalog', 'brands', limit] as const,
-    prices: ['catalog', 'prices'] as const,
+    prices: () => ['catalog', 'prices'] as const,
+    embeddings: () => ['catalog', 'embeddings'] as const,
+
     etl: {
-      all: ['catalog', 'etl'] as const,
+      all: () => ['catalog', 'etl'] as const,
       list: (limit?: number) => ['catalog', 'etl', limit] as const,
     },
-    embeddings: ['catalog', 'embeddings'] as const,
   },
-} as const;
+};

--- a/apps/admin/lib/queryKeys.ts
+++ b/apps/admin/lib/queryKeys.ts
@@ -1,57 +1,52 @@
 /**
- * Centralised query key registry for the admin SPA.
+ * Query key factory following the TkDodo self-referencing pattern.
+ * Each level spreads its parent so invalidating a parent truly invalidates all children.
  *
- * All keys are functions so that:
- *   - invalidateQueries({ queryKey: queryKeys.admin.users.all() }) uses prefix matching
- *   - specific keys compose from their parent (e.g. list builds on all)
- *
- * Usage:
- *   queryKey: queryKeys.admin.users.list({ q, page })  — in useQuery
- *   queryKey: queryKeys.admin.users.all()              — in invalidateQueries
+ * @see https://tkdodo.eu/blog/effective-react-query-keys#use-query-key-factories
  */
 export const queryKeys = {
-  cfAccessIdentity: () => ['cf-access-identity'] as const,
+  cfAccessIdentity: () => ['cfAccessIdentity'] as const,
 
   admin: {
     all: () => ['admin'] as const,
-    stats: () => ['admin', 'stats'] as const,
+    stats: () => [...queryKeys.admin.all(), 'stats'] as const,
 
     users: {
-      all: () => ['admin', 'users'] as const,
+      all: () => [...queryKeys.admin.all(), 'users'] as const,
       list: (params?: { q?: string; page?: number; limit?: number }) =>
-        ['admin', 'users', params] as const,
+        [...queryKeys.admin.users.all(), params] as const,
     },
 
     packs: {
-      all: () => ['admin', 'packs'] as const,
+      all: () => [...queryKeys.admin.all(), 'packs'] as const,
       list: (params?: { q?: string; page?: number; limit?: number }) =>
-        ['admin', 'packs', params] as const,
+        [...queryKeys.admin.packs.all(), params] as const,
     },
 
     catalog: {
-      all: () => ['admin', 'catalog'] as const,
+      all: () => [...queryKeys.admin.all(), 'catalog'] as const,
       list: (params?: { q?: string; page?: number; limit?: number }) =>
-        ['admin', 'catalog', params] as const,
+        [...queryKeys.admin.catalog.all(), params] as const,
     },
   },
 
   platform: {
     all: () => ['platform'] as const,
-    growth: (period: string) => ['platform', 'growth', period] as const,
-    activity: (period: string) => ['platform', 'activity', period] as const,
-    breakdown: () => ['platform', 'breakdown'] as const,
+    growth: (period: string) => [...queryKeys.platform.all(), 'growth', period] as const,
+    activity: (period: string) => [...queryKeys.platform.all(), 'activity', period] as const,
+    breakdown: () => [...queryKeys.platform.all(), 'breakdown'] as const,
   },
 
   catalogAnalytics: {
-    all: () => ['catalog'] as const,
-    overview: () => ['catalog', 'overview'] as const,
-    brands: (limit?: number) => ['catalog', 'brands', limit] as const,
-    prices: () => ['catalog', 'prices'] as const,
-    embeddings: () => ['catalog', 'embeddings'] as const,
+    all: () => ['catalogAnalytics'] as const,
+    overview: () => [...queryKeys.catalogAnalytics.all(), 'overview'] as const,
+    brands: (limit?: number) => [...queryKeys.catalogAnalytics.all(), 'brands', limit] as const,
+    prices: () => [...queryKeys.catalogAnalytics.all(), 'prices'] as const,
+    embeddings: () => [...queryKeys.catalogAnalytics.all(), 'embeddings'] as const,
 
     etl: {
-      all: () => ['catalog', 'etl'] as const,
-      list: (limit?: number) => ['catalog', 'etl', limit] as const,
+      all: () => [...queryKeys.catalogAnalytics.all(), 'etl'] as const,
+      list: (limit?: number) => [...queryKeys.catalogAnalytics.etl.all(), limit] as const,
     },
   },
 };

--- a/apps/admin/lib/queryKeys.ts
+++ b/apps/admin/lib/queryKeys.ts
@@ -4,6 +4,10 @@
  * All useQuery / useInfiniteQuery / invalidateQueries call sites should
  * reference these constants instead of inlining raw arrays. This makes
  * key shape changes a one-place edit and prevents typo-driven cache misses.
+ *
+ * Pattern:
+ *   queryKeys.admin.users.list({ q, page })  — for useQuery queryKey
+ *   queryKeys.admin.users.all                — for invalidateQueries (prefix match)
  */
 export const queryKeys = {
   /** CF Access identity — fetched once per page lifetime. */
@@ -12,12 +16,21 @@ export const queryKeys = {
   /** Admin entity queries (dashboard pages). */
   admin: {
     stats: ['admin', 'stats'] as const,
-    users: (params?: { q?: string; page?: number; limit?: number }) =>
-      ['admin', 'users', params] as const,
-    packs: (params?: { q?: string; page?: number; limit?: number }) =>
-      ['admin', 'packs', params] as const,
-    catalog: (params?: { q?: string; page?: number; limit?: number }) =>
-      ['admin', 'catalog', params] as const,
+    users: {
+      all: ['admin', 'users'] as const,
+      list: (params?: { q?: string; page?: number; limit?: number }) =>
+        ['admin', 'users', params] as const,
+    },
+    packs: {
+      all: ['admin', 'packs'] as const,
+      list: (params?: { q?: string; page?: number; limit?: number }) =>
+        ['admin', 'packs', params] as const,
+    },
+    catalog: {
+      all: ['admin', 'catalog'] as const,
+      list: (params?: { q?: string; page?: number; limit?: number }) =>
+        ['admin', 'catalog', params] as const,
+    },
   },
 
   /** Platform analytics queries. */
@@ -32,7 +45,10 @@ export const queryKeys = {
     overview: ['catalog', 'overview'] as const,
     brands: (limit?: number) => ['catalog', 'brands', limit] as const,
     prices: ['catalog', 'prices'] as const,
-    etl: (limit?: number) => ['catalog', 'etl', limit] as const,
+    etl: {
+      all: ['catalog', 'etl'] as const,
+      list: (limit?: number) => ['catalog', 'etl', limit] as const,
+    },
     embeddings: ['catalog', 'embeddings'] as const,
   },
 } as const;

--- a/apps/admin/lib/queryKeys.ts
+++ b/apps/admin/lib/queryKeys.ts
@@ -12,9 +12,12 @@ export const queryKeys = {
   /** Admin entity queries (dashboard pages). */
   admin: {
     stats: ['admin', 'stats'] as const,
-    users: (limitOrQuery?: number | string) => ['admin', 'users', limitOrQuery] as const,
-    packs: (limitOrQuery?: number | string) => ['admin', 'packs', limitOrQuery] as const,
-    catalog: (limitOrQuery?: number | string) => ['admin', 'catalog', limitOrQuery] as const,
+    users: (params?: { q?: string; page?: number; limit?: number }) =>
+      ['admin', 'users', params] as const,
+    packs: (params?: { q?: string; page?: number; limit?: number }) =>
+      ['admin', 'packs', params] as const,
+    catalog: (params?: { q?: string; page?: number; limit?: number }) =>
+      ['admin', 'catalog', params] as const,
   },
 
   /** Platform analytics queries. */

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -33,6 +33,7 @@
     "lucide-react": "^1.8.0",
     "next": "^15.3.4",
     "next-themes": "^0.4.6",
+    "nuqs": "^2.8.9",
     "react": "catalog:",
     "react-dom": "catalog:",
     "recharts": "3.8.1",

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -36,6 +36,7 @@
     "nuqs": "^2.8.9",
     "react": "catalog:",
     "react-dom": "catalog:",
+    "react-error-boundary": "^6.1.1",
     "recharts": "3.8.1",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.5.0",

--- a/bun.lock
+++ b/bun.lock
@@ -43,6 +43,7 @@
         "lucide-react": "^1.8.0",
         "next": "^15.3.4",
         "next-themes": "^0.4.6",
+        "nuqs": "^2.8.9",
         "react": "catalog:",
         "react-dom": "catalog:",
         "recharts": "3.8.1",
@@ -1741,7 +1742,7 @@
 
     "@stablelib/base64": ["@stablelib/base64@1.0.1", "", {}, "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ=="],
 
-    "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
+    "@standard-schema/spec": ["@standard-schema/spec@1.0.0", "", {}, "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA=="],
 
     "@standard-schema/utils": ["@standard-schema/utils@0.3.0", "", {}, "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g=="],
 
@@ -3221,6 +3222,8 @@
 
     "nullthrows": ["nullthrows@1.1.1", "", {}, "sha512-2vPPEi+Z7WqML2jZYddDIfy5Dqb0r2fze2zTxNNknZaFpVHU3mFB3R+DWeJWGVx0ecvttSGlJTI+WG+8Z4cDWw=="],
 
+    "nuqs": ["nuqs@2.8.9", "", { "dependencies": { "@standard-schema/spec": "1.0.0" }, "peerDependencies": { "@remix-run/react": ">=2", "@tanstack/react-router": "^1", "next": ">=14.2.0", "react": ">=18.2.0 || ^19.0.0-0", "react-router": "^5 || ^6 || ^7", "react-router-dom": "^5 || ^6 || ^7" }, "optionalPeers": ["@remix-run/react", "@tanstack/react-router", "next", "react-router", "react-router-dom"] }, "sha512-8ou6AEwsxMWSYo2qkfZtYFVzngwbKmg4c00HVxC1fF6CEJv3Fwm6eoZmfVPALB+vw8Udo7KL5uy96PFcYe1BIQ=="],
+
     "ob1": ["ob1@0.83.6", "", { "dependencies": { "flow-enums-runtime": "^0.0.6" } }, "sha512-m/xZYkwcjo6UqLMrUICEB3iHk7Bjt3RSR7KXMi6Y1MO/kGkPhoRmfUDF6KAan3rLAZ7ABRqnQyKUTwaqZgUV4w=="],
 
     "object-assign": ["object-assign@4.0.1", "", {}, "sha512-c6legOHWepAbWnp3j5SRUMpxCXBKI4rD7A5Osn9IzZ8w4O/KccXdW0lqdkQKbpk0eHGjNgKihgzY6WuEq99Tfw=="],
@@ -4039,6 +4042,8 @@
 
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
 
+    "@ai-sdk/provider-utils/@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
+
     "@aws-crypto/crc32/@aws-sdk/types": ["@aws-sdk/types@3.973.8", "", { "dependencies": { "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw=="],
 
     "@aws-crypto/crc32c/@aws-sdk/types": ["@aws-sdk/types@3.973.8", "", { "dependencies": { "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw=="],
@@ -4216,6 +4221,8 @@
     "@react-navigation/native/nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 
     "@react-navigation/routers/nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
+
+    "@reduxjs/toolkit/@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
     "@reduxjs/toolkit/immer": ["immer@11.1.4", "", {}, "sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw=="],
 
@@ -4682,6 +4689,10 @@
     "@jest/types/chalk/supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
     "@manypkg/tools/js-yaml/argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
+
+    "@react-native-ai/apple/@ai-sdk/provider-utils/@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
+
+    "@react-native-ai/llama/@ai-sdk/provider-utils/@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
     "@react-native/codegen/glob/minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -46,6 +46,7 @@
         "nuqs": "^2.8.9",
         "react": "catalog:",
         "react-dom": "catalog:",
+        "react-error-boundary": "^6.1.1",
         "recharts": "3.8.1",
         "sonner": "^2.0.7",
         "tailwind-merge": "^3.5.0",
@@ -3435,6 +3436,8 @@
     "react-devtools-core": ["react-devtools-core@6.1.5", "", { "dependencies": { "shell-quote": "^1.6.1", "ws": "^7" } }, "sha512-ePrwPfxAnB+7hgnEr8vpKxL9cmnp7F322t8oqcPshbIQQhDKgFDW4tjhF2wjVbdXF9O/nyuy3sQWd9JGpiLPvA=="],
 
     "react-dom": ["react-dom@19.1.0", "", { "dependencies": { "scheduler": "^0.26.0" }, "peerDependencies": { "react": "^19.1.0" } }, "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g=="],
+
+    "react-error-boundary": ["react-error-boundary@6.1.1", "", { "peerDependencies": { "react": "^18.0.0 || ^19.0.0" } }, "sha512-BrYwPOdXi5mqkk5lw+Uvt0ThHx32rCt3BkukS4X23A2AIWDPSGX6iaWTc0y9TU/mHDA/6qOSGel+B2ERkOvD1w=="],
 
     "react-fast-compare": ["react-fast-compare@3.2.2", "", {}, "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ=="],
 

--- a/packages/api/scripts/reset-stuck-etl-jobs.sql
+++ b/packages/api/scripts/reset-stuck-etl-jobs.sql
@@ -1,7 +1,0 @@
--- Reset ETL jobs stuck in 'running' state for more than 3 hours.
--- 3h accounts for large first-time imports (~500K rows + embedding generation).
--- Run manually when zombie jobs are detected.
-UPDATE etl_jobs
-SET status = 'failed', completed_at = NOW()
-WHERE status = 'running'
-  AND started_at < NOW() - INTERVAL '3 hours';

--- a/packages/api/src/routes/admin/analytics/catalog.ts
+++ b/packages/api/src/routes/admin/analytics/catalog.ts
@@ -1,6 +1,6 @@
 import { createDb } from '@packrat/api/db';
 import { catalogItems, etlJobs } from '@packrat/api/db/schema';
-import { and, avg, count, desc, gt, isNotNull, max, min, sql } from 'drizzle-orm';
+import { and, avg, count, desc, eq, gt, isNotNull, lt, max, min, sql } from 'drizzle-orm';
 import { Elysia, status } from 'elysia';
 import { z } from 'zod';
 
@@ -242,4 +242,26 @@ export const catalogAnalyticsRoutes = new Elysia({ prefix: '/catalog' })
       }
     },
     { detail: { tags: ['Admin'], summary: 'Embedding coverage' } },
+  )
+
+  .post(
+    '/etl/reset-stuck',
+    async () => {
+      const db = createDb();
+      const threeHoursAgo = new Date(Date.now() - 3 * 60 * 60 * 1000);
+
+      try {
+        const reset = await db
+          .update(etlJobs)
+          .set({ status: 'failed', completedAt: new Date() })
+          .where(and(eq(etlJobs.status, 'running'), lt(etlJobs.startedAt, threeHoursAgo)))
+          .returning();
+
+        return { reset: reset.length, ids: reset.map((r) => r.id) };
+      } catch (error) {
+        console.error('ETL reset-stuck error:', error);
+        return status(500, { error: 'Failed to reset stuck jobs', code: 'ETL_RESET_STUCK_ERROR' });
+      }
+    },
+    { detail: { tags: ['Admin'], summary: 'Reset ETL jobs stuck in running state for >3 hours' } },
   );

--- a/packages/api/src/routes/admin/index.ts
+++ b/packages/api/src/routes/admin/index.ts
@@ -203,7 +203,9 @@ export const adminRoutes = new Elysia({ prefix: '/admin' })
             lastName: users.lastName,
             role: users.role,
             emailVerified: users.emailVerified,
+            avatarUrl: users.avatarUrl,
             createdAt: users.createdAt,
+            updatedAt: users.updatedAt,
           })
           .from(users)
           .where(
@@ -221,7 +223,8 @@ export const adminRoutes = new Elysia({ prefix: '/admin' })
 
         return usersList.map((u) => ({
           ...u,
-          createdAt: u.createdAt?.toISOString() || null,
+          createdAt: u.createdAt?.toISOString() ?? null,
+          updatedAt: u.updatedAt?.toISOString() ?? null,
         }));
       } catch (error) {
         console.error('Error fetching users:', error);
@@ -254,7 +257,11 @@ export const adminRoutes = new Elysia({ prefix: '/admin' })
             description: packs.description,
             category: packs.category,
             isPublic: packs.isPublic,
+            isAIGenerated: packs.isAIGenerated,
+            tags: packs.tags,
+            image: packs.image,
             createdAt: packs.createdAt,
+            updatedAt: packs.updatedAt,
             userEmail: users.email,
           })
           .from(packs)
@@ -278,7 +285,8 @@ export const adminRoutes = new Elysia({ prefix: '/admin' })
 
         return packsList.map((p) => ({
           ...p,
-          createdAt: p.createdAt?.toISOString() || null,
+          createdAt: p.createdAt?.toISOString() ?? null,
+          updatedAt: p.updatedAt?.toISOString() ?? null,
         }));
       } catch (error) {
         console.error('Error fetching packs:', error);
@@ -308,11 +316,27 @@ export const adminRoutes = new Elysia({ prefix: '/admin' })
           .select({
             id: catalogItems.id,
             name: catalogItems.name,
+            description: catalogItems.description,
             categories: catalogItems.categories,
             brand: catalogItems.brand,
+            model: catalogItems.model,
+            sku: catalogItems.sku,
             price: catalogItems.price,
+            currency: catalogItems.currency,
             weight: catalogItems.weight,
             weightUnit: catalogItems.weightUnit,
+            availability: catalogItems.availability,
+            ratingValue: catalogItems.ratingValue,
+            reviewCount: catalogItems.reviewCount,
+            color: catalogItems.color,
+            size: catalogItems.size,
+            material: catalogItems.material,
+            seller: catalogItems.seller,
+            productUrl: catalogItems.productUrl,
+            images: catalogItems.images,
+            variants: catalogItems.variants,
+            techs: catalogItems.techs,
+            links: catalogItems.links,
             createdAt: catalogItems.createdAt,
           })
           .from(catalogItems)


### PR DESCRIPTION
## Summary

- **Pagination** on catalog, packs, and users pages (50 items/page, URL-synced `?page=N`)
- **Search debounce** (300ms) — input feels instant, URL/API update is throttled; also resets page to 0 on new search
- **Reset Stuck Jobs** button in the ETL Pipeline card — calls the new `POST /api/admin/analytics/catalog/etl/reset-stuck` endpoint, shows spinner + how many jobs were reset; removes the manual `reset-stuck-etl-jobs.sql` script
- **Error boundaries** — `app/error.tsx` (root) and `app/dashboard/error.tsx` stop 500s from blanking the whole screen

## API change

`POST /api/admin/analytics/catalog/etl/reset-stuck` — admin-only endpoint that marks jobs stuck in `running` for >3 hours as `failed`. Replaces the raw SQL script.

## Post-Deploy Monitoring & Validation

- **Pagination**: manually verify prev/next buttons on catalog page load 50 items each
- **Reset Stuck button**: after deploy, use it to clear any remaining zombie ETL jobs — response will show `{ reset: N, ids: [...] }`
- **Error boundaries**: trigger a bad API URL to confirm the "Failed to load" UI renders instead of a blank page

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Prev/Next pagination with item-range displays across Catalog, Users, and Packs.
  * Reset-stuck ETL jobs action in catalog analytics.
  * Client-side error fallback UIs and an error boundary for dashboard pages.
  * Raw JSON preview dialog for row details.

* **Improvements**
  * Search inputs now use unified query-state with paginated search (stable q + page handling).
  * Listings return richer catalog/pack/user metadata and improved price/currency display.
  * React Query key/cache patterns standardized for more consistent invalidation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->