### PR TITLE
fix(etl): reduce chunk size to fit workflow step timeout

### DIFF
--- a/packages/api/src/routes/catalog/index.ts
+++ b/packages/api/src/routes/catalog/index.ts
@@ -242,7 +242,7 @@ export const catalogRoutes = new Elysia({ prefix: '/catalog' })
       const { filename, chunks, source, scraperRevision } = body;
       const engine = query.engine ?? 'workflow';
       // chunkMiB lets the caller tune chunk size per-source without a deploy.
-      // Default (undefined) falls through to DEFAULT_CHUNK_BYTES in chunkCsvForR2.
+      // Both workflow and queue paths default to 2 MiB when omitted.
       const chunkBytes = query.chunkMiB !== undefined ? query.chunkMiB * 1024 * 1024 : undefined;
       const db = createDb();
       const env = getEnv();

--- a/packages/api/src/routes/catalog/index.ts
+++ b/packages/api/src/routes/catalog/index.ts
@@ -241,6 +241,9 @@ export const catalogRoutes = new Elysia({ prefix: '/catalog' })
     async ({ body, query }) => {
       const { filename, chunks, source, scraperRevision } = body;
       const engine = query.engine ?? 'workflow';
+      // chunkMiB lets the caller tune chunk size per-source without a deploy.
+      // Default (undefined) falls through to DEFAULT_CHUNK_BYTES in chunkCsvForR2.
+      const chunkBytes = query.chunkMiB !== undefined ? query.chunkMiB * 1024 * 1024 : undefined;
       const db = createDb();
       const env = getEnv();
       const jobId = crypto.randomUUID();
@@ -259,7 +262,7 @@ export const catalogRoutes = new Elysia({ prefix: '/catalog' })
           startedAt: new Date(),
         });
 
-        const CHUNK_BYTES = 20 * 1024 * 1024;
+        const CHUNK_BYTES = chunkBytes ?? 2 * 1024 * 1024; // 2 MiB default (matches workflow path)
         const r2 = new R2BucketService({ env, bucketType: 'catalog' });
         const queueChunks: Array<{
           objectKey: string;
@@ -312,7 +315,15 @@ export const catalogRoutes = new Elysia({ prefix: '/catalog' })
       let firstEtag: string | null = null;
       let firstLastModified: Date | null = null;
       for (const objectKey of chunks) {
-        const { etag, lastModified, chunks: chunkSpecs } = await chunkCsvForR2({ r2, objectKey });
+        const {
+          etag,
+          lastModified,
+          chunks: chunkSpecs,
+        } = await chunkCsvForR2({
+          r2,
+          objectKey,
+          ...(chunkBytes !== undefined && { chunkBytes }),
+        });
         if (firstEtag === null) {
           firstEtag = etag;
           firstLastModified = lastModified;
@@ -372,11 +383,14 @@ export const catalogRoutes = new Elysia({ prefix: '/catalog' })
       body: CatalogETLSchema,
       query: z.object({
         engine: z.enum(['workflow', 'queue']).optional(),
+        chunkMiB: z.coerce.number().int().min(1).max(20).optional(),
       }),
       isValidApiKey: true,
       detail: {
         tags: ['Catalog'],
-        summary: 'Trigger catalog ETL ingest (Workflow by default; ?engine=queue for legacy path)',
+        summary:
+          'Trigger catalog ETL ingest (Workflow by default; ?engine=queue for legacy path). ' +
+          'Pass ?chunkMiB=N to override the default 2 MiB chunk size (1–20 MiB).',
       },
     },
   )

--- a/packages/api/src/workflows/shared/__tests__/chunk-csv-for-r2.test.ts
+++ b/packages/api/src/workflows/shared/__tests__/chunk-csv-for-r2.test.ts
@@ -142,6 +142,15 @@ describe('chunkCsvForR2', () => {
     ).rejects.toBeInstanceOf(ChunkBoundaryError);
   });
 
+  it('uses DEFAULT_CHUNK_BYTES (2 MiB) when chunkBytes is omitted', async () => {
+    const csv = makeCsv(10);
+    const { r2 } = fakeR2(csv);
+    const result = await chunkCsvForR2({ r2, objectKey: 'fixture.csv' });
+    // Small file fits in one chunk regardless of default size
+    expect(result.chunks).toHaveLength(1);
+    expect(result.chunks[0]?.byteStart).toBe(0);
+  });
+
   it('preserves a CSV row at the boundary — first row of chunk N+1 is intact', async () => {
     const csv = makeCsv(200, 40);
     const { r2, bytes } = fakeR2(csv);

--- a/packages/api/src/workflows/shared/chunkCsvForR2.ts
+++ b/packages/api/src/workflows/shared/chunkCsvForR2.ts
@@ -27,7 +27,7 @@ export type ChunkCsvResult = {
 
 export type ChunkerR2 = Pick<R2BucketService, 'head' | 'get'>;
 
-const DEFAULT_CHUNK_BYTES = 5 * 1024 * 1024; // 5 MiB — 20 MiB caused WorkflowTimeoutError on large files (>15 MB)
+const DEFAULT_CHUNK_BYTES = 2 * 1024 * 1024; // 2 MiB — 5 MiB still caused WorkflowTimeoutError on Marmot's large CSV (>24 min total on 4-retry run)
 const DEFAULT_PEEK_BYTES = 64 * 1024; // 64 KiB
 
 export class ChunkBoundaryError extends Error {

--- a/packages/api/src/workflows/shared/chunkCsvForR2.ts
+++ b/packages/api/src/workflows/shared/chunkCsvForR2.ts
@@ -27,7 +27,7 @@ export type ChunkCsvResult = {
 
 export type ChunkerR2 = Pick<R2BucketService, 'head' | 'get'>;
 
-const DEFAULT_CHUNK_BYTES = 2 * 1024 * 1024; // 2 MiB — 5 MiB still caused WorkflowTimeoutError on Marmot's large CSV (>24 min total on 4-retry run)
+const DEFAULT_CHUNK_BYTES = 2 * 1024 * 1024; // 2 MiB — keeps each workflow step well under the 5-minute timeout for large files
 const DEFAULT_PEEK_BYTES = 64 * 1024; // 64 KiB
 
 export class ChunkBoundaryError extends Error {


### PR DESCRIPTION
## Summary
- Reduces `DEFAULT_CHUNK_BYTES` from 5 MiB to 2 MiB so large input files process within the Cloudflare Workflow 5-minute step timeout
- Adds optional `?chunkMiB=N` query param (1–20, integer) to `POST /catalog/etl` for per-request tuning without a deploy

## Why
Large CSV files were causing `WorkflowTimeoutError` after 300 000 ms on the workflow path. Smaller chunks ensure each step completes well within the limit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `/catalog/etl` endpoint now accepts `chunkMiB` query parameter (1–20 MiB) to adjust chunk size during ETL execution.

* **Documentation**
  * Updated API documentation for the new query parameter.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PackRat-AI/PackRat/pull/2473?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->