### PR TITLE
feat(admin): ETL failure drill-down + load-more pagination

### DIFF
--- a/apps/admin/components/analytics/catalog-analytics.tsx
+++ b/apps/admin/components/analytics/catalog-analytics.tsx
@@ -17,6 +17,14 @@ import {
   ChartTooltip,
   ChartTooltipContent,
 } from '@packrat/web-ui/components/chart';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@packrat/web-ui/components/dialog';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { RawObjectDialog } from 'admin-app/components/raw-object-dialog';
 import {
@@ -25,10 +33,13 @@ import {
   useCatalogEtl,
   useCatalogOverview,
   useCatalogPrices,
+  useEtlFailureSummary,
+  useEtlJobFailures,
 } from 'admin-app/hooks/use-catalog-analytics';
 import { resetStuckEtlJobs } from 'admin-app/lib/api';
 import { queryKeys } from 'admin-app/lib/queryKeys';
 import { RotateCcw } from 'lucide-react';
+import { useState } from 'react';
 import { Bar, BarChart, CartesianGrid, Cell, Pie, PieChart, XAxis, YAxis } from 'recharts';
 
 const priceConfig: ChartConfig = {
@@ -54,6 +65,103 @@ function statusBadgeVariant(status: string): 'default' | 'secondary' | 'destruct
   return 'secondary';
 }
 
+function EtlJobFailuresDialog({ jobId, totalInvalid }: { jobId: string; totalInvalid: number }) {
+  const [open, setOpen] = useState(false);
+  const { data, isLoading } = useEtlJobFailures(jobId, { enabled: open });
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-6 px-2 text-xs text-destructive hover:text-destructive hover:bg-destructive/10"
+        >
+          {totalInvalid.toLocaleString()} failures
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="max-w-3xl">
+        <DialogHeader>
+          <DialogTitle className="font-mono text-sm">Failures — job {jobId}</DialogTitle>
+          <DialogDescription className="sr-only">
+            Validation failures for ETL job {jobId}
+          </DialogDescription>
+        </DialogHeader>
+        {isLoading ? (
+          <div className="py-8 text-center text-sm text-muted-foreground">Loading…</div>
+        ) : data ? (
+          <div className="space-y-4 max-h-[70vh] overflow-y-auto pr-1">
+            {data.errorBreakdown.length > 0 && (
+              <div>
+                <h4 className="text-sm font-medium mb-2">Error breakdown</h4>
+                <table className="w-full text-xs">
+                  <thead>
+                    <tr className="border-b text-muted-foreground">
+                      <th className="pb-1 text-left font-medium">Field</th>
+                      <th className="pb-1 text-left font-medium">Reason</th>
+                      <th className="pb-1 text-right font-medium">Count</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {data.errorBreakdown.map((e) => (
+                      <tr key={`${e.field}|${e.reason}`} className="border-b last:border-0">
+                        <td className="py-1 pr-4 font-mono">{e.field}</td>
+                        <td className="py-1 pr-4 text-muted-foreground">{e.reason}</td>
+                        <td className="py-1 text-right font-medium">{e.count}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+            {data.samples.length > 0 && (
+              <div>
+                <h4 className="text-sm font-medium mb-2">
+                  Sample rows{' '}
+                  <span className="text-muted-foreground font-normal">
+                    ({data.totalShown} total shown)
+                  </span>
+                </h4>
+                <div className="space-y-2">
+                  {data.samples.map((s) => (
+                    <div
+                      key={s.rowIndex}
+                      className="rounded-md border bg-muted/50 p-3 text-xs space-y-1"
+                    >
+                      <div className="text-muted-foreground">Row {s.rowIndex}</div>
+                      <div className="flex flex-wrap gap-1">
+                        {s.errors.map((e, i) => (
+                          <Badge
+                            key={i}
+                            variant="destructive"
+                            className="text-xs font-mono font-normal"
+                          >
+                            {e.field}: {e.reason}
+                          </Badge>
+                        ))}
+                      </div>
+                      {s.rawData != null && (
+                        <details className="mt-1">
+                          <summary className="cursor-pointer text-muted-foreground hover:text-foreground">
+                            raw data
+                          </summary>
+                          <pre className="mt-1 text-xs whitespace-pre-wrap break-all">
+                            {JSON.stringify(s.rawData, null, 2)}
+                          </pre>
+                        </details>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+          </div>
+        ) : null}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
 export function CatalogAnalytics() {
   const queryClient = useQueryClient();
   const { data: overview } = useCatalogOverview();
@@ -61,6 +169,7 @@ export function CatalogAnalytics() {
   const { data: prices } = useCatalogPrices();
   const { data: etl } = useCatalogEtl(15);
   const { data: embeddings } = useCatalogEmbeddings();
+  const { data: failureSummary } = useEtlFailureSummary(20);
 
   const {
     mutate: resetStuck,
@@ -265,6 +374,39 @@ export function CatalogAnalytics() {
         </Card>
       )}
 
+      {/* ETL failure summary */}
+      {failureSummary && failureSummary.topErrors.length > 0 && (
+        <Card>
+          <CardHeader>
+            <CardTitle>Top Validation Errors</CardTitle>
+            <CardDescription>
+              Most common failure patterns across all ETL jobs —{' '}
+              {failureSummary.totalInvalidItems.toLocaleString()} invalid items sampled
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b text-muted-foreground">
+                  <th className="pb-2 text-left font-medium">Field</th>
+                  <th className="pb-2 text-left font-medium">Reason</th>
+                  <th className="pb-2 text-right font-medium">Count</th>
+                </tr>
+              </thead>
+              <tbody>
+                {failureSummary.topErrors.map((e) => (
+                  <tr key={`${e.field}|${e.reason}`} className="border-b last:border-0">
+                    <td className="py-2 pr-4 font-mono text-xs">{e.field}</td>
+                    <td className="py-2 pr-4 text-muted-foreground text-xs">{e.reason}</td>
+                    <td className="py-2 text-right font-medium">{e.count.toLocaleString()}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </CardContent>
+        </Card>
+      )}
+
       {/* ETL pipeline */}
       {etl && (
         <Card>
@@ -309,6 +451,7 @@ export function CatalogAnalytics() {
                     <th className="pb-2 text-right font-medium">Processed</th>
                     <th className="pb-2 text-right font-medium">Valid</th>
                     <th className="pb-2 text-right font-medium">Invalid</th>
+                    <th className="pb-2 text-left font-medium">Failures</th>
                     <th className="pb-2 text-right font-medium">Success %</th>
                     <th className="pb-2 text-left font-medium">Started</th>
                     <th className="pb-2 text-left font-medium">Completed</th>
@@ -337,6 +480,13 @@ export function CatalogAnalytics() {
                           </span>
                         ) : (
                           '—'
+                        )}
+                      </td>
+                      <td className="py-2 pr-4">
+                        {job.totalInvalid != null && job.totalInvalid > 0 ? (
+                          <EtlJobFailuresDialog jobId={job.id} totalInvalid={job.totalInvalid} />
+                        ) : (
+                          <span className="text-xs text-muted-foreground">—</span>
                         )}
                       </td>
                       <td className="py-2 pr-4 text-right">

--- a/apps/admin/components/analytics/catalog-analytics.tsx
+++ b/apps/admin/components/analytics/catalog-analytics.tsx
@@ -162,12 +162,16 @@ function EtlJobFailuresDialog({ jobId, totalInvalid }: { jobId: string; totalInv
   );
 }
 
+const ETL_PAGE_SIZE = 25;
+
 export function CatalogAnalytics() {
   const queryClient = useQueryClient();
+  const [etlLimit, setEtlLimit] = useState(ETL_PAGE_SIZE);
+
   const { data: overview } = useCatalogOverview();
   const { data: brands } = useCatalogBrands(15);
   const { data: prices } = useCatalogPrices();
-  const { data: etl } = useCatalogEtl(15);
+  const { data: etl, isFetching: etlFetching } = useCatalogEtl(etlLimit);
   const { data: embeddings } = useCatalogEmbeddings();
   const { data: failureSummary } = useEtlFailureSummary(20);
 
@@ -506,6 +510,25 @@ export function CatalogAnalytics() {
                 </tbody>
               </table>
             </div>
+            {etl.jobs.length >= etlLimit && etlLimit < 200 && (
+              <div className="mt-4 flex justify-center">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => setEtlLimit((prev) => Math.min(prev + ETL_PAGE_SIZE, 200))}
+                  disabled={etlFetching}
+                >
+                  {etlFetching
+                    ? 'Loading…'
+                    : `Load ${Math.min(ETL_PAGE_SIZE, 200 - etlLimit)} more`}
+                </Button>
+              </div>
+            )}
+            {etlLimit >= 200 && (
+              <p className="mt-3 text-center text-xs text-muted-foreground">
+                Showing maximum 200 jobs. Use the API directly for full history.
+              </p>
+            )}
           </CardContent>
         </Card>
       )}

--- a/apps/admin/components/analytics/catalog-analytics.tsx
+++ b/apps/admin/components/analytics/catalog-analytics.tsx
@@ -119,7 +119,7 @@ function EtlJobFailuresDialog({ jobId, totalInvalid }: { jobId: string; totalInv
                 <h4 className="text-sm font-medium mb-2">
                   Sample rows{' '}
                   <span className="text-muted-foreground font-normal">
-                    ({data.totalShown} total shown)
+                    (showing {data.samples.length} of {data.totalShown} fetched)
                   </span>
                 </h4>
                 <div className="space-y-2">
@@ -518,13 +518,11 @@ export function CatalogAnalytics() {
                   onClick={() => setEtlLimit((prev) => Math.min(prev + ETL_PAGE_SIZE, 200))}
                   disabled={etlFetching}
                 >
-                  {etlFetching
-                    ? 'Loading…'
-                    : `Load ${Math.min(ETL_PAGE_SIZE, 200 - etlLimit)} more`}
+                  {etlFetching ? 'Loading…' : 'Load more'}
                 </Button>
               </div>
             )}
-            {etlLimit >= 200 && (
+            {etl.jobs.length === 200 && (
               <p className="mt-3 text-center text-xs text-muted-foreground">
                 Showing maximum 200 jobs. Use the API directly for full history.
               </p>

--- a/apps/admin/hooks/use-catalog-analytics.ts
+++ b/apps/admin/hooks/use-catalog-analytics.ts
@@ -7,6 +7,8 @@ import {
   getCatalogEtl,
   getCatalogOverview,
   getCatalogPrices,
+  getEtlFailureSummary,
+  getEtlJobFailures,
 } from 'admin-app/lib/api';
 import { queryKeys } from 'admin-app/lib/queryKeys';
 
@@ -42,5 +44,21 @@ export function useCatalogEmbeddings() {
   return useQuery({
     queryKey: queryKeys.catalogAnalytics.embeddings(),
     queryFn: () => getCatalogEmbeddings(),
+  });
+}
+
+export function useEtlFailureSummary(limit = 20) {
+  return useQuery({
+    queryKey: queryKeys.catalogAnalytics.etl.failureSummary(limit),
+    queryFn: () => getEtlFailureSummary(limit),
+  });
+}
+
+export function useEtlJobFailures(jobId: string, opts: { enabled?: boolean; limit?: number } = {}) {
+  const { enabled = false, limit = 50 } = opts;
+  return useQuery({
+    queryKey: queryKeys.catalogAnalytics.etl.jobFailures(jobId, limit),
+    queryFn: () => getEtlJobFailures(jobId, limit),
+    enabled,
   });
 }

--- a/apps/admin/lib/api.ts
+++ b/apps/admin/lib/api.ts
@@ -272,3 +272,29 @@ export function getCatalogEmbeddings(): Promise<EmbeddingStats> {
 export function resetStuckEtlJobs(): Promise<{ reset: number; ids: string[] }> {
   return adminFetch('/analytics/catalog/etl/reset-stuck', { method: 'POST' });
 }
+
+export type EtlErrorRow = { field: string; reason: string; count: number };
+
+export type EtlFailureSummary = {
+  topErrors: EtlErrorRow[];
+  totalInvalidItems: number;
+};
+
+export type EtlJobFailures = {
+  jobId: string;
+  errorBreakdown: EtlErrorRow[];
+  samples: Array<{
+    rowIndex: number;
+    errors: Array<{ field: string; reason: string; value?: unknown }>;
+    rawData: unknown;
+  }>;
+  totalShown: number;
+};
+
+export function getEtlFailureSummary(limit = 20): Promise<EtlFailureSummary> {
+  return adminFetch(`/analytics/catalog/etl/failure-summary?limit=${limit}`);
+}
+
+export function getEtlJobFailures(jobId: string, limit = 50): Promise<EtlJobFailures> {
+  return adminFetch(`/analytics/catalog/etl/${encodeURIComponent(jobId)}/failures?limit=${limit}`);
+}

--- a/apps/admin/lib/queryKeys.ts
+++ b/apps/admin/lib/queryKeys.ts
@@ -47,6 +47,10 @@ export const queryKeys = {
     etl: {
       all: () => [...queryKeys.catalogAnalytics.all(), 'etl'] as const,
       list: (limit?: number) => [...queryKeys.catalogAnalytics.etl.all(), limit] as const,
+      failureSummary: (limit?: number) =>
+        [...queryKeys.catalogAnalytics.etl.all(), 'failureSummary', limit] as const,
+      jobFailures: (jobId: string, limit?: number) =>
+        [...queryKeys.catalogAnalytics.etl.all(), 'jobFailures', jobId, limit] as const,
     },
   },
 };

--- a/packages/api/src/routes/admin/analytics/catalog.ts
+++ b/packages/api/src/routes/admin/analytics/catalog.ts
@@ -1,5 +1,6 @@
 import { createDb } from '@packrat/api/db';
-import { catalogItems, etlJobs } from '@packrat/api/db/schema';
+import { catalogItems, etlJobs, invalidItemLogs } from '@packrat/api/db/schema';
+import type { ValidationError } from '@packrat/api/types/validation';
 import { and, avg, count, desc, eq, gt, isNotNull, lt, max, min, sql } from 'drizzle-orm';
 import { Elysia, status } from 'elysia';
 import { z } from 'zod';
@@ -242,6 +243,115 @@ export const catalogAnalyticsRoutes = new Elysia({ prefix: '/catalog' })
       }
     },
     { detail: { tags: ['Admin'], summary: 'Embedding coverage' } },
+  )
+
+  .get(
+    '/etl/failure-summary',
+    async ({ query }) => {
+      const db = createDb();
+      const { limit = 20 } = query;
+
+      try {
+        // Pull the errors JSONB array from each invalid log and aggregate in app
+        const logs = await db
+          .select({ errors: invalidItemLogs.errors })
+          .from(invalidItemLogs)
+          .limit(5000); // cap to avoid huge payload; covers recent history
+
+        const tally = new Map<string, number>();
+        for (const log of logs) {
+          for (const err of log.errors as ValidationError[]) {
+            const key = `${err.field}|||${err.reason}`;
+            tally.set(key, (tally.get(key) ?? 0) + 1);
+          }
+        }
+
+        const sorted = [...tally.entries()]
+          .sort((a, b) => b[1] - a[1])
+          .slice(0, limit)
+          .map(([key, count]) => {
+            const sep = key.indexOf('|||');
+            return { field: key.slice(0, sep), reason: key.slice(sep + 3), count };
+          });
+
+        return { topErrors: sorted, totalInvalidItems: logs.length };
+      } catch (error) {
+        console.error('ETL failure summary error:', error);
+        return status(500, {
+          error: 'Failed to fetch failure summary',
+          code: 'ETL_FAILURE_SUMMARY_ERROR',
+        });
+      }
+    },
+    {
+      query: z.object({
+        limit: z.coerce.number().int().min(1).max(100).optional().default(20),
+      }),
+      detail: { tags: ['Admin'], summary: 'Top validation error patterns across all ETL jobs' },
+    },
+  )
+
+  .get(
+    '/etl/:jobId/failures',
+    async ({ params, query }) => {
+      const db = createDb();
+      const { limit = 50 } = query;
+
+      try {
+        const logs = await db
+          .select({
+            id: invalidItemLogs.id,
+            errors: invalidItemLogs.errors,
+            rowIndex: invalidItemLogs.rowIndex,
+            rawData: invalidItemLogs.rawData,
+            createdAt: invalidItemLogs.createdAt,
+          })
+          .from(invalidItemLogs)
+          .where(eq(invalidItemLogs.jobId, params.jobId))
+          .orderBy(invalidItemLogs.rowIndex)
+          .limit(limit);
+
+        // Aggregate error breakdown for this job
+        const tally = new Map<string, number>();
+        for (const log of logs) {
+          for (const err of log.errors as ValidationError[]) {
+            const key = `${err.field}|||${err.reason}`;
+            tally.set(key, (tally.get(key) ?? 0) + 1);
+          }
+        }
+
+        const errorBreakdown = [...tally.entries()]
+          .sort((a, b) => b[1] - a[1])
+          .map(([key, count]) => {
+            const sep = key.indexOf('|||');
+            return { field: key.slice(0, sep), reason: key.slice(sep + 3), count };
+          });
+
+        return {
+          jobId: params.jobId,
+          errorBreakdown,
+          samples: logs.slice(0, 20).map((l) => ({
+            rowIndex: l.rowIndex,
+            errors: l.errors as ValidationError[],
+            rawData: l.rawData,
+          })),
+          totalShown: logs.length,
+        };
+      } catch (error) {
+        console.error('ETL job failures error:', error);
+        return status(500, {
+          error: 'Failed to fetch job failures',
+          code: 'ETL_JOB_FAILURES_ERROR',
+        });
+      }
+    },
+    {
+      params: z.object({ jobId: z.string().min(1) }),
+      query: z.object({
+        limit: z.coerce.number().int().min(1).max(200).optional().default(50),
+      }),
+      detail: { tags: ['Admin'], summary: 'Validation failure breakdown for a specific ETL job' },
+    },
   )
 
   .post(

--- a/packages/api/src/routes/admin/analytics/catalog.ts
+++ b/packages/api/src/routes/admin/analytics/catalog.ts
@@ -1,9 +1,12 @@
 import { createDb } from '@packrat/api/db';
 import { catalogItems, etlJobs, invalidItemLogs } from '@packrat/api/db/schema';
-import type { ValidationError } from '@packrat/api/types/validation';
+import { ValidationErrorsSchema } from '@packrat/api/types/validation';
+import { fromZod } from '@packrat/guards';
 import { and, avg, count, desc, eq, gt, isNotNull, lt, max, min, sql } from 'drizzle-orm';
 import { Elysia, status } from 'elysia';
 import { z } from 'zod';
+
+const parseValidationErrors = fromZod(ValidationErrorsSchema);
 
 export const catalogAnalyticsRoutes = new Elysia({ prefix: '/catalog' })
   .get(
@@ -260,7 +263,7 @@ export const catalogAnalyticsRoutes = new Elysia({ prefix: '/catalog' })
 
         const tally = new Map<string, number>();
         for (const log of logs) {
-          for (const err of log.errors as ValidationError[]) {
+          for (const err of parseValidationErrors(log.errors) ?? []) {
             const key = `${err.field}|||${err.reason}`;
             tally.set(key, (tally.get(key) ?? 0) + 1);
           }
@@ -314,7 +317,7 @@ export const catalogAnalyticsRoutes = new Elysia({ prefix: '/catalog' })
         // Aggregate error breakdown for this job
         const tally = new Map<string, number>();
         for (const log of logs) {
-          for (const err of log.errors as ValidationError[]) {
+          for (const err of parseValidationErrors(log.errors) ?? []) {
             const key = `${err.field}|||${err.reason}`;
             tally.set(key, (tally.get(key) ?? 0) + 1);
           }
@@ -332,7 +335,7 @@ export const catalogAnalyticsRoutes = new Elysia({ prefix: '/catalog' })
           errorBreakdown,
           samples: logs.slice(0, 20).map((l) => ({
             rowIndex: l.rowIndex,
-            errors: l.errors as ValidationError[],
+            errors: parseValidationErrors(l.errors) ?? [],
             rawData: l.rawData,
           })),
           totalShown: logs.length,

--- a/packages/api/src/routes/admin/analytics/catalog.ts
+++ b/packages/api/src/routes/admin/analytics/catalog.ts
@@ -255,11 +255,12 @@ export const catalogAnalyticsRoutes = new Elysia({ prefix: '/catalog' })
       const { limit = 20 } = query;
 
       try {
-        // Pull the errors JSONB array from each invalid log and aggregate in app
+        // Pull the errors JSONB array from recent invalid logs and aggregate in app
         const logs = await db
           .select({ errors: invalidItemLogs.errors })
           .from(invalidItemLogs)
-          .limit(5000); // cap to avoid huge payload; covers recent history
+          .orderBy(desc(invalidItemLogs.createdAt))
+          .limit(5000);
 
         const tally = new Map<string, number>();
         for (const log of logs) {
@@ -301,23 +302,27 @@ export const catalogAnalyticsRoutes = new Elysia({ prefix: '/catalog' })
       const { limit = 50 } = query;
 
       try {
-        const logs = await db
+        const rawLogs = await db
           .select({
-            id: invalidItemLogs.id,
             errors: invalidItemLogs.errors,
             rowIndex: invalidItemLogs.rowIndex,
             rawData: invalidItemLogs.rawData,
-            createdAt: invalidItemLogs.createdAt,
           })
           .from(invalidItemLogs)
           .where(eq(invalidItemLogs.jobId, params.jobId))
           .orderBy(invalidItemLogs.rowIndex)
           .limit(limit);
 
+        // Parse errors once per row — reuse for both tally and samples
+        const logs = rawLogs.map((l) => ({
+          ...l,
+          parsedErrors: parseValidationErrors(l.errors) ?? [],
+        }));
+
         // Aggregate error breakdown for this job
         const tally = new Map<string, number>();
         for (const log of logs) {
-          for (const err of parseValidationErrors(log.errors) ?? []) {
+          for (const err of log.parsedErrors) {
             const key = `${err.field}|||${err.reason}`;
             tally.set(key, (tally.get(key) ?? 0) + 1);
           }
@@ -335,7 +340,7 @@ export const catalogAnalyticsRoutes = new Elysia({ prefix: '/catalog' })
           errorBreakdown,
           samples: logs.slice(0, 20).map((l) => ({
             rowIndex: l.rowIndex,
-            errors: parseValidationErrors(l.errors) ?? [],
+            errors: l.parsedErrors,
             rawData: l.rawData,
           })),
           totalShown: logs.length,

--- a/packages/api/src/types/validation.ts
+++ b/packages/api/src/types/validation.ts
@@ -1,5 +1,15 @@
+import { z } from 'zod';
+
 export interface ValidationError {
   field: string;
   reason: string;
   value?: string | number | boolean | null | undefined;
 }
+
+export const ValidationErrorSchema = z.object({
+  field: z.string(),
+  reason: z.string(),
+  value: z.union([z.string(), z.number(), z.boolean(), z.null()]).optional(),
+});
+
+export const ValidationErrorsSchema = z.array(ValidationErrorSchema);


### PR DESCRIPTION
## Summary

- **ETL failure drill-down**: new `GET /analytics/catalog/etl/failure-summary` and `GET /analytics/catalog/etl/:jobId/failures` endpoints surface validation error patterns. UI adds a "Top Validation Errors" card (cross-job aggregation) and a per-row "N failures" button that lazy-loads a dialog with field/reason breakdown + expandable raw data samples
- **ETL pagination**: replaces the fixed 15-job limit with a "Load more" button fetching in 25-job increments up to the API max of 200
- **Safe casts**: `ValidationErrorsSchema` added to `@packrat/api/types/validation`; all `as ValidationError[]` casts replaced with `fromZod(ValidationErrorsSchema)` to pass strict cast checks

## Testing

- Pre-push hooks pass (`clean-checks`, biome, type-check)
- Type-checked admin package; no new errors introduced

## Post-Deploy Monitoring & Validation

- **What to monitor**: `/analytics/catalog/etl/failure-summary` response — expect `topErrors` populated if invalid items exist
- **Validation**: click "N failures" on any job with `totalInvalid > 0` and confirm dialog loads
- **No operational risk**: read-only analytics endpoints + UI pagination state change

---

[![Compound Engineered](https://img.shields.io/badge/Compound-Engineered-6366f1)](https://github.com/EveryInc/compound-engineering-plugin) 🤖 Generated with [Claude Code](https://claude.com/claude-code)