### PR TITLE
fix(schemas): coerce readingTime to number in GuideSchema

### DIFF
--- a/packages/schemas/src/guides.ts
+++ b/packages/schemas/src/guides.ts
@@ -8,7 +8,7 @@ export const GuideSchema = z.object({
   categories: z.array(z.string()).optional(),
   description: z.string(),
   author: z.string().optional(),
-  readingTime: z.number().optional(),
+  readingTime: z.coerce.number().optional(),
   difficulty: z.string().optional(),
   content: z.string().optional(),
   createdAt: z.string().datetime(),

--- a/packages/schemas/src/guides.ts
+++ b/packages/schemas/src/guides.ts
@@ -1,3 +1,4 @@
+import { isString } from '@packrat/guards';
 import { z } from 'zod';
 
 export const GuideSchema = z.object({
@@ -10,7 +11,7 @@ export const GuideSchema = z.object({
   author: z.string().optional(),
   readingTime: z.preprocess((val) => {
     if (val === undefined || val === null) return undefined;
-    const n = typeof val === 'string' ? parseFloat(val) : val;
+    const n = isString(val) ? parseFloat(val) : val;
     return Number.isFinite(n) ? n : undefined;
   }, z.number().optional()),
   difficulty: z.string().optional(),

--- a/packages/schemas/src/guides.ts
+++ b/packages/schemas/src/guides.ts
@@ -8,7 +8,11 @@ export const GuideSchema = z.object({
   categories: z.array(z.string()).optional(),
   description: z.string(),
   author: z.string().optional(),
-  readingTime: z.coerce.number().optional(),
+  readingTime: z.preprocess((val) => {
+    if (val === undefined || val === null) return undefined;
+    const n = typeof val === 'string' ? parseFloat(val) : val;
+    return Number.isFinite(n) ? n : undefined;
+  }, z.number().optional()),
   difficulty: z.string().optional(),
   content: z.string().optional(),
   createdAt: z.string().datetime(),


### PR DESCRIPTION
## Summary

- `readingTime` in `GuideSchema` was typed as `z.number()`, but `gray-matter` parses frontmatter values from `.md`/`.mdx` files as strings
- This caused `GuideDetailSchema.parse()` to throw a `ZodError` (`Expected number, received string`) on every guide detail request, returning a 500
- Fix: change `z.number().optional()` → `z.coerce.number().optional()` so Zod coerces the string value to a number automatically

Fixes #2487

## Test plan

- [x] Open the Guides section in the mobile app
- [x] Select any guide — it should load its content without error
- [x] Confirm no 500 errors appear in the API logs for `GET /api/guides/:id`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved reading time field validation to accept flexible input formats (e.g., numeric strings automatically converted to numbers).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PackRat-AI/PackRat/pull/2491?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->