### PR TITLE
fix(etl): prevent Worker OOM on large CSV files via stream backpressure

### DIFF
--- a/packages/api/src/services/etl/processCatalogEtl.ts
+++ b/packages/api/src/services/etl/processCatalogEtl.ts
@@ -67,7 +67,11 @@ export async function processCatalogETL({
 
     (async () => {
       for await (const chunk of streamToText(r2Object.body)) {
-        parser.write(chunk);
+        // Respect backpressure: if the parser buffer is full, wait for drain before
+        // pushing more data. Without this, R2 fills the parser buffer for the entire
+        // file (up to 600 MB) before the main loop processes any rows → Worker OOM.
+        const ok = parser.write(chunk);
+        if (!ok) await new Promise<void>((resolve) => parser.once('drain', resolve));
       }
       parser.end();
     })();


### PR DESCRIPTION
## Summary

- **Root cause**: R2 delivers large files (329–607 MB) faster than the csv-parse loop can consume rows. Without backpressure, `parser.write()` buffers the entire file before a single row is processed → Worker hits 128 MB memory limit → killed externally → outer `catch` never runs → job stuck `running` forever.
- **Fix**: Check `parser.write()` return value and `await drain` before pushing more chunks — standard Node.js streams backpressure contract.
- **Secondary fix** (previous commit): yield to event loop every 100 rows instead of every row, which was causing wall-clock limit issues on large files.

## Root Cause Detail

```
R2 stream → streamToText → parser.write() [no backpressure]
                             ↓
                    Parser buffer grows to 329-607 MB
                             ↓
                    Worker OOM (128 MB limit)
                             ↓
                    Worker killed externally
                             ↓
                    catch{} block never runs
                             ↓
                    Job stays in 'running' state forever
```

## Fix

```typescript
const ok = parser.write(chunk);
if (!ok) await new Promise<void>((resolve) => parser.once('drain', resolve));
```

## Affected Jobs

Seven jobs were stuck/failed due to this bug and have been re-queued:
- backcountry (329 MB file, failed 5×)
- campsaver, rei, campmor, omcgear, geartrade, evo

## Post-Deploy Monitoring & Validation

- **What to monitor**: `wrangler tail packrat-api --format pretty` — watch for `✅ Done processing` log lines for the 7 re-queued jobs
- **Expected healthy signal**: Each job transitions `running → completed`, `totalProcessed` matches CSV row count
- **Failure signal**: Job stays `running` > 10 min → still OOM (unlikely after fix)
- **Validation window**: 30 min after deploy; owner: @andrew-bierman
- **Queries**:
  ```sql
  SELECT id, source, status, "totalProcessed", "totalValid" 
  FROM etl_jobs 
  WHERE status != 'completed' 
  ORDER BY "startedAt" DESC LIMIT 20;
  ```

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability and reliability of catalog data processing for large files, reducing potential performance issues during data import operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PackRat-AI/PackRat/pull/2418)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->