### PR TITLE
fix(etl): mark jobs completed explicitly + add retry for failed jobs

### DIFF
--- a/apps/admin/components/analytics/catalog-analytics.tsx
+++ b/apps/admin/components/analytics/catalog-analytics.tsx
@@ -36,7 +36,7 @@ import {
   useEtlFailureSummary,
   useEtlJobFailures,
 } from 'admin-app/hooks/use-catalog-analytics';
-import { resetStuckEtlJobs } from 'admin-app/lib/api';
+import { resetStuckEtlJobs, retryEtlJob } from 'admin-app/lib/api';
 import { queryKeys } from 'admin-app/lib/queryKeys';
 import { RotateCcw } from 'lucide-react';
 import { useState } from 'react';
@@ -182,6 +182,17 @@ export function CatalogAnalytics() {
     data: resetResult,
   } = useMutation({
     mutationFn: resetStuckEtlJobs,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.catalogAnalytics.etl.all() });
+    },
+  });
+
+  const {
+    mutate: retryJob,
+    isPending: isRetrying,
+    variables: retryingJobId,
+  } = useMutation({
+    mutationFn: retryEtlJob,
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: queryKeys.catalogAnalytics.etl.all() });
     },
@@ -460,6 +471,7 @@ export function CatalogAnalytics() {
                     <th className="pb-2 text-left font-medium">Started</th>
                     <th className="pb-2 text-left font-medium">Completed</th>
                     <th className="pb-2 w-8" />
+                    <th className="pb-2 w-8" />
                   </tr>
                 </thead>
                 <tbody>
@@ -504,6 +516,22 @@ export function CatalogAnalytics() {
                       </td>
                       <td className="py-2">
                         <RawObjectDialog label={`job:${job.id}`} data={job} />
+                      </td>
+                      <td className="py-2">
+                        {job.status === 'failed' && (
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            className="h-6 px-2 text-xs"
+                            disabled={isRetrying && retryingJobId === job.id}
+                            onClick={() => retryJob(job.id)}
+                          >
+                            <RotateCcw
+                              className={`h-3 w-3 mr-1 ${isRetrying && retryingJobId === job.id ? 'animate-spin' : ''}`}
+                            />
+                            Retry
+                          </Button>
+                        )}
                       </td>
                     </tr>
                   ))}

--- a/apps/admin/lib/api.ts
+++ b/apps/admin/lib/api.ts
@@ -298,3 +298,11 @@ export function getEtlFailureSummary(limit = 20): Promise<EtlFailureSummary> {
 export function getEtlJobFailures(jobId: string, limit = 50): Promise<EtlJobFailures> {
   return adminFetch(`/analytics/catalog/etl/${encodeURIComponent(jobId)}/failures?limit=${limit}`);
 }
+
+export function retryEtlJob(
+  jobId: string,
+): Promise<{ success: boolean; newJobId: string; objectKey: string }> {
+  return adminFetch(`/analytics/catalog/etl/${encodeURIComponent(jobId)}/retry`, {
+    method: 'POST',
+  });
+}

--- a/packages/api/src/routes/admin/analytics/catalog.ts
+++ b/packages/api/src/routes/admin/analytics/catalog.ts
@@ -1,6 +1,8 @@
 import { createDb } from '@packrat/api/db';
 import { catalogItems, etlJobs, invalidItemLogs } from '@packrat/api/db/schema';
+import { queueCatalogETL } from '@packrat/api/services/etl/queue';
 import { ValidationErrorsSchema } from '@packrat/api/types/validation';
+import { getEnv } from '@packrat/api/utils/env-validation';
 import { fromZod } from '@packrat/guards';
 import { and, avg, count, desc, eq, gt, isNotNull, lt, max, min, sql } from 'drizzle-orm';
 import { Elysia, status } from 'elysia';
@@ -382,4 +384,70 @@ export const catalogAnalyticsRoutes = new Elysia({ prefix: '/catalog' })
       }
     },
     { detail: { tags: ['Admin'], summary: 'Reset ETL jobs stuck in running state for >3 hours' } },
