### PR TITLE
feat(ios): add extended virtual addressing and increased memory limit entitlements

### DIFF
--- a/apps/expo/app.config.ts
+++ b/apps/expo/app.config.ts
@@ -146,6 +146,10 @@ export default (): ExpoConfig =>
             },
           ],
         },
+        entitlements: {
+          'com.apple.developer.kernel.extended-virtual-addressing': true,
+          'com.apple.developer.kernel.increased-memory-limit': true,
+        },
       },
       android: {
         adaptiveIcon: {


### PR DESCRIPTION
## Summary

- Adds `com.apple.developer.kernel.extended-virtual-addressing` entitlement to the iOS build config
- Adds `com.apple.developer.kernel.increased-memory-limit` entitlement to the iOS build config

These entitlements allow the app to request more virtual address space and a higher memory ceiling from the iOS kernel, improving stability for memory-intensive workloads (AI features, large pack lists, map rendering).

## Test plan

- [ ] Build iOS app with EAS and confirm the entitlements appear in the provisioning profile / `.entitlements` file
- [x] Verify no build errors are introduced