### PR TITLE
feat(etl): expose failureRate, embedding failures, and verification fields

### DIFF
--- a/packages/api/src/routes/admin/analytics/catalog.ts
+++ b/packages/api/src/routes/admin/analytics/catalog.ts
@@ -369,6 +369,13 @@ export const catalogAnalyticsRoutes = new Elysia({ prefix: '/catalog' })
               j.totalProcessed != null && j.totalProcessed > 0 && j.totalValid != null
                 ? Math.round((j.totalValid / j.totalProcessed) * 1000) / 10
                 : null,
+            failureRate:
+              j.totalProcessed != null && j.totalProcessed > 0 && j.totalInvalid != null
+                ? Math.round((j.totalInvalid / j.totalProcessed) * 1000) / 10
+                : null,
+            totalEmbeddingFailures: j.totalEmbeddingFailures,
+            verifiedRowCount: j.verifiedRowCount ?? null,
+            verifiedAt: j.verifiedAt?.toISOString() ?? null,
           })),
           summary: {
             totalRuns: s?.totalRuns ?? 0,

--- a/packages/schemas/src/admin.ts
+++ b/packages/schemas/src/admin.ts
@@ -179,6 +179,10 @@ export const EtlJobSchema = z.object({
   totalValid: z.number().nullable(),
   totalInvalid: z.number().nullable(),
   successRate: z.number().nullable(),
+  failureRate: z.number().nullable(),
+  totalEmbeddingFailures: z.number(),
+  verifiedRowCount: z.number().nullable(),
+  verifiedAt: z.string().nullable(),
 });
 
 export const EtlResponseSchema = z.object({


### PR DESCRIPTION
## Summary

Exposes four additional fields in the admin ETL job response that were already tracked in the database but not returned via the API:

- **`failureRate`** — complement to `successRate`; percentage of rows that failed validation, making it easier to spot problematic scraper runs at a glance
- **`totalEmbeddingFailures`** — count of items upserted without embeddings due to generation errors; was tracked silently before, now visible for observability
- **`verifiedRowCount`** / **`verifiedAt`** — post-ingestion reconciliation audit trail written by the admin reconcile endpoint; exposes the verification status in the job list

## Changes

- `packages/schemas/src/admin.ts`: added four fields to `EtlJobSchema`
- `packages/api/src/routes/admin/analytics/catalog.ts`: populated new fields from DB columns in the `/etl` route handler

## Test plan

- [x] Type check passes (`bun check-types`)
- [x] Biome lint clean on changed files
- [x] Pre-commit and pre-push hooks pass
- [ ] Deploy and verify `/api/admin/analytics/catalog/etl` response includes new fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * ETL job responses now include additional analytics metrics: failure rate, embedding failure count, verified row count, and verification timestamp.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PackRat-AI/PackRat/pull/2476?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->