### PR TITLE
fix(auth): disable JWT private key encryption

### DIFF
--- a/packages/api/src/auth/auth.config.ts
+++ b/packages/api/src/auth/auth.config.ts
@@ -69,7 +69,7 @@ export const auth = betterAuth({
     },
   },
 
-  plugins: [bearer(), jwt(), admin()],
+  plugins: [bearer(), jwt({ disablePrivateKeyEncryption: true }), admin()],
 
   trustedOrigins: ['http://localhost:8787', 'packrat://'],
 });

--- a/packages/api/src/auth/index.ts
+++ b/packages/api/src/auth/index.ts
@@ -153,7 +153,9 @@ async function buildAuth(env: ValidatedEnv): Promise<any> {
 
       // JWT: issues asymmetric JWTs and exposes a JWKS endpoint at
       // /api/auth/jwks for downstream service verification.
-      jwt(),
+      // Private key encryption is disabled — it causes decrypt failures when
+      // BETTER_AUTH_SECRET rotates or differs across environments.
+      jwt({ disablePrivateKeyEncryption: true }),
 
       // Admin: role-based user management endpoints.
       admin(),


### PR DESCRIPTION
## Summary

- Passes `disablePrivateKeyEncryption: true` to the `jwt()` BetterAuth plugin in both the live auth factory (`auth/index.ts`) and the CLI stub (`auth.config.ts`)
- Fixes `BetterAuthError: Failed to decrypt private key` errors occurring on every authenticated request in the dev worker

## Root cause

BetterAuth's JWT plugin encrypts the stored private key using `BETTER_AUTH_SECRET`. When the secret rotates or differs across environments, decryption fails and every request that touches the JWKS errors out.

## Notes

On first deploy the existing encrypted JWKS row will fail to decrypt once, then BetterAuth regenerates the key unencrypted. This means **existing JWTs are invalidated** on that first request. To skip the one-time churn, delete all rows from the `jwks` table before deploying.

## Test plan

- [ ] Deploy to dev worker and confirm `GET /api/packs` no longer returns the `Failed to decrypt private key` error
- [ ] Verify `/api/auth/jwks` endpoint returns a valid JWK set
- [ ] Confirm sign-in and authenticated requests work end-to-end