+  )
+
+  .post(
+    '/etl/:jobId/retry',
+    async ({ params }) => {
+      const db = createDb();
+      const env = getEnv();
+
+      if (!env.ETL_QUEUE) {
+        return status(400, {
+          error: 'ETL_QUEUE is not configured',
+          code: 'ETL_QUEUE_NOT_CONFIGURED',
+        });
+      }
+
+      try {
+        const job = await db.query.etlJobs.findFirst({
+          where: eq(etlJobs.id, params.jobId),
+        });
+
+        if (!job) {
+          return status(404, { error: 'ETL job not found', code: 'ETL_JOB_NOT_FOUND' });
+        }
+
+        if (job.status !== 'failed') {
+          return status(400, {
+            error: 'Only failed jobs can be retried',
+            code: 'ETL_JOB_NOT_FAILED',
+          });
+        }
+
+        if (!job.source || !job.filename) {
+          return status(400, {
+            error: 'Job missing source or filename — cannot reconstruct R2 key',
+            code: 'ETL_JOB_MISSING_METADATA',
+          });
+        }
+
+        const objectKey = `v2/${job.source}/${job.filename}`;
+        const newJobId = crypto.randomUUID();
+
+        await db.insert(etlJobs).values({
+          id: newJobId,
+          status: 'running',
+          source: job.source,
+          filename: job.filename,
+          scraperRevision: job.scraperRevision,
+          startedAt: new Date(),
+        });
+
+        await queueCatalogETL({
+          queue: env.ETL_QUEUE,
+          objectKeys: [objectKey],
+          jobId: newJobId,
+        });
+
+        return { success: true, newJobId, objectKey };
+      } catch (error) {
+        console.error('ETL retry error:', error);
+        return status(500, { error: 'Failed to retry ETL job', code: 'ETL_RETRY_ERROR' });
+      }
+    },
+    {
+      params: z.object({ jobId: z.string().min(1) }),
+      detail: { tags: ['Admin'], summary: 'Retry a failed ETL job using its original R2 object' },
+    },
   );

--- a/packages/api/src/services/etl/processCatalogEtl.ts
+++ b/packages/api/src/services/etl/processCatalogEtl.ts
@@ -160,6 +160,11 @@ export async function processCatalogETL({
 
     const totalRows = rowIndex;
 
+    await db
+      .update(etlJobs)
+      .set({ status: 'completed', completedAt: new Date() })
+      .where(eq(etlJobs.id, jobId));
+
     console.log(`🔍 [TRACE] ✅ Done processing ${objectKey} - ${totalRows} rows processed`);
   } catch (error) {
     await db


### PR DESCRIPTION
processCatalogEtl never set status='completed' on the happy path — the updateEtlJobProgress completion check only fired when remainingItems>0, so jobs whose row count was an exact multiple of BATCH_SIZE (100) stayed 'running' until Reset Stuck marked them 'failed' 3 hours later.

Fix: unconditionally set status='completed'/completedAt after flushing all remaining batches, before the catch block.

Also adds POST /analytics/catalog/etl/:jobId/retry (admin API) which reconstructs the R2 key as v2/{source}/{filename} from stored job metadata, creates a new ETL job, and re-queues it — allowing failed loads to be replayed without re-scraping.

Surfaces a Retry button in the ETL pipeline table for failed jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Description

<!-- A clear and concise description of what this PR changes and why. -->

Closes #<!-- issue number, if applicable -->

## Type of change

<!-- Check all that apply -->

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️  Refactor / code improvement
- [ ] 📝 Documentation update
- [ ] 🔧 CI / configuration change
- [ ] ⬆️  Dependency update
- [ ] 🗄️  Database migration

## Area(s) affected

- [ ] Mobile app (`apps/expo`)
- [ ] API / Backend (`packages/api`)
- [ ] Landing page (`apps/landing`)
- [ ] Guides site (`apps/guides`)
- [ ] CI / CD (`.github/`)

## Testing

<!-- Describe how you tested your changes. -->

- [ ] Added / updated unit tests
- [ ] Manually tested on iOS
- [ ] Manually tested on Android
- [ ] Manually tested on Web
- [ ] API endpoints verified (e.g. `curl` or Postman)

## Screenshots / recordings

<!-- If your change affects the UI, please add screenshots or a short screen recording. -->

## Pre-merge checklist

- [ ] `bun format && bun lint` passes with no errors
- [ ] `bun check-types` passes with no errors
- [ ] No new secrets or credentials are committed
- [ ] Database migration included (if schema changed)
- [ ] Feature flag added (if this is a new feature)
- [ ] PR title follows conventional commits (`feat:`, `fix:`, `chore:`, etc.)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to retry failed ETL jobs in the admin analytics interface.
  * "Retry" button now appears on failed job rows, allowing administrators to rerun them without manual intervention.
  * Enhanced job completion status tracking for better visibility into ETL operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->