### PR TITLE
fix(gear-inventory): open item details when Details option is tapped

### DIFF
--- a/apps/expo/app/(app)/gear-inventory.tsx
+++ b/apps/expo/app/(app)/gear-inventory.tsx
@@ -5,11 +5,20 @@ import { useUserPackItems } from 'expo-app/features/packs/hooks/useUserPackItems
 import type { PackItem } from 'expo-app/features/packs/types';
 import { cn } from 'expo-app/lib/cn';
 import { useTranslation } from 'expo-app/lib/hooks/useTranslation';
+import { useRouter } from 'expo-router';
 import { useState } from 'react';
 import { Pressable, ScrollView, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
-function CategorySection({ category, items }: { category: string; items: PackItem[] }) {
+function CategorySection({
+  category,
+  items,
+  onItemPress,
+}: {
+  category: string;
+  items: PackItem[];
+  onItemPress: (item: PackItem) => void;
+}) {
   return (
     <View className="mb-4">
       <View className="bg-primary/10 px-4 py-2">
@@ -19,7 +28,7 @@ function CategorySection({ category, items }: { category: string; items: PackIte
       </View>
       <View className="mt-3">
         {items.map((item) => (
-          <PackItemCard key={item.id} item={item} onPress={() => {}} />
+          <PackItemCard key={item.id} item={item} onPress={onItemPress} />
         ))}
       </View>
     </View>
@@ -29,6 +38,14 @@ function CategorySection({ category, items }: { category: string; items: PackIte
 export default function GearInventoryScreen() {
   const [viewMode, setViewMode] = useState<'all' | 'category'>('all');
   const items = useUserPackItems();
+  const router = useRouter();
+
+  const handleItemPress = (item: PackItem) => {
+    router.push({
+      pathname: '/item/[id]',
+      params: { id: item.id, packId: item.packId },
+    });
+  };
   const { t } = useTranslation();
 
   const groupByCategory = (items: PackItem[]) => {
@@ -95,13 +112,18 @@ export default function GearInventoryScreen() {
         {viewMode === 'all' ? (
           <View className=" flex-1 pb-20">
             {items.map((item) => (
-              <PackItemCard key={item.id} item={item} onPress={() => {}} />
+              <PackItemCard key={item.id} item={item} onPress={handleItemPress} />
             ))}
           </View>
         ) : (
           <View className="pb-4">
             {Object.entries(itemsByCategory).map(([category, groupedItems]) => (
-              <CategorySection key={category} category={category} items={groupedItems} />
+              <CategorySection
+                key={category}
+                category={category}
+                items={groupedItems}
+                onItemPress={handleItemPress}
+              />
             ))}
           </View>
         )}


### PR DESCRIPTION
## Summary

- The `onPress` handler passed to `PackItemCard` in the Gear Inventory screen was a no-op (`() => {}`), so tapping "View Details" from the three-dot action sheet did nothing
- Fixed by wiring up `router.push('/item/[id]', { id, packId })` as the `onPress` handler in both "All" and "By Category" view modes
- Also propagated the handler into `CategorySection` via a new `onItemPress` prop

Closes #2484

## Test plan

- [x] Open Gear Inventory, tap the three-dot menu on any item → "View Details" → item detail screen opens
- [x] Switch to "By Category" view, repeat — detail screen opens from that mode too
- [x] "Edit" and "Delete" actions still work as before