### PR TITLE
fix(api): guard catalog vector search embeddings

### DIFF
--- a/packages/api/src/services/catalogService.ts
+++ b/packages/api/src/services/catalogService.ts
@@ -19,6 +19,7 @@ import {
   gt,
   ilike,
   inArray,
+  isNotNull,
   isNull,
   or,
   type SQL,
@@ -234,6 +235,8 @@ export class CatalogService {
 
     const { embedding: _embedding, ...columnsToSelect } = getTableColumns(catalogItems);
 
+    const vectorWhere = and(isNotNull(catalogItems.embedding), gt(similarity, 0.1));
+
     const [items, vectorTotalCountResult] = await Promise.all([
       this.db
         .select({
@@ -241,7 +244,7 @@ export class CatalogService {
           similarity,
         })
         .from(catalogItems)
-        .where(gt(similarity, 0.1))
+        .where(vectorWhere)
         .orderBy(desc(similarity))
         .limit(limit)
         .offset(offset),
@@ -250,7 +253,7 @@ export class CatalogService {
           totalCount: count(),
         })
         .from(catalogItems)
-        .where(gt(similarity, 0.1)),
+        .where(vectorWhere),
     ]);
     const totalCount = vectorTotalCountResult[0]?.totalCount ?? 0;
 
@@ -303,7 +306,7 @@ export class CatalogService {
           similarity,
         })
         .from(catalogItems)
-        .where(gt(similarity, 0.1))
+        .where(and(isNotNull(catalogItems.embedding), gt(similarity, 0.1)))
         .orderBy(desc(similarity))
         .limit(limit);
     });


### PR DESCRIPTION
## Summary
- filter catalog vector search queries to rows with non-null embeddings
- apply the same guard to vector search count queries and batch vector search

## Verification
- bun run check -- packages/api/src/services/catalogService.ts
- bun run check

Note: packages/api typecheck OOMed locally even with NODE_OPTIONS=--max-old-space-size=8192; leaving full typecheck to CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved vector search accuracy and reliability by enhancing how embedding data is filtered and processed in catalog search operations. Search results are now more consistent and of higher quality. These improvements apply to both standard individual searches and bulk batch search operations, ensuring users receive the most dependable results across all search scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PackRat-AI/PackRat/pull/2483?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->