### PR TITLE
fix(admin/analytics): coerce Neon int8 strings to Number() in overvie…

### DIFF
--- a/packages/api/src/routes/admin/analytics/catalog.ts
+++ b/packages/api/src/routes/admin/analytics/catalog.ts
@@ -65,14 +65,14 @@ export const catalogAnalyticsRoutes = new Elysia({ prefix: '/catalog' })
 
         return {
           totalItems: t.totalItems,
-          totalBrands: t.totalBrands,
+          totalBrands: Number(t.totalBrands),
           avgPrice: t.avgPrice != null ? Math.round(Number(t.avgPrice) * 100) / 100 : null,
           minPrice: t.minPrice != null ? Number(t.minPrice) : null,
           maxPrice: t.maxPrice != null ? Number(t.maxPrice) : null,
           embeddingCoverage: {
             total: e.total,
-            withEmbedding: e.withEmbedding,
-            pct: e.total > 0 ? Math.round((e.withEmbedding / e.total) * 1000) / 10 : 0,
+            withEmbedding: Number(e.withEmbedding),
+            pct: e.total > 0 ? Math.round((Number(e.withEmbedding) / e.total) * 1000) / 10 : 0,
           },
           availability: availabilityStats.map((r) => ({
             status: r.status ?? null,
@@ -215,9 +215,9 @@ export const catalogAnalyticsRoutes = new Elysia({ prefix: '/catalog' })
           })),
           summary: {
             totalRuns: s?.totalRuns ?? 0,
-            completed: s?.completed ?? 0,
-            failed: s?.failed ?? 0,
-            totalItemsIngested: s?.totalItemsIngested ?? 0,
+            completed: Number(s?.completed ?? 0),
+            failed: Number(s?.failed ?? 0),
+            totalItemsIngested: Number(s?.totalItemsIngested ?? 0),
           },
         };
       } catch (error) {


### PR DESCRIPTION
…w + ETL summary

Neon returns PostgreSQL BIGINT (int8) as JavaScript strings to avoid precision loss. raw sql<number> is a TS-only hint — COUNT/SUM results from raw SQL come back as strings at runtime. Drizzle's count() adds ::int cast internally, but sql`count(...)` and sql`sum(...)` do not.

TypeBox t.Number() rejects string values so response validation failed. Coerce totalBrands, withEmbedding, completed, failed, totalItemsIngested.

## Description

<!-- A clear and concise description of what this PR changes and why. -->

Closes #<!-- issue number, if applicable -->

## Type of change

<!-- Check all that apply -->

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️  Refactor / code improvement
- [ ] 📝 Documentation update
- [ ] 🔧 CI / configuration change
- [ ] ⬆️  Dependency update
- [ ] 🗄️  Database migration

## Area(s) affected

- [ ] Mobile app (`apps/expo`)
- [ ] API / Backend (`packages/api`)
- [ ] Landing page (`apps/landing`)
- [ ] Guides site (`apps/guides`)
- [ ] CI / CD (`.github/`)

## Testing

<!-- Describe how you tested your changes. -->

- [ ] Added / updated unit tests
- [ ] Manually tested on iOS
- [ ] Manually tested on Android
- [ ] Manually tested on Web
- [ ] API endpoints verified (e.g. `curl` or Postman)

## Screenshots / recordings

<!-- If your change affects the UI, please add screenshots or a short screen recording. -->

## Pre-merge checklist

- [ ] `bun format && bun lint` passes with no errors
- [ ] `bun check-types` passes with no errors
- [ ] No new secrets or credentials are committed
- [ ] Database migration included (if schema changed)
- [ ] Feature flag added (if this is a new feature)
- [ ] PR title follows conventional commits (`feat:`, `fix:`, `chore:`, etc.)
