### PR TITLE
fix(etl): flush remaining items before totalProcessed + use ORM for completion status

### DIFF
--- a/packages/api/src/services/etl/processCatalogEtl.ts
+++ b/packages/api/src/services/etl/processCatalogEtl.ts
@@ -130,9 +130,22 @@ export async function processCatalogETL({
 
     console.log(`🔍 [TRACE] Streaming complete - processing remaining batches`);
 
-    // Flush remaining items after the stream ends
-    const remainingItems = validItemsBatch.length + invalidItemsBatch.length;
+    // Flush remaining items BEFORE updating totalProcessed so that if a flush throws,
+    // totalProcessed isn't inflated while valid/invalid counts stay null.
+    const remainingValid = validItemsBatch.length;
+    const remainingInvalid = invalidItemsBatch.length;
 
+    if (remainingValid > 0) {
+      console.log(`🔍 [TRACE] Processing valid items batch - size: ${remainingValid}`);
+      await processValidItemsBatch({ jobId, items: validItemsBatch, env });
+    }
+
+    if (remainingInvalid > 0) {
+      console.log(`🔍 [TRACE] Processing invalid items batch - size: ${remainingInvalid}`);
+      await processLogsBatch({ jobId, logs: invalidItemsBatch, env });
+    }
+
+    const remainingItems = remainingValid + remainingInvalid;
     if (remainingItems > 0) {
       await db
         .update(etlJobs)
@@ -140,32 +153,16 @@ export async function processCatalogETL({
         .where(eq(etlJobs.id, jobId));
     }
 
-    if (validItemsBatch.length > 0) {
-      console.log(`🔍 [TRACE] Processing valid items batch - size: ${validItemsBatch.length}`);
-      await processValidItemsBatch({
-        jobId,
-        items: validItemsBatch,
-        env,
-      });
-    }
-
-    if (invalidItemsBatch.length > 0) {
-      console.log(`🔍 [TRACE] Processing invalid items batch - size: ${invalidItemsBatch.length}`);
-      await processLogsBatch({
-        jobId,
-        logs: invalidItemsBatch,
-        env,
-      });
-    }
-
     const totalRows = rowIndex;
 
-    // Use raw SQL to avoid neon-http enum serialization issues with Drizzle ORM.
+    // Mark completed using Drizzle ORM (same as the failed path below) — avoids the
+    // silent failure that ::etl_job_status raw SQL casts produced in some Neon HTTP driver versions.
     // Isolated try-catch so a transient DB hiccup here doesn't cascade to status='failed'.
     try {
-      await db.execute(
-        sql`UPDATE etl_jobs SET status = 'completed'::etl_job_status, completed_at = NOW() WHERE id = ${jobId}`,
-      );
+      await db
+        .update(etlJobs)
+        .set({ status: 'completed', completedAt: new Date() })
+        .where(eq(etlJobs.id, jobId));
     } catch (completionErr) {
       console.error(
         `[ETL] Failed to mark job ${jobId} completed — will be reset by stuck-job sweep:`,


### PR DESCRIPTION
## Summary

- **Remaining-items ordering bug**: `totalProcessed` was incremented *before* flushing the final valid/invalid batches. If `processValidItemsBatch` or `processLogsBatch` threw, `totalProcessed` showed an inflated count while `totalValid`/`totalInvalid` stayed null — making job records misleading (e.g. the May 7 EMS job: 15,975 `totalProcessed`, null valid/invalid). Fixed by flushing remaining items first, then updating `totalProcessed`.

- **Silent completion failure**: the final `status = 'completed'` update used raw SQL with an `::etl_job_status` cast that silently failed in some Neon HTTP driver versions (the inner try-catch swallowed the error). This left jobs stuck in `'running'`, which the `reset-stuck` sweep then marked as `'failed'` — even though all items were successfully ingested (the "phantom failure" pattern visible as 100% successRate + status=failed). Fixed by using the same `db.update().set({ status: 'completed' })` ORM pattern that already works reliably for the `'failed'` path in the outer catch.

## Root cause

These two bugs together explain the patterns observed in the May 7–8 ETL run:
- Many jobs showing `status: failed` with `successRate: 100` → phantom failures from the completion update bug
- Jobs with high `totalProcessed` but null `totalValid`/`totalInvalid` → ordering bug in the remaining-items flush

## Test plan

- [ ] Trigger an ETL run for a source with a small file — verify it completes with `status: completed` and non-null `totalValid`/`totalInvalid`
- [ ] Verify the admin `/catalog/etl` endpoint no longer shows phantom failures after successful runs

## Post-Deploy Monitoring & Validation

- **What to monitor**: `GET /api/admin/analytics/catalog/etl` — watch for jobs completing with `status: completed` instead of `status: failed` after the fix ships
- **Expected healthy behavior**: ETL jobs for files that process 100% valid items should show `status: completed`, `successRate: 100`, non-null `totalValid`/`totalInvalid`
- **Failure signal**: jobs still showing phantom failures (100% successRate + status=failed) → the Drizzle ORM completion update is still failing; check Neon connection logs
- **Validation window**: first ETL run after deploy
- **Owner**: whoever monitors the admin dashboard

---

[![Compound Engineered](https://img.shields.io/badge/Compound-Engineered-6366f1)](https://github.com/EveryInc/compound-engineering-plugin) 🤖 Generated with [Claude Code](https://claude.com/claude-code)