### PR TITLE
fix(api): clamp KV expirationTtl to minimum 60s

### DIFF
--- a/packages/api/src/auth/index.ts
+++ b/packages/api/src/auth/index.ts
@@ -53,7 +53,11 @@ export async function getAuth(env: ValidatedEnv): Promise<any> {
           get: async (key: string) => env.AUTH_KV.get(key),
           // biome-ignore lint/complexity/useMaxParams: Better Auth secondaryStorage.set interface requires 3 params
           set: async (key: string, value: string, ttl?: number) => {
-            await env.AUTH_KV.put(key, value, ttl ? { expirationTtl: ttl } : undefined);
+            await env.AUTH_KV.put(
+              key,
+              value,
+              ttl ? { expirationTtl: Math.max(ttl, 60) } : undefined,
+            );
           },
           delete: async (key: string) => env.AUTH_KV.delete(key),
         }


### PR DESCRIPTION
## Summary

- Cloudflare KV rejects `expirationTtl` values below 60 seconds with a 400 error
- Better Auth passes `ttl=10` for short-lived verification tokens, triggering this error on every write
- Fix clamps the TTL to `Math.max(ttl, 60)` before passing it to `AUTH_KV.put`

Resolves #2461