### PR TITLE
fix(auth): filter encrypted jwks rows to resolve JWK must be an object error

### DIFF
--- a/packages/api/src/auth/index.ts
+++ b/packages/api/src/auth/index.ts
@@ -155,7 +155,31 @@ async function buildAuth(env: ValidatedEnv): Promise<any> {
       // /api/auth/jwks for downstream service verification.
       // Private key encryption is disabled — it causes decrypt failures when
       // BETTER_AUTH_SECRET rotates or differs across environments.
-      jwt({ jwks: { disablePrivateKeyEncryption: true } }),
+      //
+      // The adapter.getJwks filter skips any rows that were stored in the old
+      // encrypted format (where JSON.parse(privateKey) returns a string rather
+      // than a JWK object). Better Auth creates a fresh plaintext key when the
+      // filtered list is empty, resolving the "JWK must be an object" error that
+      // occurs after switching from encrypted to plaintext storage.
+      jwt({
+        jwks: { disablePrivateKeyEncryption: true },
+        adapter: {
+          // biome-ignore lint/suspicious/noExplicitAny: Better Auth ctx/key/jwks generics are not expressible here
+          getJwks: async (ctx: any) => {
+            // biome-ignore lint/suspicious/noExplicitAny: jwks row type from Better Auth is not exported
+            const keys: any[] = (await ctx.context.adapter.findMany({ model: 'jwks' })) ?? [];
+            // biome-ignore lint/suspicious/noExplicitAny: jwks row type from Better Auth is not exported
+            return keys.filter((key: any) => {
+              try {
+                const parsed = JSON.parse(key.privateKey);
+                return parsed !== null && typeof parsed === 'object' && !Array.isArray(parsed);
+              } catch {
+                return false;
+              }
+            });
+          },
+        },
+      }),
 
       // Admin: role-based user management endpoints.
       admin(),

--- a/packages/api/src/auth/index.ts
+++ b/packages/api/src/auth/index.ts
@@ -13,6 +13,7 @@ import { generateAppleClientSecret, verifyPasswordCompat } from '@packrat/api/au
 import { createConnection } from '@packrat/api/db';
 import type { ValidatedEnv } from '@packrat/api/utils/env-validation';
 import * as schema from '@packrat/db';
+import { isObject } from '@packrat/guards';
 import { betterAuth } from 'better-auth';
 import { admin, bearer, jwt } from 'better-auth/plugins';
 
@@ -171,8 +172,7 @@ async function buildAuth(env: ValidatedEnv): Promise<any> {
             // biome-ignore lint/suspicious/noExplicitAny: jwks row type from Better Auth is not exported
             return keys.filter((key: any) => {
               try {
-                const parsed = JSON.parse(key.privateKey);
-                return parsed !== null && typeof parsed === 'object' && !Array.isArray(parsed);
+                return isObject(JSON.parse(key.privateKey));
               } catch {
                 return false;
               }


### PR DESCRIPTION
## Summary

- **Root cause**: `disablePrivateKeyEncryption: true` was added in a previous commit, but existing `jwks` rows in the database were stored in the old encrypted format. The encrypted format stores `privateKey` as `JSON.stringify(ciphertextString)`, so `JSON.parse(key.privateKey)` returns a plain **string** rather than a JWK object. `jose`'s `importJWK` then throws `TypeError: JWK must be an object` on every authenticated request, causing all protected endpoints to return 500.
- **Fix**: Override `adapter.getJwks` in the JWT plugin config to filter out any row where `privateKey` does not parse to a plain object. When all old encrypted rows are filtered, Better Auth's signing code falls back to `createJwk`, generating and storing a fresh plaintext key automatically.
- Uses `isObject` from `@packrat/guards` (radash) to detect the encrypted format.

## Test plan

- [x] Restart the API dev server — first request to any authenticated endpoint should succeed (not 500)
- [x] Verify `wrangler` logs show no more `TypeError: JWK must be an object` errors
- [x] Verify `GET /api/auth/jwks` returns a valid key set
- [x] Sign in and confirm Bearer token auth works end-to-end