### PR TITLE
chore(engines): pin node to ^24.0.0 (current LTS)

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
   "packageManager": "bun@1.3.14",
   "engines": {
     "bun": ">=1.3.14",
-    "node": ">=24.0.0"
+    "node": "^24.0.0"
   },
   "catalog": {
     "@ai-sdk/openai": "^3.0.53",


### PR DESCRIPTION
## Why

Root `package.json` had `"node": ">=24.0.0"`, which permits non-LTS jumps. With Node 26 already in the wild (and not LTS), a fresh `bun install` on a maintainer machine could silently install non-LTS Node and pass engines.

## Change

\`\`\`diff
-    "node": ">=24.0.0"
+    "node": "^24.0.0"
\`\`\`

Restricts to the 24.x series — current Node LTS, supported through 2027. When Node 26 becomes LTS (~Oct 2026), bump to `^24.0.0 || ^26.0.0` or move the floor.

## Verification

- `bun install` — succeeds.
- `bun check:all` — 12/12 pre-push checks pass (re-verified locally now that the hook environment has both bun + node available).
- No changes to runtime behavior; this only narrows the install-time engines window.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>