### PR TITLE
fix(admin-api): allow CORS for preview/localhost origins and skip OPTIONS preflight auth

### DIFF
--- a/packages/api/src/routes/admin/index.ts
+++ b/packages/api/src/routes/admin/index.ts
@@ -96,7 +96,19 @@ export const adminRoutes = new Elysia({ prefix: '/admin' })
   // is rejected by browsers per the CORS spec).
   .use(
     cors({
-      origin: 'https://admin.packratai.com',
+      // Allow production domain, Cloudflare preview deployments, and local dev.
+      // With credentials:true the browser requires a specific origin (not *), so
+      // we reflect the request origin back when it's in our allowlist.
+      origin: (request) => {
+        const origin = request.headers.get('origin');
+        if (!origin) return false;
+        if (origin === 'https://admin.packratai.com') return true;
+        // Cloudflare Workers preview URLs (branch deploys of packrat-admin)
+        if (origin.endsWith('.workers.dev')) return true;
+        // Local development
+        if (/^https?:\/\/localhost(:\d+)?$/.test(origin)) return true;
+        return false;
+      },
       credentials: true,
       allowedHeaders: ['Authorization', 'Content-Type'],
     }),
@@ -152,6 +164,8 @@ export const adminRoutes = new Elysia({ prefix: '/admin' })
   )
   .onBeforeHandle(async ({ request, path }) => {
     if (path === '/api/admin/token') return;
+    // OPTIONS preflight requests carry no credentials — let the CORS plugin handle them.
+    if (request.method === 'OPTIONS') return;
     const ok = await adminAuthGuard(request);
     if (!ok) return status(401, { error: 'Unauthorized' });
   })


### PR DESCRIPTION
## Summary

- **CORS**: The admin API was hard-coded to only allow `https://admin.packratai.com` as a CORS origin. All API calls from Cloudflare preview URLs (`*.workers.dev`) and local dev (`http://localhost:*`) were blocked by the browser before they even reached the server. Changed `origin` from a single string to a function that reflects the request origin back when it matches the allowlist.
- **OPTIONS preflight**: The `onBeforeHandle` auth guard ran for all requests including CORS preflight (`OPTIONS`). Since preflights carry no credentials, they got 401 responses, which blocked the browser from making the actual credentialed request. Added an early return for `OPTIONS` so the CORS plugin handles those exclusively.

## Allowed origins after this change
- `https://admin.packratai.com` (production)
- Any `*.workers.dev` (Cloudflare branch/preview deploys)
- `http://localhost` + `http://localhost:$PORT` (local dev)

## Security note
Auth still requires a valid JWT token on all non-OPTIONS admin routes. The CORS relaxation only allows the browser to attempt the request — it does not bypass authentication.

## Testing
- Local dev API calls to `http://localhost:8787` will no longer be rejected by CORS
- Cloudflare preview deployments will be able to hit the production API
- Production admin at `admin.packratai.com` is unchanged

## Post-Deploy Monitoring & Validation
No additional operational monitoring required: CORS headers are request metadata only and do not affect data integrity or authentication.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>