### PR TITLE
Enforce drizzle-kit generated migrations with a custom lint check

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "ios": "cd apps/expo && bun ios",
     "lefthook": "lefthook install",
     "lint": "biome check --write",
-    "lint:custom": "bun run scripts/lint/no-raw-typeof.ts && bun run scripts/lint/no-raw-regex.ts && bun run packages/env/scripts/no-raw-process-env.ts && bun run scripts/lint/no-duplicate-guards.ts && bun run scripts/lint/no-unauth-routes.ts",
+    "lint:custom": "bun run scripts/lint/no-raw-typeof.ts && bun run scripts/lint/no-raw-regex.ts && bun run packages/env/scripts/no-raw-process-env.ts && bun run scripts/lint/no-duplicate-guards.ts && bun run scripts/lint/no-unauth-routes.ts && bun run scripts/lint/check-drizzle-migrations.ts",
     "lint:strict": "biome check && bun run lint:custom",
     "lint-unsafe": "biome check --write --unsafe",
     "mcp": "bun run --cwd packages/mcp dev",

--- a/scripts/check-all.ts
+++ b/scripts/check-all.ts
@@ -83,6 +83,10 @@ const ALL_CHECKS: CheckDef[] = [
     script: join(ROOT, 'scripts', 'lint', 'no-unauth-routes.ts'),
   },
   {
+    name: 'check-drizzle-migrations',
+    script: join(ROOT, 'scripts', 'lint', 'check-drizzle-migrations.ts'),
+  },
+  {
     name: 'check-type-casts',
     script: join(ROOT, 'packages', 'checks', 'src', 'check-type-casts.ts'),
     args: ['--strict'],

--- a/scripts/lint/check-drizzle-migrations.ts
+++ b/scripts/lint/check-drizzle-migrations.ts
@@ -1,0 +1,60 @@
+#!/usr/bin/env bun
+
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const ROOT = join(import.meta.dir, '..', '..');
+
+const MIGRATION_TARGETS = [
+  { name: 'packages/api', allowManual: new Set(['0010_great_colleen_wing.sql']) },
+  { name: 'packages/osm-db', allowManual: new Set(['0000_extensions.sql']) },
+];
+
+const DRIZZLE_FILE_PATTERN = /^\d{4}_[a-z0-9]+(?:_[a-z0-9]+)+\.sql$/;
+const DRIZZLE_TEMPLATE_COMMENT = '-- Custom SQL migration file, put your code below! --';
+
+interface Violation {
+  packageName: string;
+  message: string;
+}
+
+function checkTarget(target: (typeof MIGRATION_TARGETS)[number], violations: Violation[]): void {
+  const drizzleDir = join(ROOT, target.name, 'drizzle');
+  if (!existsSync(drizzleDir)) return;
+
+  const sqlFiles = readdirSync(drizzleDir)
+    .filter((file) => file.endsWith('.sql'))
+    .sort();
+
+  for (const file of sqlFiles) {
+    if (target.allowManual.has(file)) continue;
+
+    if (!DRIZZLE_FILE_PATTERN.test(file)) {
+      violations.push({
+        packageName: target.name,
+        message: `${file}: migration name must match drizzle-kit format (NNNN_word_word.sql)`,
+      });
+    }
+
+    const content = readFileSync(join(drizzleDir, file), 'utf-8');
+    if (content.includes(DRIZZLE_TEMPLATE_COMMENT)) {
+      violations.push({
+        packageName: target.name,
+        message: `${file}: contains drizzle template comment; regenerate via drizzle-kit instead of hand-writing`,
+      });
+    }
+  }
+}
+
+const violations: Violation[] = [];
+for (const target of MIGRATION_TARGETS) checkTarget(target, violations);
+
+if (violations.length > 0) {
+  console.log(`Drizzle migration checks failed (${violations.length}):\n`);
+  for (const violation of violations) {
+    console.log(`${violation.packageName}: ${violation.message}`);
+  }
+  process.exit(1);
+}
+
+console.log('Drizzle migration checks passed.');


### PR DESCRIPTION
### Motivation
- Prevent ad-hoc handwritten SQL migrations that diverge from the drizzle-kit workflow and cause migration/journal mismatches. 
- Give CI and local developers an automated guardrail so new migrations are generated via `drizzle-kit` rather than hand-edited. 
- Allow existing legacy manual migrations to remain while enforcing the rule for new files.

### Description
- Add a new check script at `scripts/lint/check-drizzle-migrations.ts` that scans `packages/api/drizzle` and `packages/osm-db/drizzle` migration folders and reports violations. 
- The script enforces filename format using the regex `^\d{4}_[a-z0-9]+(?:_[a-z0-9]+)+\.sql$` and flags files that contain the drizzle template marker `-- Custom SQL migration file, put your code below! --`. 
- Include an allowlist for known legacy/manual migrations: `packages/api/drizzle/0010_great_colleen_wing.sql` and `packages/osm-db/drizzle/0000_extensions.sql`. 
- Wire the check into the master runner `scripts/check-all.ts` as `check-drizzle-migrations` and into root `lint:custom` in `package.json`.

### Testing
- Ran `bun scripts/lint/check-drizzle-migrations.ts`, which passed (no violations after adding the intentional allowlist). 
- Ran `bun scripts/check-all.ts`, which included the new check and reported the new check as passing while an unrelated existing `check-react-doctor` failed due to external npm registry 403 responses in this environment. 
- The pre-commit `biome check` lint step executed as part of the commit and passed for the modified files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07bf45ad688323ad4697645a2dbef6)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced database migration validation to enforce consistent naming and structure across SQL migration files, improving data integrity during deployments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PackRat-AI/PackRat/pull/2430?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->