### PR TITLE
fix(etl): fix phantom failures, partial ingest, and large-file timeouts

### DIFF
--- a/packages/api/src/services/etl/processCatalogEtl.ts
+++ b/packages/api/src/services/etl/processCatalogEtl.ts
@@ -73,7 +73,7 @@ export async function processCatalogETL({
     })();
 
     for await (const record of parser) {
-      await new Promise((resolve) => setTimeout(resolve, 1)); // Yield to event loop for GC Opportunities to prevent memory bloat
+      if (rowIndex % 100 === 0) await new Promise((resolve) => setTimeout(resolve, 1)); // Yield every 100 rows for GC; per-row yield hits the CF Worker wall-clock limit on large files
       const row = record as string[];
       if (!isHeaderProcessed) {
         fieldMap = row.reduce<Record<string, number>>((acc, header, idx) => {


### PR DESCRIPTION
## Summary

Three bugs found while investigating ETL failures in the admin dashboard:

1. **Phantom failures (100% success rate, status=failed)** — The `::etl_job_status` raw SQL cast silently fails in some Neon HTTP driver versions, leaving jobs in `running`; the stuck-job sweep then marks them `failed`. Fixed by using Drizzle ORM `.set({ status: 'completed' })` (same pattern as the already-working `failed` update).

2. **Partial ingest / inflated totalProcessed** — `totalProcessed` was incremented before flushing the remaining valid/invalid batches. If a flush threw, `totalProcessed` was inflated while `totalValid`/`totalInvalid` stayed null. Fixed by flushing first, then updating the counter.

3. **Large-file timeouts (backcountry 142k rows, campsaver 110k, geartrade 210k, etc.)** — The per-row `await setTimeout(1)` yield created a hard floor of N ms for N rows. backcountry = 142+ seconds minimum before any actual processing — guaranteed CF Worker wall-clock timeout. Reduced to every 100 rows; overhead drops from 142s → 1.4s while still giving GC breathing room.

## Root cause trace

- backcountry_2026-04-26T19-52-52.csv: confirmed present in R2 (329.6 MB, 142,095 rows)
- All 5 prior backcountry failures had `totalProcessed: null` = Worker was killed before writing any batch
- EMS (16k rows) had been double-counted (31,775 shown) because the queue retried the same message; upserts are idempotent so data is correct

## Post-Deploy Monitoring & Validation

- **What to monitor**: ETL job list at `/api/admin/analytics/catalog/etl`
- **Expected healthy behavior**: backcountry/campsaver/geartrade jobs complete with `status: completed` and `successRate: 100%`; `totalProcessed` matches `totalValid + totalInvalid`
- **Failure signal**: `totalProcessed: null` after job completes = still timing out; retry with the new build deployed
- **Validation window**: retry backcountry after deploy and monitor to completion (~15–20 min expected)

---

[![Compound Engineered](https://img.shields.io/badge/Compound-Engineered-6366f1)](https://github.com/EveryInc/compound-engineering-plugin) 🤖 Generated with [Claude Code](https://claude.com/claude-code)