### PR TITLE
chore: add .envrc so direnv loads .env.local on cd

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+dotenv_if_exists .env.local


### PR DESCRIPTION
## Summary
- Adds a one-line `.envrc` (`dotenv_if_exists .env.local`) so [direnv](https://direnv.net/) auto-exports the contents of `.env.local` whenever you `cd` into the repo.
- Removes the manual `export PACKRAT_NATIVEWIND_UI_GITHUB_TOKEN=... && bun install` two-step that `configure-deps.ts` currently nudges you toward — the token is already in `.env.local` for runtime, and direnv promotes it into the parent shell before bun reads `bunfig.toml`.

## Why
`bunfig.toml` resolves `\$PACKRAT_NATIVEWIND_UI_GITHUB_TOKEN` at bun process startup, **before** the preinstall hook runs, so the env must be present in the parent shell. `.env.local` alone can't satisfy that. direnv fills the gap cleanly without per-shell exports.

## No secrets
- `.envrc` itself contains no secrets — just the directive.
- `.env.local` is already in `.gitignore`.

## Test plan
- [ ] `direnv allow` in the repo root.
- [ ] `cd` out and back in; direnv prints `loading ~/Code/PackRat/.envrc` and `export +PACKRAT_NATIVEWIND_UI_GITHUB_TOKEN`.
- [ ] `bun install` succeeds with no manual export.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated environment variable loading to conditionally support local configuration overrides.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PackRat-AI/PackRat/pull/2456?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->