### PR TITLE
fix(expo): use proceedLogOut key in sync-in-progress logout dialog

### DIFF
--- a/apps/expo/app/(app)/(tabs)/profile/index.tsx
+++ b/apps/expo/app/(app)/(tabs)/profile/index.tsx
@@ -303,7 +303,7 @@ function ListFooterComponent() {
               // dialogs are not surfaced in XCTest/UIAutomator accessibility trees).
               Alert.alert(t('profile.syncInProgress'), t('profile.syncMessage'), [
                 { text: t('common.cancel'), style: 'cancel' },
-                { text: t('auth.logOut'), style: 'destructive', onPress: handleSignOut },
+                { text: t('auth.proceedLogOut'), style: 'destructive', onPress: handleSignOut },
               ]);
               return;
             }


### PR DESCRIPTION
## Summary

- The sync-in-progress `Alert` dialog was using `auth.logOut` ("Log Out") as the destructive button label
- The correct key is `auth.proceedLogOut` ("Proceed"), which matches the intent — confirming the user wants to proceed despite pending sync, not simply re-labelling the logout action
- This mismatch caused Maestro E2E tests to fail (iOS + Android) in [run #26063488028](https://github.com/PackRat-AI/PackRat/actions/runs/26063488028/job/76628958869)

## Test plan

- [ ] Trigger a sync, then attempt to log out — confirm the dialog's destructive button reads "Proceed"
- [ ] E2E Maestro suite passes on both iOS and Android

🤖 Generated with [Claude Code](https://claude.com/claude-code)