### PR TITLE
fix(image-detection): make schema fields required for OpenAI strict response_format

### DIFF
--- a/packages/api/src/services/imageDetectionService.ts
+++ b/packages/api/src/services/imageDetectionService.ts
@@ -24,11 +24,11 @@ const detectedItemSchema = z.object({
   description: z
     .string()
     .describe('Brief description including key characteristics optimized for catalog search'),
-  quantity: z.number().int().positive().default(1).describe('Number of this item visible'),
+  quantity: z.number().int().positive().describe('Number of this item visible'),
   category: z.string().describe('Category of outdoor gear (e.g., Sleep System, Clothing, etc.)'),
-  consumable: z.boolean().default(false).describe('Whether the item is consumable'),
-  worn: z.boolean().default(false).describe('Whether the item is worn'),
-  notes: z.string().nullable().optional(),
+  consumable: z.boolean().describe('Whether the item is consumable'),
+  worn: z.boolean().describe('Whether the item is worn'),
+  notes: z.string().nullable().describe('Additional notes, or null if none'),
   confidence: z.number().min(0).max(1).describe('Confidence level in the identification (0-1)'),
 });
 


### PR DESCRIPTION
## Summary

- Removes `.default()` from `quantity`, `consumable`, and `worn` fields in `detectedItemSchema`
- Replaces `.nullable().optional()` with `.nullable()` on the `notes` field
- All schema properties are now listed in `required`, satisfying OpenAI's `response_format` strict JSON schema constraint

## Root Cause

OpenAI's Responses API (`/v1/responses`) enforces that every property in a `response_format` JSON schema must appear in the `required` array. Zod omits fields with `.default()` or `.optional()` from `required`, which caused a 400 `invalid_json_schema` error whenever `analyzeImage` was called.

Closes #2470

## Test Plan

- [ ] Trigger an image analysis via `POST /api/packs/analyze-image` with a valid image URL and confirm it returns 200 with detected items
- [ ] Confirm `notes` is `null` (not missing) when the model has no extra notes to add