### PR TITLE
feat(ci): automated mobile release pipeline

### DIFF
--- a/.github/RELEASING.md
+++ b/.github/RELEASING.md
@@ -38,7 +38,7 @@ Confirm these secrets exist in the repo's GitHub Settings → Secrets and variab
 | API changed flag is correct | Summary — API changed row; cross-check with `git diff <prev-tag> development -- packages/api/` locally |
 | All remote actions unchecked | Summary — Remote actions section shows `[ ]` for all |
 | No branch created on origin | `git branch -r \| grep release` returns nothing |
-| No tag pushed | `git tag --list 'v2.0.27'` on origin returns nothing |
+| No tag pushed | `git ls-remote --tags origin 'refs/tags/v2.0.27'` returns nothing |
 | No GitHub Release created | Releases page on GitHub shows no new entry |
 | No PR opened | Pull Requests tab shows no release PR |
 | `eas-build-dryrun` job shows correct commands | Job log shows both platforms, correct profile and submit targets |

--- a/.github/RELEASING.md
+++ b/.github/RELEASING.md
@@ -1,0 +1,140 @@
+# Release Pipeline — Testing Guide
+
+This document covers how to test the automated mobile release pipeline before using it for a real release. Work through the steps in order.
+
+---
+
+## Prerequisites
+
+Confirm these secrets exist in the repo's GitHub Settings → Secrets and variables → Actions:
+
+| Secret | Purpose |
+|---|---|
+| `PACKRAT_NATIVEWIND_UI_GITHUB_TOKEN` | Private package install |
+| `EXPO_TOKEN` | EAS CLI authentication |
+| `SENTRY_AUTH_TOKEN` | Sentry release creation |
+| `SENTRY_ORG` | Sentry org slug |
+| `SENTRY_PROJECT` | Sentry project slug |
+
+---
+
+## Step 1 — Dry-run validation (always run this first)
+
+**Goal**: Verify every local stage computes correctly without touching remote state.
+
+1. Go to **Actions → Release Cut → Run workflow**.
+2. Enter any valid next version (e.g. `2.0.27`). Check **Dry run**.
+3. Wait for all jobs to finish, then open the **cut** job's **Summary** tab.
+
+**What to verify:**
+
+| Check | Where to look |
+|---|---|
+| Pre-flight jobs all green | Job list — preflight-typecheck, preflight-lint, preflight-tests |
+| Version normalized correctly (no double `v`) | Summary table — Tag row shows `v2.0.27` |
+| Branch name is `release/v2.0.27` | Summary table — Release branch row |
+| Previous release tag detected | Summary table — Previous release row |
+| Changelog contains expected commits | Summary — Changelog preview section |
+| API changed flag is correct | Summary — API changed row; cross-check with `git diff <prev-tag> development -- packages/api/` locally |
+| All remote actions unchecked | Summary — Remote actions section shows `[ ]` for all |
+| No branch created on origin | `git branch -r \| grep release` returns nothing |
+| No tag pushed | `git tag --list 'v2.0.27'` on origin returns nothing |
+| No GitHub Release created | Releases page on GitHub shows no new entry |
+| No PR opened | Pull Requests tab shows no release PR |
+| `eas-build-dryrun` job shows correct commands | Job log shows both platforms, correct profile and submit targets |
+
+---
+
+## Step 2 — Pre-flight failure test
+
+**Goal**: Confirm the workflow fails fast when checks fail and does not touch git.
+
+1. On the `development` branch, introduce a deliberate type error in any TypeScript file (e.g. assign a string to a number-typed variable).
+2. Run **Release Cut** with any version and **Dry run: true**.
+3. Expect:
+   - `preflight-typecheck` fails and shows the type error.
+   - The `cut` job is skipped (never runs).
+   - No branch, tag, PR, or release is created.
+4. Revert the type error before moving on.
+
+Repeat with a lint error (add an unused import or a rule violation) to exercise `preflight-lint`, and with a failing test to exercise `preflight-tests`.
+
+---
+
+## Step 3 — Concurrency lock test
+
+**Goal**: Confirm two simultaneous release runs do not race.
+
+1. Trigger **Release Cut** (dry run, any version).
+2. Before it finishes, trigger it again with a different version.
+3. Expect: the second run queues and waits (it does **not** cancel the first, because `cancel-in-progress: false`).
+4. Once the first run finishes, the second starts.
+
+---
+
+## Step 4 — Full live run (test version)
+
+**Goal**: Exercise all remote operations end-to-end without shipping to stores.
+
+> Use a dedicated test version number that is clearly not a real release, e.g. `0.0.1-test`. Delete all artifacts after the test.
+
+1. Run **Release Cut** with version `0.0.1-test`, **Dry run: false**.
+2. Wait for the `cut` job to complete. Verify:
+   - Branch `release/v0.0.1-test` exists on origin.
+   - Tag `v0.0.1-test` exists on origin.
+   - GitHub Release `PackRat v0.0.1-test` exists with the generated changelog.
+   - A PR from `release/v0.0.1-test` → `main` is open with the correct title and body.
+   - The **API changed** note in the PR body matches what the Summary showed.
+3. If **API unchanged**: verify the `eas-build` job starts and appears in the [EAS dashboard](https://expo.dev). Cancel it immediately to avoid a real store submission.
+4. If **API changed**: the `eas-build` job should be skipped. Verify `release-deploy.yml` is **not** running yet.
+
+**Cleanup**: close the PR without merging, delete the branch `release/v0.0.1-test` and the tag `v0.0.1-test` from origin, delete the GitHub Release.
+
+---
+
+## Step 5 — Post-merge deploy test (release-deploy.yml)
+
+**Goal**: Verify the automatic EAS trigger fires when a release PR merges to main.
+
+> Only run this against a test version and with the EAS build ready to be cancelled.
+
+1. Complete Step 4 up through PR creation.
+2. Merge the test PR to main.
+3. Go to **Actions** and confirm `Release Deploy` triggered automatically.
+4. Verify the job name shows the correct release branch ref.
+5. Confirm the EAS build appears in the EAS dashboard and the Sentry release is created.
+6. Cancel the EAS build immediately to avoid a store submission.
+
+**Cleanup**: same as Step 4, plus delete the merged branch.
+
+---
+
+## Step 6 — Real release
+
+Once Steps 1–5 pass cleanly, the pipeline is ready for a real release.
+
+1. Run **Release Cut**, enter the real version, **Dry run: false**.
+2. Review the PR and the GitHub Release changelog — edit the release body if the generated copy needs polish.
+3. Get QA sign-off and merge the PR.
+4. Monitor EAS builds in the [EAS dashboard](https://expo.dev).
+5. Monitor store review status:
+   - **iOS**: App Store Connect → My Apps → TestFlight or App Store tab.
+   - **Android**: Google Play Console → Release → Production.
+6. Confirm the Sentry release appears at sentry.io with commits associated.
+
+---
+
+## Rollback
+
+If the EAS build or store submission fails after a real release cut:
+
+1. **Do not** delete the tag or the GitHub Release — they are public and pinned.
+2. Cancel the EAS build from the EAS dashboard if it is still running.
+3. Fix the root cause on the `release/vX.Y.Z` branch (not on development).
+4. Commit the fix, push the branch.
+5. Re-run **Release Cut** with the same version — the bump step will fail on "working directory not clean" because the tag already exists locally. Instead, trigger the `eas-build` job directly from the EAS dashboard or push a manual `eas build` command, then create the Sentry release manually:
+   ```bash
+   bunx @sentry/cli releases new <version>
+   bunx @sentry/cli releases set-commits <version> --auto
+   bunx @sentry/cli releases finalize <version>
+   ```

--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -163,6 +163,11 @@ jobs:
         # script works; neither is pushed without the push step below.
         run: bun bump ${{ steps.norm.outputs.version }}
 
+      - name: Validate bump output
+        run: |
+          git tag --list '${{ steps.norm.outputs.tag }}' | grep -q . || \
+            { echo "ERROR: bun bump did not create tag ${{ steps.norm.outputs.tag }}"; exit 1; }
+
       - name: Refresh lockfile after version bump
         env:
           PACKRAT_NATIVEWIND_UI_GITHUB_TOKEN: ${{ secrets.PACKRAT_NATIVEWIND_UI_GITHUB_TOKEN }}
@@ -171,6 +176,15 @@ jobs:
           if ! git diff --quiet bun.lock; then
             git add bun.lock
             git commit -m "chore: update lockfile for ${{ steps.norm.outputs.tag }}"
+          fi
+
+      - name: Retag HEAD after lockfile refresh
+        # If the lockfile refresh created a new commit, the tag from bun bump
+        # points at the pre-lockfile commit. Force-move it to HEAD so the tag
+        # and the release branch tip always refer to the same SHA.
+        run: |
+          if [ "$(git rev-parse HEAD)" != "$(git rev-parse ${{ steps.norm.outputs.tag }})" ]; then
+            git tag -f ${{ steps.norm.outputs.tag }} HEAD
           fi
 
       - name: Push release branch and tag
@@ -191,7 +205,7 @@ jobs:
         id: api_check
         run: |
           # New tag is first in the sorted list; previous release is second.
-          PREV_TAG=$(git tag --sort=-version:refname | grep '^v' | sed -n '2p')
+          PREV_TAG=$(git tag --sort=-version:refname | grep '^v' | sed -n '2p' || true)
           echo "Previous release tag: ${PREV_TAG:-<none>}"
           if [ -z "$PREV_TAG" ]; then
             echo "changed=false" >> "$GITHUB_OUTPUT"
@@ -206,7 +220,7 @@ jobs:
       - name: Generate changelog
         id: changelog
         run: |
-          PREV_TAG=$(git tag --sort=-version:refname | grep '^v' | sed -n '2p')
+          PREV_TAG=$(git tag --sort=-version:refname | grep '^v' | sed -n '2p' || true)
           RANGE="${PREV_TAG:+${PREV_TAG}..HEAD}"
 
           FEATS=$(git log ${RANGE} --pretty=format:"%s (%h)" --no-merges \

--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -8,6 +8,18 @@ name: Release Cut
 #
 # If the API has changed, the EAS build is deferred to release-deploy.yml
 # which triggers automatically when the release PR merges to main.
+#
+# DRY-RUN MODE (dry_run: true)
+# All local operations run — pre-flight, branch creation, version bump,
+# lockfile refresh, changelog generation, API-change detection — so you
+# see exactly what a real run would do. Remote writes are skipped:
+#   • git push (branch + tag)
+#   • GitHub Release creation
+#   • PR creation
+#   • EAS builds + store submissions
+#   • Sentry release creation
+# A step summary is written at the end of every run (dry or live) listing
+# all computed values and the actions that were (or would have been) taken.
 
 on:
   workflow_dispatch:
@@ -16,6 +28,11 @@ on:
         description: 'New version — semver without leading v (e.g. 2.0.27)'
         required: true
         type: string
+      dry_run:
+        description: 'Dry run — validate and preview without pushing, creating releases, or building'
+        required: false
+        type: boolean
+        default: false
 
 concurrency:
   group: release-cut
@@ -26,7 +43,8 @@ permissions:
   pull-requests: write
 
 # ── Pre-flight ───────────────────────────────────────────────────────────────
-# All three jobs run in parallel. The cut job waits for all of them.
+# All three jobs run in parallel regardless of dry_run — the whole point of
+# dry-run is to verify these pass before you commit to a real release.
 
 jobs:
   preflight-typecheck:
@@ -97,7 +115,7 @@ jobs:
 
   # ── Cut release branch ──────────────────────────────────────────────────
   cut:
-    name: Cut release branch
+    name: Cut release branch${{ inputs.dry_run && ' (dry run)' || '' }}
     needs: [preflight-typecheck, preflight-lint, preflight-tests]
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -112,8 +130,8 @@ jobs:
         run: |
           V="${{ inputs.version }}"
           V="${V#v}"
-          echo "version=$V"  >> "$GITHUB_OUTPUT"
-          echo "tag=v$V"     >> "$GITHUB_OUTPUT"
+          echo "version=$V"         >> "$GITHUB_OUTPUT"
+          echo "tag=v$V"            >> "$GITHUB_OUTPUT"
           echo "branch=release/v$V" >> "$GITHUB_OUTPUT"
 
       - uses: actions/checkout@v4
@@ -126,7 +144,7 @@ jobs:
           git config user.name  "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-      - name: Create release branch
+      - name: Create release branch (local)
         run: git checkout -b ${{ steps.norm.outputs.branch }}
 
       - uses: oven-sh/setup-bun@v2
@@ -139,8 +157,10 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: Bump version
-        # bump.ts bumps all package.json files + app.config.ts, then
-        # commits ("chore: bump version to vX.Y.Z") and creates the git tag.
+        # bump.ts bumps all package.json files + app.config.ts, commits
+        # "chore: bump version to vX.Y.Z", and creates the local git tag.
+        # Runs in dry-run mode too — the local commit/tag confirm the bump
+        # script works; neither is pushed without the push step below.
         run: bun bump ${{ steps.norm.outputs.version }}
 
       - name: Refresh lockfile after version bump
@@ -154,14 +174,23 @@ jobs:
           fi
 
       - name: Push release branch and tag
+        if: ${{ !inputs.dry_run }}
         run: |
           git push origin ${{ steps.norm.outputs.branch }}
           git push origin ${{ steps.norm.outputs.tag }}
 
+      - name: '[dry-run] Would push branch and tag'
+        if: ${{ inputs.dry_run }}
+        run: |
+          echo "DRY RUN — skipping remote push."
+          echo "  Would push branch: ${{ steps.norm.outputs.branch }}"
+          echo "  Would push tag:    ${{ steps.norm.outputs.tag }}"
+          git log --oneline -3
+
       - name: Detect API changes since last release
         id: api_check
         run: |
-          # The tag we just pushed is first; the previous release is second.
+          # New tag is first in the sorted list; previous release is second.
           PREV_TAG=$(git tag --sort=-version:refname | grep '^v' | sed -n '2p')
           echo "Previous release tag: ${PREV_TAG:-<none>}"
           if [ -z "$PREV_TAG" ]; then
@@ -180,7 +209,6 @@ jobs:
           PREV_TAG=$(git tag --sort=-version:refname | grep '^v' | sed -n '2p')
           RANGE="${PREV_TAG:+${PREV_TAG}..HEAD}"
 
-          # Conventional-commit groups: features first, then fixes, then rest.
           FEATS=$(git log ${RANGE} --pretty=format:"%s (%h)" --no-merges \
             | grep -E "^feat(\(.+\))?: " | sed 's/^/- /' || true)
           FIXES=$(git log ${RANGE} --pretty=format:"%s (%h)" --no-merges \
@@ -205,6 +233,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Create GitHub Release
+        if: ${{ !inputs.dry_run }}
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ steps.norm.outputs.tag }}
@@ -217,12 +246,15 @@ jobs:
             Download on the [App Store](https://apps.apple.com/app/id6499243187) · [Google Play](https://play.google.com/store/apps/details?id=com.packratai.mobile&pli=1)
 
       - name: Open PR to main
+        if: ${{ !inputs.dry_run }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          API_NOTE="${{ steps.api_check.outputs.changed == 'true' \
-            && 'Yes — EAS build and store submission will trigger automatically after this PR merges.' \
-            || 'No — EAS build and store submission have already been queued.' }}"
+          if [ "${{ steps.api_check.outputs.changed }}" = "true" ]; then
+            API_NOTE="Yes — EAS build and store submission will trigger automatically after this PR merges."
+          else
+            API_NOTE="No — EAS build and store submission have already been queued."
+          fi
 
           gh pr create \
             --base  main \
@@ -239,11 +271,69 @@ jobs:
           - [ ] Version numbers verified
           - [ ] QA sign-off"
 
-  # ── EAS build (immediate path — API unchanged) ──────────────────────────
+      # Always written — gives a clear record of what happened (or would have).
+      - name: Write step summary
+        if: always()
+        run: |
+          DRY="${{ inputs.dry_run }}"
+          API_CHANGED="${{ steps.api_check.outputs.changed }}"
+          PREV_TAG=$(git tag --sort=-version:refname | grep '^v' | sed -n '2p' || echo '<none>')
+
+          if [ "$DRY" = "true" ]; then
+            MODE="**DRY RUN** — no remote changes made"
+          else
+            MODE="**Live run**"
+          fi
+
+          if [ "$API_CHANGED" = "true" ]; then
+            EAS_NOTE="Deferred — API changed. EAS build will trigger when the release PR merges to main via \`release-deploy.yml\`."
+          else
+            if [ "$DRY" = "true" ]; then
+              EAS_NOTE="Would queue immediately (API unchanged). Skipped in dry-run."
+            else
+              EAS_NOTE="Queued immediately (API unchanged)."
+            fi
+          fi
+
+          {
+            echo "## Release Cut Summary"
+            echo ""
+            echo "> ${MODE}"
+            echo ""
+            echo "| Field | Value |"
+            echo "|---|---|"
+            echo "| Version | \`${{ steps.norm.outputs.version }}\` |"
+            echo "| Tag | \`${{ steps.norm.outputs.tag }}\` |"
+            echo "| Release branch | \`${{ steps.norm.outputs.branch }}\` |"
+            echo "| Previous release | \`${PREV_TAG}\` |"
+            echo "| API changed | ${API_CHANGED} |"
+            echo ""
+            echo "### Changelog preview"
+            echo ""
+            echo "${{ steps.changelog.outputs.body }}"
+            echo ""
+            echo "### Remote actions"
+            echo ""
+            if [ "$DRY" = "true" ]; then
+              echo "- [ ] Branch pushed to origin (skipped)"
+              echo "- [ ] Tag pushed to origin (skipped)"
+              echo "- [ ] GitHub Release created (skipped)"
+              echo "- [ ] PR opened to main (skipped)"
+              echo "- [ ] EAS build: ${EAS_NOTE}"
+            else
+              echo "- [x] Branch pushed to origin"
+              echo "- [x] Tag pushed to origin"
+              echo "- [x] GitHub Release created"
+              echo "- [x] PR opened to main"
+              echo "- [ ] EAS build: ${EAS_NOTE}"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  # ── EAS build — immediate path (API unchanged, live run) ────────────────
   eas-build:
     name: EAS Production Build + Submit
     needs: [cut]
-    if: needs.cut.outputs.api_changed == 'false'
+    if: needs.cut.outputs.api_changed == 'false' && !inputs.dry_run
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -283,3 +373,41 @@ jobs:
           bunx @sentry/cli releases new "${{ needs.cut.outputs.version }}"
           bunx @sentry/cli releases set-commits "${{ needs.cut.outputs.version }}" --auto
           bunx @sentry/cli releases finalize "${{ needs.cut.outputs.version }}"
+
+  # ── EAS build — dry-run preview (API unchanged, dry-run) ────────────────
+  eas-build-dryrun:
+    name: '[dry-run] EAS Production Build + Submit preview'
+    needs: [cut]
+    if: needs.cut.outputs.api_changed == 'false' && inputs.dry_run
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Show what would run
+        run: |
+          echo "DRY RUN — EAS production build and store submission skipped."
+          echo ""
+          echo "Commands that would execute against version ${{ needs.cut.outputs.version }}:"
+          echo ""
+          echo "  eas build --platform ios     --profile production --non-interactive --auto-submit"
+          echo "  eas build --platform android --profile production --non-interactive --auto-submit"
+          echo ""
+          echo "  sentry-cli releases new       ${{ needs.cut.outputs.version }}"
+          echo "  sentry-cli releases set-commits ${{ needs.cut.outputs.version }} --auto"
+          echo "  sentry-cli releases finalize  ${{ needs.cut.outputs.version }}"
+          echo ""
+          echo "EAS submit profile (from apps/expo/eas.json):"
+          echo "  iOS:     ASC App ID 6499243187"
+          echo "  Android: track=production"
+
+      - name: Write EAS dry-run summary
+        run: |
+          {
+            echo "## EAS Build Dry-run"
+            echo ""
+            echo "| Platform | Profile | Auto-submit |"
+            echo "|---|---|---|"
+            echo "| iOS | production | App Store (ASC 6499243187) |"
+            echo "| Android | production | Play Store (track: production) |"
+            echo ""
+            echo "Sentry release \`${{ needs.cut.outputs.version }}\` would be created and finalized."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -1,0 +1,285 @@
+name: Release Cut
+
+# Manually triggered. Accepts a version, runs pre-flight checks, cuts a
+# release branch from development, bumps the version, generates a changelog,
+# creates a GitHub release, opens a PR to main, and — if the API hasn't
+# changed since the last release — immediately queues EAS production builds
+# with auto-submit for both stores.
+#
+# If the API has changed, the EAS build is deferred to release-deploy.yml
+# which triggers automatically when the release PR merges to main.
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'New version — semver without leading v (e.g. 2.0.27)'
+        required: true
+        type: string
+
+concurrency:
+  group: release-cut
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  pull-requests: write
+
+# ── Pre-flight ───────────────────────────────────────────────────────────────
+# All three jobs run in parallel. The cut job waits for all of them.
+
+jobs:
+  preflight-typecheck:
+    name: Pre-flight · Type check
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: development
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        env:
+          PACKRAT_NATIVEWIND_UI_GITHUB_TOKEN: ${{ secrets.PACKRAT_NATIVEWIND_UI_GITHUB_TOKEN }}
+        run: bun install --frozen-lockfile
+
+      - name: Type check
+        run: bun check-types
+
+  preflight-lint:
+    name: Pre-flight · Lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: development
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        env:
+          PACKRAT_NATIVEWIND_UI_GITHUB_TOKEN: ${{ secrets.PACKRAT_NATIVEWIND_UI_GITHUB_TOKEN }}
+        run: bun install --frozen-lockfile
+
+      - name: Lint
+        run: bun biome check
+
+  preflight-tests:
+    name: Pre-flight · Unit tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: development
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        env:
+          PACKRAT_NATIVEWIND_UI_GITHUB_TOKEN: ${{ secrets.PACKRAT_NATIVEWIND_UI_GITHUB_TOKEN }}
+        run: bun install --frozen-lockfile
+
+      - name: API unit tests
+        run: bun test:api:unit
+
+      - name: Expo unit tests
+        run: bun test:expo
+
+  # ── Cut release branch ──────────────────────────────────────────────────
+  cut:
+    name: Cut release branch
+    needs: [preflight-typecheck, preflight-lint, preflight-tests]
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    outputs:
+      version: ${{ steps.norm.outputs.version }}
+      tag: ${{ steps.norm.outputs.tag }}
+      branch: ${{ steps.norm.outputs.branch }}
+      api_changed: ${{ steps.api_check.outputs.changed }}
+    steps:
+      - name: Normalize version input
+        id: norm
+        run: |
+          V="${{ inputs.version }}"
+          V="${V#v}"
+          echo "version=$V"  >> "$GITHUB_OUTPUT"
+          echo "tag=v$V"     >> "$GITHUB_OUTPUT"
+          echo "branch=release/v$V" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/checkout@v4
+        with:
+          ref: development
+          fetch-depth: 0
+
+      - name: Configure git identity
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Create release branch
+        run: git checkout -b ${{ steps.norm.outputs.branch }}
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies (frozen)
+        env:
+          PACKRAT_NATIVEWIND_UI_GITHUB_TOKEN: ${{ secrets.PACKRAT_NATIVEWIND_UI_GITHUB_TOKEN }}
+        run: bun install --frozen-lockfile
+
+      - name: Bump version
+        # bump.ts bumps all package.json files + app.config.ts, then
+        # commits ("chore: bump version to vX.Y.Z") and creates the git tag.
+        run: bun bump ${{ steps.norm.outputs.version }}
+
+      - name: Refresh lockfile after version bump
+        env:
+          PACKRAT_NATIVEWIND_UI_GITHUB_TOKEN: ${{ secrets.PACKRAT_NATIVEWIND_UI_GITHUB_TOKEN }}
+        run: |
+          bun install
+          if ! git diff --quiet bun.lock; then
+            git add bun.lock
+            git commit -m "chore: update lockfile for ${{ steps.norm.outputs.tag }}"
+          fi
+
+      - name: Push release branch and tag
+        run: |
+          git push origin ${{ steps.norm.outputs.branch }}
+          git push origin ${{ steps.norm.outputs.tag }}
+
+      - name: Detect API changes since last release
+        id: api_check
+        run: |
+          # The tag we just pushed is first; the previous release is second.
+          PREV_TAG=$(git tag --sort=-version:refname | grep '^v' | sed -n '2p')
+          echo "Previous release tag: ${PREV_TAG:-<none>}"
+          if [ -z "$PREV_TAG" ]; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          elif git diff "$PREV_TAG" HEAD -- packages/api/ | grep -q .; then
+            echo "API changes detected since $PREV_TAG"
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "No API changes since $PREV_TAG"
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Generate changelog
+        id: changelog
+        run: |
+          PREV_TAG=$(git tag --sort=-version:refname | grep '^v' | sed -n '2p')
+          RANGE="${PREV_TAG:+${PREV_TAG}..HEAD}"
+
+          # Conventional-commit groups: features first, then fixes, then rest.
+          FEATS=$(git log ${RANGE} --pretty=format:"%s (%h)" --no-merges \
+            | grep -E "^feat(\(.+\))?: " | sed 's/^/- /' || true)
+          FIXES=$(git log ${RANGE} --pretty=format:"%s (%h)" --no-merges \
+            | grep -E "^fix(\(.+\))?: "  | sed 's/^/- /' || true)
+          PERF=$(git log ${RANGE}  --pretty=format:"%s (%h)" --no-merges \
+            | grep -E "^perf(\(.+\))?: " | sed 's/^/- /' || true)
+          OTHER=$(git log ${RANGE} --pretty=format:"%s (%h)" --no-merges \
+            | grep -vE "^(feat|fix|perf|chore|ci|docs|test|build|style|refactor)(\(.+\))?: " \
+            | sed 's/^/- /' | head -20 || true)
+
+          BODY=""
+          [ -n "$FEATS" ] && BODY+="### Features"$'\n'"$FEATS"$'\n\n'
+          [ -n "$FIXES" ] && BODY+="### Bug Fixes"$'\n'"$FIXES"$'\n\n'
+          [ -n "$PERF"  ] && BODY+="### Performance"$'\n'"$PERF"$'\n\n'
+          [ -n "$OTHER" ] && BODY+="### Other Changes"$'\n'"$OTHER"$'\n\n'
+          [ -z "$BODY"  ] && BODY="No notable changes."
+
+          {
+            echo "body<<EOF"
+            echo "$BODY"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.norm.outputs.tag }}
+          name: PackRat ${{ steps.norm.outputs.tag }}
+          body: |
+            ## What's New
+
+            ${{ steps.changelog.outputs.body }}
+            ---
+            Download on the [App Store](https://apps.apple.com/app/id6499243187) · [Google Play](https://play.google.com/store/apps/details?id=com.packratai.mobile&pli=1)
+
+      - name: Open PR to main
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          API_NOTE="${{ steps.api_check.outputs.changed == 'true' \
+            && 'Yes — EAS build and store submission will trigger automatically after this PR merges.' \
+            || 'No — EAS build and store submission have already been queued.' }}"
+
+          gh pr create \
+            --base  main \
+            --head  "${{ steps.norm.outputs.branch }}" \
+            --title "Release ${{ steps.norm.outputs.tag }}" \
+            --body "## Release ${{ steps.norm.outputs.tag }}
+
+          Automated release PR cut from \`development\`.
+
+          **API changed since last release:** ${API_NOTE}
+
+          ### Checklist
+          - [ ] Changelog reviewed
+          - [ ] Version numbers verified
+          - [ ] QA sign-off"
+
+  # ── EAS build (immediate path — API unchanged) ──────────────────────────
+  eas-build:
+    name: EAS Production Build + Submit
+    needs: [cut]
+    if: needs.cut.outputs.api_changed == 'false'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.cut.outputs.branch }}
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        env:
+          PACKRAT_NATIVEWIND_UI_GITHUB_TOKEN: ${{ secrets.PACKRAT_NATIVEWIND_UI_GITHUB_TOKEN }}
+        run: bun install --frozen-lockfile
+
+      - name: Setup EAS CLI
+        uses: expo/expo-github-action@v8
+        with:
+          eas-version: latest
+          token: ${{ secrets.EXPO_TOKEN }}
+
+      - name: EAS Build + Submit · iOS
+        working-directory: apps/expo
+        run: eas build --platform ios --profile production --non-interactive --auto-submit
+
+      - name: EAS Build + Submit · Android
+        working-directory: apps/expo
+        run: eas build --platform android --profile production --non-interactive --auto-submit
+
+      - name: Create Sentry release
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+          SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+        run: |
+          bunx @sentry/cli releases new "${{ needs.cut.outputs.version }}"
+          bunx @sentry/cli releases set-commits "${{ needs.cut.outputs.version }}" --auto
+          bunx @sentry/cli releases finalize "${{ needs.cut.outputs.version }}"

--- a/.github/workflows/release-deploy.yml
+++ b/.github/workflows/release-deploy.yml
@@ -1,0 +1,80 @@
+name: Release Deploy
+
+# Triggers automatically when a release/* branch is merged into main.
+# This is the second half of the release pipeline for the "API changed" path:
+# once the team has reviewed and merged the release PR (which may include API
+# changes whose Cloudflare Worker deployment is handled separately), this
+# workflow queues the EAS production build and store submissions, then creates
+# the Sentry release.
+#
+# For the "API unchanged" path, builds are queued directly by release-cut.yml.
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+concurrency:
+  group: release-deploy-${{ github.event.pull_request.head.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  eas-build:
+    name: EAS Production Build + Submit
+    # Only runs when a release/* branch is merged (not just closed).
+    if: |
+      github.event.pull_request.merged == true &&
+      startsWith(github.event.pull_request.head.ref, 'release/')
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Resolve release ref
+        id: ref
+        run: |
+          BRANCH="${{ github.event.pull_request.head.ref }}"
+          # branch is release/vX.Y.Z → strip prefix to get the tag
+          TAG="${BRANCH#release/}"
+          VERSION="${TAG#v}"
+          echo "branch=$BRANCH"   >> "$GITHUB_OUTPUT"
+          echo "tag=$TAG"         >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.ref.outputs.tag }}
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        env:
+          PACKRAT_NATIVEWIND_UI_GITHUB_TOKEN: ${{ secrets.PACKRAT_NATIVEWIND_UI_GITHUB_TOKEN }}
+        run: bun install --frozen-lockfile
+
+      - name: Setup EAS CLI
+        uses: expo/expo-github-action@v8
+        with:
+          eas-version: latest
+          token: ${{ secrets.EXPO_TOKEN }}
+
+      - name: EAS Build + Submit · iOS
+        working-directory: apps/expo
+        run: eas build --platform ios --profile production --non-interactive --auto-submit
+
+      - name: EAS Build + Submit · Android
+        working-directory: apps/expo
+        run: eas build --platform android --profile production --non-interactive --auto-submit
+
+      - name: Create Sentry release
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+          SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+        run: |
+          bunx @sentry/cli releases new "${{ steps.ref.outputs.version }}"
+          bunx @sentry/cli releases set-commits "${{ steps.ref.outputs.version }}" --auto
+          bunx @sentry/cli releases finalize "${{ steps.ref.outputs.version }}"

--- a/.github/workflows/release-deploy.yml
+++ b/.github/workflows/release-deploy.yml
@@ -24,10 +24,12 @@ permissions:
 jobs:
   eas-build:
     name: EAS Production Build + Submit
-    # Only runs when a release/* branch is merged (not just closed).
+    # Only runs when a release/* branch is merged (not just closed), and only
+    # from the canonical repo (prevents fork PRs from attempting secret access).
     if: |
       github.event.pull_request.merged == true &&
-      startsWith(github.event.pull_request.head.ref, 'release/')
+      startsWith(github.event.pull_request.head.ref, 'release/') &&
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:

--- a/.github/workflows/release-ios.yml
+++ b/.github/workflows/release-ios.yml
@@ -1,9 +1,10 @@
-name: Release Mobile Apps
+name: Release Mobile Apps (legacy)
+
+# This workflow is superseded by release-cut.yml + release-deploy.yml.
+# The push-tag trigger has been removed to avoid duplicate GitHub releases.
+# Kept as a manual fallback for creating a GitHub release from an existing tag.
 
 on:
-  push:
-    tags:
-      - 'v*'
   workflow_dispatch:
     inputs:
       tag:


### PR DESCRIPTION
## Summary

Adds a fully automated mobile release pipeline with dry-run support.

### New workflows

**`release-cut.yml`** — manually triggered via `workflow_dispatch`:
- Accepts a `version` input and a `dry_run` boolean (default `false`)
- Runs type-check, lint, and unit tests in parallel before touching git
- Cuts `release/vX.Y.Z` from `development`, bumps all version files via `bun bump`, refreshes the lockfile
- Detects API changes since the previous release tag
- Generates a conventional-commit changelog grouped by feat/fix/perf
- Creates a GitHub Release with the changelog
- Opens a PR to `main`
- If API unchanged: immediately queues EAS production builds with `--auto-submit` for iOS + Android, then creates a Sentry release
- If API changed: defers EAS build to `release-deploy.yml` (triggers on PR merge to main)
- Writes a step summary on every run showing computed values, changelog preview, and which remote actions were taken or skipped

**`release-deploy.yml`** — triggers automatically on merge of a `release/*` branch to `main`:
- Handles the "API changed" path — queues EAS builds + store submissions + Sentry release after the team has reviewed and merged

### Updated

**`release-ios.yml`** — removed the `push tags v*` trigger to prevent duplicate GitHub Releases. Kept as a `workflow_dispatch` legacy fallback only.

### Docs

**`.github/RELEASING.md`** — six-step test plan covering dry-run validation, pre-flight failure testing, concurrency lock, full live run with a test version, post-merge deploy verification, and rollback instructions.

## Test plan

After merging to `development` and then to `main`, trigger **Release Cut** from the Actions tab:
- Version: `2.0.27` (or next real version), Dry run: ✅
- Verify all pre-flight jobs pass
- Check the job Summary tab — confirms version/branch/changelog/API-changed computed correctly, all remote actions show `[ ]`
- Confirm no branch, tag, PR, or GitHub Release was created

🤖 Generated with [Claude Code](https://claude.com/claude-code)