### PR TITLE
fix(api): clamp KV expirationTtl to minimum 60s

### DIFF
--- a/packages/api/src/auth/index.ts
+++ b/packages/api/src/auth/index.ts
@@ -53,7 +53,11 @@ export async function getAuth(env: ValidatedEnv): Promise<any> {
           get: async (key: string) => env.AUTH_KV.get(key),
           // biome-ignore lint/complexity/useMaxParams: Better Auth secondaryStorage.set interface requires 3 params
           set: async (key: string, value: string, ttl?: number) => {
-            await env.AUTH_KV.put(key, value, ttl ? { expirationTtl: ttl } : undefined);
+            await env.AUTH_KV.put(
+              key,
+              value,
+              ttl ? { expirationTtl: Math.max(ttl, 60) } : undefined,
+            );
           },
           delete: async (key: string) => env.AUTH_KV.delete(key),
         }


### PR DESCRIPTION
## Summary

- Cloudflare KV rejects `expirationTtl` values below 60 seconds with a `400 Invalid expiration_ttl` error
- Better Auth passes `ttl=10` when storing short-lived verification tokens, triggering this error on every sign-up attempt
- Fix clamps the TTL to `Math.max(ttl, 60)` before passing it to `AUTH_KV.put`

Resolves #2461

## Test plan

- [ ] Sign up with a new account on iOS/Android — should succeed without "Registration Failed" error
- [ ] Confirm KV writes no longer return 400 in Worker logs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved storage expiration handling by enforcing a minimum time-to-live (TTL) of 60 seconds, preventing potential issues with excessively short expiration durations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PackRat-AI/PackRat/pull/2466?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->