### PR TITLE
fix(guides): build OG images for all 504 posts (was 39)

### DIFF
--- a/apps/guides/__tests__/og-image.test.ts
+++ b/apps/guides/__tests__/og-image.test.ts
@@ -28,12 +28,14 @@ function assertValidPng(filePath: string): void {
 }
 
 describe('guides OG image generation', () => {
+  // Generating per-post PNGs takes ~30-60s for the full set;
+  // default vitest hook timeout is 5s.
   beforeAll(() => {
     execSync('bun run scripts/generate-og-images.ts', {
       cwd: APP_DIR,
       stdio: 'inherit',
     });
-  });
+  }, 180_000);
 
   it('generates public/og-image.png', () => {
     expect(fs.existsSync(ROOT_OG_PATH)).toBe(true);

--- a/apps/guides/package.json
+++ b/apps/guides/package.json
@@ -3,7 +3,7 @@
   "version": "2.0.25",
   "private": true,
   "scripts": {
-    "build": "bun run generate-og-images && bun run build-content && next build",
+    "build": "bun run build-content && bun run generate-og-images && next build",
     "build-content": "bun run scripts/build-content.ts",
     "clean": "bunx rimraf .next node_modules out",
     "demo-enhancement": "bun run scripts/demo-enhancement.ts",


### PR DESCRIPTION
## The bug

`apps/guides/package.json` build script ran in the wrong order:

```json
"build": "bun run generate-og-images && bun run build-content && next build"
```

`generate-og-images` runs **first** and reads `lib/content.ts`. But `lib/content.ts` is itself **written by build-content** from `content/posts/*.mdx`. So OG generation saw the **stale committed** version of `lib/content.ts` (39 posts) instead of the freshly-built 504-post list.

Visible in the CF Pages build log:
- Build content: `Built 504 posts and 29 categories`
- OG generation: `Done — generated 1 root + 39 post OG images`

→ **465 of 504 guides shipped without OG/Twitter images**.

## The fix

One-line swap: run `build-content` first, then `generate-og-images`, then `next build`.

```diff
- "build": "bun run generate-og-images && bun run build-content && next build"
+ "build": "bun run build-content && bun run generate-og-images && next build"
```

## Verified locally

```
Built 504 posts and 29 categories
Done — generated 1 root + 504 post OG images.
```

## Follow-up

A hardening PR will follow with:
- Test asserting `generate-og-images` count matches `build-content` post count
- GH Actions workflow that builds guides + landing on every PR (so we get build signal without relying on CF Pages)
- Lighthouse CI guardrails