### PR TITLE
fix(etl): guard variants.values.join crash when values is a string

### DIFF
--- a/packages/api/src/utils/__tests__/embeddingHelper.test.ts
+++ b/packages/api/src/utils/__tests__/embeddingHelper.test.ts
@@ -279,5 +279,23 @@ describe('embeddingHelper', () => {
       const result = getEmbeddingText(item, existingItem);
       expect(result).toContain('Headwear');
     });
+
+    it('handles variant with string values (not array) on item', () => {
+      const item = {
+        name: 'Pants',
+        variants: [{ attribute: 'Color', values: 'Black' as unknown as string[] }],
+      };
+      const result = getEmbeddingText(item);
+      expect(result).toContain('Color: Black');
+    });
+
+    it('handles variant with string values (not array) on existingItem', () => {
+      const item = { name: 'Pants' };
+      const existingItem = {
+        variants: [{ attribute: 'Size', values: 'Large' as unknown as string[] }],
+      };
+      const result = getEmbeddingText(item, existingItem);
+      expect(result).toContain('Size: Large');
+    });
   });
 });

--- a/packages/api/src/utils/embeddingHelper.ts
+++ b/packages/api/src/utils/embeddingHelper.ts
@@ -18,10 +18,20 @@ export const getEmbeddingText = (
     ('category' in item && item.category) ||
       (existingItem && 'category' in existingItem && existingItem.category),
     ('variants' in item &&
-      item.variants?.map((v) => `${v.attribute}: ${v.values.join(', ')}`).join('; ')) ||
+      item.variants
+        ?.map((v) => {
+          const vals = Array.isArray(v.values) ? v.values : [v.values].filter(Boolean);
+          return `${v.attribute}: ${vals.join(', ')}`;
+        })
+        .join('; ')) ||
       (existingItem &&
         'variants' in existingItem &&
-        existingItem.variants?.map((v) => `${v.attribute}: ${v.values.join(', ')}`).join('; ')),
+        existingItem.variants
+          ?.map((v) => {
+            const vals = Array.isArray(v.values) ? v.values : [v.values].filter(Boolean);
+            return `${v.attribute}: ${vals.join(', ')}`;
+          })
+          .join('; ')),
     ('techs' in item && item.techs
       ? Object.entries(item.techs)
           .map(([k, v]) => `${k}: ${v}`)


### PR DESCRIPTION
## Summary

- **Root cause**: The patagonia spider can yield a `variants` item where `values` is a raw string scalar (e.g. `"000"`) instead of an array when a product has only one colour in its JSON-LD `color` field.
- **ETL crash**: `embeddingHelper.getEmbeddingText` called `v.values.join(', ')` unconditionally, throwing `TypeError: n.values.join is not a function` and erroring the entire `chunk-0-1` step (retried 4×, finally errored the workflow instance).
- **Fix**: Normalise `values` to an array before joining in both the primary-item and `existingItem` branches of `getEmbeddingText`.

The companion fix to the patagonia spider (normalise `color` field to a list) is in the scrapyd repo separately.

## Test plan

- [ ] Verify `bun test:api:unit` passes (csv-utils and ETL unit tests exercise this path)
- [ ] Re-trigger patagonia ETL after this is deployed — should complete without `n.values.join` error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved embedding generation for product variants with enhanced data normalization and filtering, resulting in more accurate variant representation in search functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PackRat-AI/PackRat/pull/2475?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->