### PR TITLE
fix(cors): add admin.packratai.com + *.workers.dev to root cors allow…

### DIFF
--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -33,6 +33,8 @@ export const app = new Elysia({ adapter: CloudflareAdapter })
         const allowed = [
           /^https:\/\/(www\.)?packrat\.world$/,
           /^https:\/\/[\w-]+\.packrat\.world$/,
+          /^https:\/\/[\w-]+\.packratai\.com$/,
+          /^https?:\/\/[\w-]+\.workers\.dev$/,
           /^http:\/\/localhost:\d+$/,
           /^exp:\/\//,
         ];


### PR DESCRIPTION
…list

Root cors runs first and short-circuits OPTIONS preflights before the admin-scoped cors plugin can set Access-Control-Allow-Origin. Admin origin was only in the admin-scoped plugin, so preflights from admin.packratai.com got no origin header. Non-preflight requests worked because the full middleware chain ran and the admin cors added the header to the response.

Fix: add admin.packratai.com and *.workers.dev to root cors allowlist so OPTIONS preflights get the origin header reflected back correctly.

## Description

<!-- A clear and concise description of what this PR changes and why. -->

Closes #<!-- issue number, if applicable -->

## Type of change

<!-- Check all that apply -->

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️  Refactor / code improvement
- [ ] 📝 Documentation update
- [ ] 🔧 CI / configuration change
- [ ] ⬆️  Dependency update
- [ ] 🗄️  Database migration

## Area(s) affected

- [ ] Mobile app (`apps/expo`)
- [ ] API / Backend (`packages/api`)
- [ ] Landing page (`apps/landing`)
- [ ] Guides site (`apps/guides`)
- [ ] CI / CD (`.github/`)

## Testing

<!-- Describe how you tested your changes. -->

- [ ] Added / updated unit tests
- [ ] Manually tested on iOS
- [ ] Manually tested on Android
- [ ] Manually tested on Web
- [ ] API endpoints verified (e.g. `curl` or Postman)

## Screenshots / recordings

<!-- If your change affects the UI, please add screenshots or a short screen recording. -->

## Pre-merge checklist

- [ ] `bun format && bun lint` passes with no errors
- [ ] `bun check-types` passes with no errors
- [ ] No new secrets or credentials are committed
- [ ] Database migration included (if schema changed)
- [ ] Feature flag added (if this is a new feature)
- [ ] PR title follows conventional commits (`feat:`, `fix:`, `chore:`, etc.)
