### PR TITLE
api: implement chat rate-limiter and enable rate-limiting tests

### DIFF
--- a/packages/api/src/routes/chat.ts
+++ b/packages/api/src/routes/chat.ts
@@ -22,7 +22,7 @@ export const chatRoutes = new Elysia({ prefix: '/chat' })
   // Chat streaming
   .post(
     '/',
-    async ({ body, user }) => {
+    async ({ body, user, request }) => {
       const typedBody = body as {
         messages?: UIMessage[] | undefined;
         contextType?: string;
@@ -66,8 +66,23 @@ export const chatRoutes = new Elysia({ prefix: '/chat' })
         systemPrompt += `\n- The current location of the user is: ${location}.`;
       }
 
-      const { AI_PROVIDER, OPENAI_API_KEY, CLOUDFLARE_ACCOUNT_ID, CLOUDFLARE_AI_GATEWAY_ID, AI } =
-        getEnv();
+      const {
+        AI_PROVIDER,
+        OPENAI_API_KEY,
+        CLOUDFLARE_ACCOUNT_ID,
+        CLOUDFLARE_AI_GATEWAY_ID,
+        AI,
+        TOKEN_RATE_LIMITER,
+      } = getEnv();
+
+      if (TOKEN_RATE_LIMITER) {
+        const ip = request.headers.get('cf-connecting-ip') ?? 'unknown';
+        const rateLimitKey = `chat:${user.userId}:${ip}`;
+        const { success } = await TOKEN_RATE_LIMITER.limit({ key: rateLimitKey });
+        if (!success) {
+          return status(429, { error: 'Too many chat requests, please try again shortly.' });
+        }
+      }
 
       const aiProvider = createAIProvider({
         openAiApiKey: OPENAI_API_KEY,

--- a/packages/api/test/chat.test.ts
+++ b/packages/api/test/chat.test.ts
@@ -49,7 +49,7 @@ describe('Chat Routes', () => {
 
   // Rate limiting is not implemented on /chat yet — keeping a placeholder for
   // when it is so we don't forget to cover it. Skip for now to avoid noise.
-  describe.skip('Rate Limiting (TODO: once implemented)', () => {
+  describe('Rate Limiting', () => {
     it('caps concurrent requests', async () => {
       const requests = Array(5)
         .fill(null)


### PR DESCRIPTION
### Motivation
- The `/chat` route had a TODO around rate limiting and the corresponding tests were skipped, leaving an unimplemented production concern and no coverage for concurrent request throttling.

### Description
- Extract `TOKEN_RATE_LIMITER` from `getEnv()` and accept the `request` object in the `POST /chat` handler. 
- Apply runtime throttling when the optional `TOKEN_RATE_LIMITER` binding is present, composing the limiter key as `chat:${user.userId}:${ip}` and returning `429` when quota is exhausted. 
- Leave AI provider and streaming behavior unchanged when the request is allowed. 
- Re-enabled the previously skipped rate-limiting test block in `packages/api/test/chat.test.ts` so the endpoint behavior is covered by tests.

### Testing
- Ran the package unit test suite with `bun run test:api:unit` and all `packages/api` unit tests passed, including the newly active rate-limiting test. 
- The `chat` tests assert that concurrent requests return either `200` or `429` as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07c00a28788323979038c1a21d5c2f)