### PR TITLE
fix(app): address post-merge review comments from #2384

### DIFF
--- a/apps/expo/features/catalog/types.ts
+++ b/apps/expo/features/catalog/types.ts
@@ -91,8 +91,8 @@ export interface CatalogItem {
 
   embedding?: number[] | null; // vector(1536)
 
-  createdAt: string;
-  updatedAt: string;
+  createdAt: string | Date;
+  updatedAt: string | Date;
 }
 
 export type CatalogItemWithQuantity = CatalogItem & { quantity?: number };

--- a/packages/app/index.ts
+++ b/packages/app/index.ts
@@ -8,4 +8,5 @@ export { useCreatePackMutation } from './src/features/pack/create/queries';
 export { useCreateTripMutation } from './src/features/trip/create/queries';
 export * from './src/shared/api';
 export * from './src/shared/lib/date';
+export * from './src/shared/lib/uuid';
 export * from './src/shared/lib/weight';

--- a/packages/app/src/entities/catalog/queries.ts
+++ b/packages/app/src/entities/catalog/queries.ts
@@ -27,7 +27,7 @@ export function useCatalogItemsInfinite({
 }: UseCatalogItemsParams) {
   const client = useApiClient();
   return useInfiniteQuery({
-    queryKey: queryKeys.catalogInfinite(query, category),
+    queryKey: queryKeys.catalogInfinite({ search: query, category, limit, sort }),
     queryFn: async ({ pageParam = 1 }) => {
       const { data, error } = await client.catalog.get({
         query: {
@@ -38,7 +38,7 @@ export function useCatalogItemsInfinite({
           ...(sort ? { sort } : {}),
         },
       });
-      if (error) throw new Error(`Failed to fetch catalog items: ${String(error)}`);
+      if (error) throw new Error(`Failed to fetch catalog items: ${error.value}`);
       const parseResult = CatalogItemsResponseSchema.safeParse(data);
       if (parseResult.success) return parseResult.data;
       return {

--- a/packages/app/src/entities/feed/queries.ts
+++ b/packages/app/src/entities/feed/queries.ts
@@ -9,7 +9,7 @@ export function useFeed() {
       const { data, error } = await client.feed.get({
         query: { page: pageParam as number, limit: 20 },
       });
-      if (error) throw new Error(`Failed to fetch feed: ${String(error)}`);
+      if (error) throw new Error(`Failed to fetch feed: ${error.value}`);
       return data;
     },
     getNextPageParam: (lastPage) => {

--- a/packages/app/src/features/pack/add-item/queries.ts
+++ b/packages/app/src/features/pack/add-item/queries.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { queryKeys, useApiClient } from '../../../shared/api';
+import { generateId } from '../../../shared/lib/uuid';
 
 interface AddPackItemInput {
   name: string;
@@ -22,7 +23,7 @@ export function useAddPackItemMutation() {
     mutationFn: async ({ packId, body }: { packId: string; body: AddPackItemInput }) => {
       const { data, error } = await client.packs({ packId }).items.post({
         ...body,
-        id: crypto.randomUUID(),
+        id: generateId(),
         quantity: body.quantity ?? 1,
         consumable: body.consumable ?? false,
         worn: body.worn ?? false,

--- a/packages/app/src/features/pack/create/queries.ts
+++ b/packages/app/src/features/pack/create/queries.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { queryKeys, useApiClient } from '../../../shared/api';
+import { generateId } from '../../../shared/lib/uuid';
 
 interface CreatePackInput {
   name: string;
@@ -18,7 +19,7 @@ export function useCreatePackMutation() {
       const now = new Date().toISOString();
       const { data, error } = await client.packs.post({
         ...input,
-        id: crypto.randomUUID(),
+        id: generateId(),
         isPublic: input.isPublic ?? false,
         localCreatedAt: now,
         localUpdatedAt: now,

--- a/packages/app/src/features/trip/create/queries.ts
+++ b/packages/app/src/features/trip/create/queries.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { queryKeys, useApiClient } from '../../../shared/api';
+import { generateId } from '../../../shared/lib/uuid';
 
 interface CreateTripInput {
   name: string;
@@ -19,7 +20,7 @@ export function useCreateTripMutation() {
       const now = new Date().toISOString();
       const { data, error } = await client.trips.post({
         ...input,
-        id: crypto.randomUUID(),
+        id: generateId(),
         localCreatedAt: now,
         localUpdatedAt: now,
       });

--- a/packages/app/src/shared/api/query-keys.ts
+++ b/packages/app/src/shared/api/query-keys.ts
@@ -6,8 +6,14 @@ export const queryKeys = {
   trip: (id: string) => ['trip', id] as const,
   catalog: (opts: { page?: number; search?: string; category?: string } = {}) =>
     ['catalog', { page: opts.page ?? 1, search: opts.search, category: opts.category }] as const,
-  catalogInfinite: (search?: string, category?: string) =>
-    ['catalogInfinite', { search, category }] as const,
+  catalogInfinite: (
+    opts: {
+      search?: string;
+      category?: string;
+      limit?: number;
+      sort?: { field: string; order: string };
+    } = {},
+  ) => ['catalogInfinite', opts] as const,
   catalogItem: (id: number) => ['catalogItem', id] as const,
   feed: (page = 1, filter?: 'trending' | 'recent' | 'following') =>
     ['feed', { page, filter }] as const,

--- a/packages/app/src/shared/lib/uuid.ts
+++ b/packages/app/src/shared/lib/uuid.ts
@@ -1,0 +1,10 @@
+// crypto.randomUUID() is not available in older React Native (Hermes < 0.71).
+// crypto.getRandomValues() is available since RN 0.60 via the Hermes polyfill.
+export function generateId(): string {
+  const bytes = new Uint8Array(16);
+  crypto.getRandomValues(bytes);
+  bytes[6] = ((bytes[6] ?? 0) & 0x0f) | 0x40;
+  bytes[8] = ((bytes[8] ?? 0) & 0x3f) | 0x80;
+  const hex = Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('');
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+}


### PR DESCRIPTION
## Summary

Follow-up fixes from Copilot review comments on #2384, applied after that PR merged.

- **CI fix**: `apps/expo/features/catalog/types.ts` — `createdAt`/`updatedAt` changed to `string | Date` (Drizzle returns `Date`, Eden Treaty returns `string`)
- **UUID**: replaced `crypto.randomUUID()` with `generateId()` backed by `crypto.getRandomValues()` for older React Native / Hermes compatibility; added `packages/app/src/shared/lib/uuid.ts`
- **queryKey**: `catalogInfinite` now includes `limit` + `sort` in the cache key so different pagination/sort params get independent query entries
- **error messages**: `String(error)` → `error.value` in `feed/queries.ts` and `catalog/queries.ts` to match Eden Treaty error shape

## Post-Deploy Monitoring & Validation

No additional operational monitoring required: all changes are type-level or client-side query logic with no server-side impact.

---

[![Compound Engineered](https://img.shields.io/badge/Compound-Engineered-6366f1)](https://github.com/EveryInc/compound-engineering-plugin) 🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced catalog browsing with expanded filtering and sorting options.

* **Bug Fixes**
  * Improved error messaging for catalog and feed failures.
  * Enhanced date field handling for catalog items to support both string and date formats.
  * Strengthened ID generation for creating trips and pack items for improved reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->