### PR TITLE
fix: strip .csv from workflow instance ID (CF Workflows invalid_id)

### DIFF
--- a/docs/runbooks/etl-pipeline.md
+++ b/docs/runbooks/etl-pipeline.md
@@ -70,13 +70,16 @@ Response:
   "message": "Catalog ETL workflow triggered",
   "jobId": "<uuid>",
   "engine": "workflow",
-  "workflowInstanceId": "cotopaxi-cotopaxi_2026-05-14T16-54-05.csv"
+  "workflowInstanceId": "cotopaxi-cotopaxi_2026-05-14T16-54-05"
 }
 ```
 
-The deterministic `workflowInstanceId` (`${source}-${filename}`) means
+The deterministic `workflowInstanceId` (`${source}-${filenameWithoutExtension}`) means
 duplicate triggers for the same file are rejected by the Workflows runtime
 — safe to retry the curl on network failures.
+
+Note: CF Workflows instance IDs only allow `[a-zA-Z0-9_-]` — the `.csv` extension is
+stripped when building the ID.
 
 ## Inspecting a workflow instance
 
@@ -117,7 +120,7 @@ Response:
   "success": true,
   "newJobId": "<uuid>",
   "objectKey": "v2/cotopaxi/cotopaxi_2026-05-14T16-54-05.csv",
-  "workflowInstanceId": "cotopaxi-cotopaxi_...-retry-<newJobId>"
+  "workflowInstanceId": "retry-<newJobId>"
 }
 ```
 

--- a/packages/api/src/routes/admin/analytics/catalog.ts
+++ b/packages/api/src/routes/admin/analytics/catalog.ts
@@ -126,10 +126,11 @@ async function reingestJob(args: {
       chunksTotal: totalChunks,
     }));
 
-    // Suffix the instance ID with the new jobId so duplicate retries
-    // don't collide with the original instance or with each other.
+    // CF Workflows IDs allow [a-zA-Z0-9_-] only, max 64 chars.
+    // source-filename-retry-uuid can exceed 64 chars; use suffix+newJobId which is
+    // always unique (UUID) and well within limits.
     const suffix = mode === 'retry' ? 'retry' : 'repair';
-    const workflowInstanceId = `${original.source}-${original.filename}-${suffix}-${newJobId}`;
+    const workflowInstanceId = `${suffix}-${newJobId}`;
 
     await db.insert(etlJobs).values({
       id: newJobId,

--- a/packages/api/src/routes/catalog/index.ts
+++ b/packages/api/src/routes/catalog/index.ts
@@ -39,6 +39,8 @@ import {
 import { Elysia, NotFoundError, status } from 'elysia';
 import { z } from 'zod';
 
+const FILE_EXT_RE = /\.[^.]*$/;
+
 export const catalogRoutes = new Elysia({ prefix: '/catalog' })
   .use(authPlugin)
   .use(apiKeyAuthPlugin)
@@ -327,7 +329,8 @@ export const catalogRoutes = new Elysia({ prefix: '/catalog' })
         chunksTotal: totalChunks,
       }));
 
-      const instanceId = `${source}-${filename}`;
+      // CF Workflows instance IDs only allow [a-zA-Z0-9_-] — strip the file extension.
+      const instanceId = `${source}-${filename.replace(FILE_EXT_RE, '')}`.slice(0, 64);
 
       await db.insert(etlJobs).values({
         id: jobId,


### PR DESCRIPTION
## Problem

Every ETL trigger via the workflow engine path returned 500. Cloudflare Workers observability showed:

```
Error: (instance.invalid_id) Instance has invalid id
```

The workflow instance ID was built as `${source}-${filename}`, e.g. `23zero-23zero_2026-05-21T04-26-37.csv`. CF Workflows only allows `[a-zA-Z0-9_-]` in instance IDs — the `.csv` dot makes it invalid.

This was missed because:
- The queue path (`?engine=queue`) never calls `ETL_WORKFLOW.create()` so it was unaffected
- Local/wrangler-triggered workflow tests auto-generate UUIDs as instance IDs (no custom ID supplied)
- The `.csv` in the ID looks like a valid filename but violates the Workflows ID spec

## Fix

- `packages/api/src/routes/catalog/index.ts`: Strip file extension from `instanceId` using a module-level regex
- `packages/api/src/routes/admin/analytics/catalog.ts`: Retry/repair path now uses `${suffix}-${newJobId}` — UUID-based (always unique, always valid, always under 64 chars) instead of `source-filename-suffix-uuid` which can exceed the 64-char limit
- `docs/runbooks/etl-pipeline.md`: Updated example `workflowInstanceId` values

## Test plan

- [ ] Trigger ETL via `POST /api/catalog/etl?engine=workflow` after deploy — expect `jobId` in response and a new workflow instance visible in CF dashboard
- [ ] Verify `wrangler workflows instances list packrat-catalog-etl` shows a new running instance
- [ ] Re-run `scripts/manual_upload.py` (packrat-scrapyd) to re-trigger the 44 CSVs that failed with 500

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated ETL pipeline runbook with revised API response examples and clarified workflow instance identifier formats and constraints.

* **Chores**
  * Updated workflow instance ID generation to comply with stricter naming constraints, removing file extensions from identifiers for consistency across ETL pipeline components.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PackRat-AI/PackRat/pull/2463?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->