### PR TITLE
fix(auth): check __Secure- prefixed cookie when reading session token

### DIFF
--- a/apps/expo/lib/api/packrat.ts
+++ b/apps/expo/lib/api/packrat.ts
@@ -14,20 +14,16 @@ const COOKIE_STORE_KEY = 'packrat_cookie';
 const CookieStoreSchema = z.record(z.object({ value: z.string() }));
 
 // expoClient stores cookies as JSON: { "better-auth.session_token": { value, expires } }
+// HTTPS servers (remote dev/prod) prefix the cookie name with __Secure-; HTTP (local) does not.
 function parseSessionToken(cookieJson: string | null): string | null {
-  console.log('[auth] Parsing session token from cookie string:', cookieJson);
   if (!cookieJson) return null;
-  try {
-    const cookies = fromZod(CookieStoreSchema)(JSON.parse(cookieJson));
-    console.log(
-      '[auth] Parsed session token from cookie string:',
-      cookies?.['better-auth.session_token']?.value ?? 'null',
-    );
-    return cookies?.['better-auth.session_token']?.value ?? null;
-  } catch (err) {
-    console.warn('[auth] Failed to parse session token from cookie string:', err);
-    return null;
-  }
+  const cookies = fromZod(CookieStoreSchema)(JSON.parse(cookieJson));
+  if (!cookies) return null;
+  return (
+    cookies['better-auth.session_token']?.value ??
+    cookies['__Secure-better-auth.session_token']?.value ??
+    null
+  );
 }
 
 export const apiClient = createApiClient({


### PR DESCRIPTION
Better Auth prefixes session cookies with __Secure- on HTTPS (remote dev/prod) but not on HTTP (local). getAccessToken was only looking up the unprefixed key, returning null for every remote request and causing a 401 on all authenticated endpoints.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized session token parsing logic to improve code efficiency while maintaining existing authentication behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PackRat-AI/PackRat/pull/2426)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->