### PR TITLE
feat(api): route AI providers through Cloudflare Gateway

### DIFF
--- a/.envrc.example
+++ b/.envrc.example
@@ -1,0 +1,1 @@
+dotenv_if_exists .env.local

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ report.[0-9]_.[0-9]_.[0-9]_.[0-9]_.json
 .env.test.local
 .env.production.local
 .env.local
+.envrc
 
 # caches
 .eslintcache

--- a/README.md
+++ b/README.md
@@ -325,6 +325,12 @@ cd PackRat
 
    Run bun install to regenerate .dev.vars whenever environment variables are changed.
 
+   Optional: if you use direnv, copy `.envrc.example` to `.envrc` to auto-load `.env.local` in your shell. `.envrc` is ignored because it is local machine behavior.
+
+   AI-backed API features prefer Cloudflare AI Gateway when `CLOUDFLARE_ACCOUNT_ID`, `CLOUDFLARE_AI_GATEWAY_ID`, and `CLOUDFLARE_API_TOKEN` are all present. Direct provider keys such as `OPENAI_API_KEY`, `GOOGLE_GENERATIVE_AI_API_KEY`, and `PERPLEXITY_API_KEY` are still required for fallback and rollback.
+
+   See `docs/runbooks/ai-gateway-unified-billing.md` for production setup, fallback behavior, and provider coverage.
+
    Only variables prefixed with PUBLIC\_ will be bundled into the Expo app (e.g., PUBLIC_API_URL). These are safe to expose in the client environment.
 
    ⚠️ Do not include secrets (e.g., private API keys) in PUBLIC\_ variables — they may be exposed in the bundled app.

--- a/docs/brainstorms/2026-05-23-cf-gateway-unified-billing-openai-requirements.md
+++ b/docs/brainstorms/2026-05-23-cf-gateway-unified-billing-openai-requirements.md
@@ -1,0 +1,118 @@
+---
+date: 2026-05-23
+topic: cf-gateway-unified-billing-openai
+---
+
+# Cloudflare AI Gateway Unified Billing for OpenAI
+
+## Summary
+
+PackRat should use Cloudflare AI Gateway Unified Billing as the preferred billing and authentication path for OpenAI-backed runtime AI features. Existing Google/Gemini and Perplexity usages remain direct-provider exceptions in this pass.
+
+---
+
+## Problem Frame
+
+PackRat's runtime AI surface is mostly OpenAI-backed, but the codebase currently mixes shared OpenAI-through-gateway usage with direct OpenAI SDK setup. That keeps provider billing, key management, and request traceability harder to manage than necessary.
+
+Cloudflare AI Gateway Unified Billing can route supported third-party provider traffic through Cloudflare account credits and a Cloudflare API token instead of direct provider keys. For this pass, the operational pain is concentrated enough around OpenAI that broad multi-provider migration would add carrying cost without matching near-term value.
+
+---
+
+## Actors
+
+- A1. PackRat operator: Manages AI provider spend, credentials, deployment configuration, and incident investigation.
+- A2. PackRat user: Uses AI-backed app features and should not see behavior regress when billing path changes.
+- A3. Implementation agent: Plans and implements the migration from this scope document.
+
+---
+
+## Key Flows
+
+- F1. OpenAI-backed request uses Cloudflare unified billing
+  - **Trigger:** A PackRat runtime feature invokes an OpenAI-backed model.
+  - **Actors:** A1, A2
+  - **Steps:** The feature selects the shared OpenAI provider path, the request is sent through Cloudflare AI Gateway unified billing when configured, and PackRat records enough metadata to trace the request in Cloudflare.
+  - **Outcome:** The request succeeds through Cloudflare billing without requiring a direct OpenAI key for the primary production path.
+  - **Covered by:** R1, R2, R4, R5
+
+- F2. Unsupported or non-migrated provider remains direct
+  - **Trigger:** A PackRat feature uses Google/Gemini template analysis or Perplexity web search.
+  - **Actors:** A1, A2
+  - **Steps:** The feature continues using its existing provider configuration, and logs/configuration make clear that it is outside the OpenAI unified billing migration.
+  - **Outcome:** Non-OpenAI features keep working while their billing/key behavior remains explicit.
+  - **Covered by:** R3, R5, R7
+
+---
+
+## Requirements
+
+**OpenAI unified billing**
+- R1. PackRat must prefer Cloudflare AI Gateway Unified Billing for OpenAI-backed runtime AI requests when the required Cloudflare configuration is present.
+- R2. OpenAI-backed runtime features must no longer require a direct OpenAI API key for the primary production unified billing path.
+- R3. The migration must preserve existing direct-provider behavior for Google/Gemini template generation and Perplexity web search.
+
+**Compatibility and fallback**
+- R4. PackRat must retain a clear direct OpenAI fallback for local development, emergency rollback, or environments not configured for unified billing.
+- R5. Failures must make the active billing/authentication path clear enough for operators to distinguish Cloudflare unified billing issues from direct-provider key issues.
+
+**Observability**
+- R6. OpenAI-backed requests routed through Cloudflare must expose enough request metadata for operators to correlate PackRat logs with Cloudflare AI Gateway observability.
+- R7. PackRat documentation or runbooks must identify which AI features are covered by unified billing and which remain direct-provider exceptions.
+
+---
+
+## Acceptance Examples
+
+- AE1. **Covers R1, R2, R6.** Given production has valid Cloudflare AI Gateway unified billing configuration and no direct OpenAI key, when a user sends an AI chat message, the request completes through Cloudflare and PackRat logs include correlation metadata for AI Gateway investigation.
+- AE2. **Covers R3, R7.** Given the template generation route uses Google/Gemini, when an admin generates a pack template from online content, the feature continues to use the configured Google provider path and the runbook lists it as outside this OpenAI migration.
+- AE3. **Covers R4, R5.** Given a local developer has a direct OpenAI key but no Cloudflare API token, when they run an OpenAI-backed feature locally, the feature can use the direct OpenAI fallback and errors identify the direct-provider path.
+
+---
+
+## Success Criteria
+
+- Operators can manage the main OpenAI bill and credentials through Cloudflare instead of a separate OpenAI production key.
+- The main OpenAI-backed user experiences continue working without visible behavior regressions.
+- AI failures and cost investigations are easier because PackRat logs and Cloudflare AI Gateway records can be correlated.
+- A downstream planner can enumerate the OpenAI call sites to migrate without also needing to decide whether Google/Gemini or Perplexity are in scope.
+
+---
+
+## Scope Boundaries
+
+- In scope: OpenAI-backed runtime AI features, including chat, embeddings, catalog/vector flows, pack generation, image gear detection, wildlife identification, and season suggestions.
+- In scope: preserving direct OpenAI fallback for development and rollback.
+- In scope: documenting provider coverage and operational setup for Cloudflare credits, spend limits, and request investigation.
+- Deferred: migrating Google/Gemini pack-template analysis to Cloudflare unified billing.
+- Deferred: migrating Perplexity web search to Cloudflare AI Gateway or replacing it with another provider.
+- Deferred: adding a user- or admin-facing provider selection menu.
+- Out of scope: changing model behavior, prompt behavior, AI feature UX, or catalog embedding dimensions as part of this billing migration.
+
+---
+
+## Key Decisions
+
+- OpenAI first: PackRat mostly uses OpenAI at runtime, so this pass targets the dominant billing/key-management pain without expanding into every installed AI dependency.
+- Keep non-OpenAI direct for now: Google/Gemini and Perplexity are real runtime usages, but they are narrower and should not block the OpenAI billing cleanup.
+- Prefer Cloudflare unified billing over BYOK for production OpenAI: The goal is fewer provider bills and fewer provider API keys, not only routing direct OpenAI keys through Cloudflare.
+
+---
+
+## Dependencies / Assumptions
+
+- Cloudflare AI Gateway Unified Billing is available and enabled for the PackRat Cloudflare account.
+- The PackRat Cloudflare account has credits, spend limits, and a suitable API token configured before production cutover.
+- OpenAI models used by PackRat are available through Cloudflare's unified billing path.
+- Cloudflare Workers AI models remain billed separately and are not part of this unified billing migration.
+- The Vercel AI SDK integration through Cloudflare's AI Gateway provider is expected to reduce implementation complexity because PackRat already uses the Vercel AI SDK.
+
+---
+
+## Outstanding Questions
+
+### Deferred to Planning
+
+- [Affects R1, R2][Needs research] Which exact Cloudflare AI Gateway provider mode should PackRat use for each OpenAI call shape: unified model wrapper, OpenAI-compatible provider wrapper, AI binding, or provider-native endpoint?
+- [Affects R6][Technical] Which request metadata is available from the Vercel AI SDK integration for reliable Cloudflare AI Gateway log correlation?
+- [Affects R4][Technical] What configuration flag or precedence rule should determine Cloudflare unified billing versus direct OpenAI fallback?

--- a/docs/plans/2026-05-23-001-feat-cf-gateway-unified-billing-plan.md
+++ b/docs/plans/2026-05-23-001-feat-cf-gateway-unified-billing-plan.md
@@ -1,0 +1,419 @@
+---
+title: "feat: Add Cloudflare AI Gateway Unified Billing for OpenAI"
+type: feat
+status: completed
+date: 2026-05-23
+origin: docs/brainstorms/2026-05-23-cf-gateway-unified-billing-openai-requirements.md
+---
+
+# feat: Add Cloudflare AI Gateway Unified Billing for OpenAI
+
+## Summary
+
+Introduce a shared OpenAI provider path that prefers Cloudflare AI Gateway Unified Billing in production while preserving direct OpenAI fallback for development and rollback. Migrate PackRat's remaining direct OpenAI runtime call sites into that shared path, then document which AI features are unified-billing covered versus still direct-provider.
+
+---
+
+## Problem Frame
+
+PackRat already routes some OpenAI calls through Cloudflare AI Gateway, but the current path still assumes an OpenAI API key and several runtime features instantiate OpenAI directly. The result is a mixed operational model for billing, secrets, and request investigation.
+
+---
+
+## Requirements
+
+- R1. PackRat must prefer Cloudflare AI Gateway Unified Billing for OpenAI-backed runtime AI requests when the required Cloudflare configuration is present.
+- R2. OpenAI-backed runtime features must no longer require a direct OpenAI API key for the primary production unified billing path.
+- R3. The migration must preserve existing direct-provider behavior for Google/Gemini template generation and Perplexity web search.
+- R4. PackRat must retain a clear direct OpenAI fallback for local development, emergency rollback, or environments not configured for unified billing.
+- R5. Failures must make the active billing/authentication path clear enough for operators to distinguish Cloudflare unified billing issues from direct-provider key issues.
+- R6. OpenAI-backed requests routed through Cloudflare must expose enough request metadata for operators to correlate PackRat logs with Cloudflare AI Gateway observability.
+- R7. PackRat documentation or runbooks must identify which AI features are covered by unified billing and which remain direct-provider exceptions.
+
+**Origin actors:** A1 PackRat operator, A2 PackRat user, A3 Implementation agent
+**Origin flows:** F1 OpenAI-backed request uses Cloudflare unified billing, F2 Unsupported or non-migrated provider remains direct
+**Origin acceptance examples:** AE1 production chat through Cloudflare without direct OpenAI key, AE2 Google/Gemini remains direct, AE3 local direct OpenAI fallback
+
+---
+
+## Scope Boundaries
+
+- In scope: OpenAI-backed runtime AI features, including chat, embeddings, catalog/vector flows, pack generation, image gear detection, wildlife identification, and season suggestions.
+- In scope: direct OpenAI fallback for local development, emergency rollback, and environments not configured for Cloudflare unified billing.
+- In scope: operator-facing logging and docs that identify the active billing/authentication path.
+- Out of scope: model, prompt, UX, embedding dimension, and catalog schema behavior changes.
+- Out of scope: user- or admin-facing provider selection.
+
+### Deferred to Follow-Up Work
+
+- Google/Gemini pack-template analysis: Cloudflare unified billing supports Google AI Studio, so this is a good follow-up after OpenAI is stable.
+- Perplexity web search: Cloudflare AI Gateway has a Perplexity provider integration, but unified billing support must be verified before migration.
+- Multi-provider abstraction beyond OpenAI: keep the current plan focused on the dominant runtime provider and avoid designing a provider menu prematurely.
+
+---
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `packages/api/src/utils/ai/provider.ts` is the existing shared provider helper. It currently routes OpenAI through Cloudflare AI Gateway's OpenAI provider endpoint but still requires `OPENAI_API_KEY`.
+- `packages/api/src/services/embeddingService.ts` centralizes embedding generation through `createAIProvider`, and is used by catalog, pack item, and ETL flows.
+- `packages/api/src/routes/chat.ts`, `packages/api/src/routes/packs/index.ts`, `packages/api/src/routes/catalog/index.ts`, `packages/api/src/services/catalogService.ts`, and `packages/api/src/services/etl/processValidItemsBatch.ts` already use the shared provider path for some OpenAI-backed behavior.
+- `packages/api/src/services/imageDetectionService.ts`, `packages/api/src/services/wildlifeIdentificationService.ts`, `packages/api/src/services/packService.ts`, and `packages/api/src/routes/seasonSuggestions.ts` still instantiate OpenAI directly.
+- `packages/api/src/utils/env-validation.ts` currently requires `OPENAI_API_KEY` in production and validates `AI_PROVIDER` as `openai | cloudflare-workers-ai`.
+- `packages/api/src/utils/ai/logging.ts` exists but is not wired into active AI call sites and only extracts Cloudflare IDs for `cloudflare-workers-ai`.
+- `.github/scripts/env.ts`, `README.md`, and `packages/api/wrangler.jsonc` describe the repo's root `.env.local` to API `.dev.vars` environment flow.
+
+### Institutional Learnings
+
+- `docs/solutions/developer-experience/better-auth-cli-cloudflare-worker-factory-2026-05-02.md` reinforces that Cloudflare Worker runtime bindings and CLI/local contexts often need separate static/dev-safe configuration. This plan should preserve local fallback rather than assuming production bindings exist everywhere.
+
+### External References
+
+- Cloudflare Unified Billing docs: <https://developers.cloudflare.com/ai-gateway/features/unified-billing/>
+  - Unified billing uses Cloudflare credits and Cloudflare API token authentication for supported third-party models.
+  - Workers AI models are not charged via unified billing.
+  - HTTP unified billing provider set includes OpenAI, Anthropic, Google AI Studio, Google Vertex AI, xAI, and Groq.
+  - Spend limits and ZDR are gateway-level operational concerns; ZDR currently applies to OpenAI and Anthropic.
+- Cloudflare Vercel AI SDK integration: <https://developers.cloudflare.com/ai-gateway/integrations/vercel-ai-sdk/>
+  - Use `ai-gateway-provider` and `createAiGateway(...)` with provider wrappers such as `createUnified()` or provider-specific wrappers.
+  - The current package version observed during planning is `ai-gateway-provider@3.1.3`.
+- Cloudflare supported models docs: <https://developers.cloudflare.com/ai-gateway/supported-models/>
+  - Model availability should be checked during implementation for PackRat's exact OpenAI chat and embedding model IDs.
+
+---
+
+## Key Technical Decisions
+
+- Use Cloudflare's AI SDK gateway provider as the preferred integration path: PackRat already uses Vercel AI SDK functions for chat, objects, and embeddings, so a provider-level change avoids hand-authored REST clients.
+- Add an explicit billing mode instead of relying only on secret presence: operators need a predictable rollback switch between Cloudflare unified billing and direct OpenAI.
+- Keep the shared provider helper OpenAI-focused for this pass: Google/Gemini and Perplexity remain direct-provider exceptions, so a broad multi-provider abstraction would add unnecessary design surface.
+- Make `OPENAI_API_KEY` optional only when Cloudflare unified billing is configured: production should not fail validation solely because the OpenAI key is absent, but direct fallback must still validate the direct key before use.
+- Treat observability as structured billing-path metadata plus Cloudflare correlation IDs where available: the plan should not promise a specific header if the AI SDK integration does not expose it for every response type.
+
+---
+
+## Open Questions
+
+### Resolved During Planning
+
+- Should Gemini be included in this implementation? No. Cloudflare unified billing supports Google AI Studio, but the active implementation should stay OpenAI-first and defer Gemini to follow-up work.
+- Should Perplexity be included in this implementation? No. Cloudflare AI Gateway supports Perplexity as a provider integration, but unified billing support was not confirmed during planning.
+- Which integration family should be preferred? Use Cloudflare's Vercel AI SDK provider unless implementation proves a specific OpenAI call shape is unsupported.
+- How should fallback be selected? Use an explicit billing mode with direct OpenAI fallback requiring `OPENAI_API_KEY`; do not silently fall back from production Cloudflare failures unless the operator has configured direct mode.
+
+### Deferred to Implementation
+
+- Exact model ID mapping: verify whether PackRat's current chat and embedding model IDs should stay provider-native or use unified model prefixes with the selected `ai-gateway-provider` wrapper.
+- Correlation metadata availability: confirm what metadata the AI SDK gateway provider exposes for stream, object, and embedding calls, then log the strongest available correlation fields.
+- Exact environment variable names: prefer names that match existing repo conventions and Cloudflare docs, but settle final names while editing `env-validation` and deployment docs.
+
+---
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+```mermaid
+flowchart TD
+  A[OpenAI-backed PackRat feature] --> B[Shared OpenAI provider helper]
+  B --> C{Billing mode}
+  C -->|Cloudflare unified| D[AI Gateway provider with Cloudflare token]
+  C -->|Direct fallback| E[Direct OpenAI provider with OpenAI key]
+  D --> F[Vercel AI SDK generate/stream/embed call]
+  E --> F
+  F --> G[Structured AI billing-path log]
+```
+
+---
+
+## Implementation Units
+
+### U1. Add billing-mode environment contract
+
+**Goal:** Define and validate the configuration that selects Cloudflare unified billing versus direct OpenAI fallback.
+
+**Requirements:** R1, R2, R4, R5
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `packages/api/src/utils/env-validation.ts`
+- Modify: `packages/api/src/utils/__tests__/env-validation.test.ts`
+- Modify: `packages/api/test/setup.ts`
+- Modify: `.github/scripts/env.ts`
+- Modify: `README.md`
+- Modify: `packages/api/wrangler.jsonc`
+
+**Approach:**
+- Introduce an explicit AI billing mode for OpenAI-backed requests, with values for Cloudflare unified billing and direct OpenAI fallback.
+- Add Cloudflare AI Gateway token validation for the unified billing path.
+- Make `OPENAI_API_KEY` optional only when the selected mode does not need a direct OpenAI key.
+- Preserve existing Google and Perplexity env validation because those providers remain direct in this plan.
+- Document how root `.env.local` fans out into API `.dev.vars`, and which secrets belong in Cloudflare dashboard or Wrangler secrets for production.
+
+**Patterns to follow:**
+- `packages/api/src/utils/env-validation.ts` conditional validation style around `apiEnvSchema` and test schema.
+- `.github/scripts/env.ts` root-env fanout into `packages/api/.dev.vars`.
+- `packages/api/wrangler.jsonc` comments for operational environment guidance.
+
+**Test scenarios:**
+- Happy path: production env with Cloudflare billing mode, Cloudflare account/gateway/token, and no OpenAI key validates successfully.
+- Happy path: production env with direct billing mode and valid OpenAI key validates successfully.
+- Error path: direct billing mode without OpenAI key fails validation with a clear configuration error.
+- Error path: Cloudflare billing mode without Cloudflare token fails validation with a clear configuration error.
+- Regression: Google and Perplexity direct-provider secrets remain required according to the current production env contract.
+
+**Verification:**
+- Env validation tests prove production can run OpenAI unified billing without a direct OpenAI key.
+- Local test setup still provides a valid environment for existing API tests.
+
+---
+
+### U2. Replace the OpenAI provider helper with unified billing support
+
+**Goal:** Make the shared provider helper produce an OpenAI-compatible AI SDK provider for either Cloudflare unified billing or direct OpenAI fallback.
+
+**Requirements:** R1, R2, R4, R5, R6
+
+**Dependencies:** U1
+
+**Files:**
+- Modify: `packages/api/package.json`
+- Modify: `package.json`
+- Modify: `bun.lock`
+- Modify: `packages/api/src/utils/ai/provider.ts`
+- Modify: `packages/api/src/utils/ai/logging.ts`
+- Create or modify: `packages/api/src/utils/ai/__tests__/provider.test.ts`
+- Create or modify: `packages/api/src/utils/ai/__tests__/logging.test.ts`
+- Modify: `packages/api/test/setup.ts`
+
+**Approach:**
+- Add `ai-gateway-provider` to the API workspace dependencies.
+- Keep one public helper for OpenAI-backed call sites, but have it select Cloudflare unified billing or direct OpenAI based on validated env/config.
+- Return the same kind of AI SDK model factory interface call sites already expect, so `streamText`, `generateObject`, `embed`, and `embedMany` can keep their existing call shape.
+- Include billing path, provider, model, gateway ID, and available Cloudflare correlation metadata in logging output.
+- Remove or quarantine the misleading `cloudflare-workers-ai` behavior that currently returns OpenAI through the gateway, unless implementation needs a short compatibility bridge.
+
+**Patterns to follow:**
+- Existing `createAIProvider` call-site shape in `packages/api/src/routes/chat.ts` and `packages/api/src/services/embeddingService.ts`.
+- Existing `logAIRequest` structure in `packages/api/src/utils/ai/logging.ts`.
+- Global provider mocks in `packages/api/test/setup.ts`.
+
+**Test scenarios:**
+- Happy path: Cloudflare billing mode creates an AI Gateway-backed provider with Cloudflare account, gateway, and token values.
+- Happy path: direct billing mode creates a direct OpenAI provider and passes the OpenAI key.
+- Error path: Cloudflare billing mode with missing token throws a configuration error that identifies Cloudflare unified billing.
+- Error path: direct billing mode with missing OpenAI key throws a configuration error that identifies direct OpenAI.
+- Observability: logging records billing path and model for both Cloudflare and direct modes.
+- Observability: when Cloudflare correlation metadata is available, logging includes it without requiring it for direct mode.
+
+**Verification:**
+- Provider tests pin the selection rules so later call-site migrations cannot accidentally reintroduce a required OpenAI key for unified billing.
+- Type checks confirm the returned provider still satisfies existing AI SDK usage.
+
+---
+
+### U3. Migrate direct OpenAI runtime services into the shared provider path
+
+**Goal:** Eliminate direct OpenAI SDK setup from OpenAI-backed runtime services that are currently outside the shared helper.
+
+**Requirements:** R1, R2, R4, R5, R6
+
+**Dependencies:** U2
+
+**Files:**
+- Modify: `packages/api/src/services/imageDetectionService.ts`
+- Modify: `packages/api/src/services/wildlifeIdentificationService.ts`
+- Modify: `packages/api/src/services/packService.ts`
+- Modify: `packages/api/src/routes/seasonSuggestions.ts`
+- Modify: `packages/api/src/services/__tests__/packService.test.ts`
+- Create or modify: `packages/api/src/services/__tests__/imageDetectionService.test.ts`
+- Create or modify: `packages/api/src/services/__tests__/wildlifeIdentificationService.test.ts`
+- Create or modify: `packages/api/src/routes/__tests__/seasonSuggestions.test.ts`
+
+**Approach:**
+- Replace direct `createOpenAI` usage with the shared OpenAI provider helper.
+- Preserve model IDs, prompts, schemas, temperatures, and response handling.
+- Add or adjust unit coverage so the services prove they call the shared provider instead of direct OpenAI.
+- Keep image and wildlife behavior unchanged; this unit is about billing/auth path only.
+
+**Execution note:** Use characterization-style tests for services that currently lack focused tests, asserting current prompts/schema-facing behavior enough to guard against accidental behavior changes while moving provider setup.
+
+**Patterns to follow:**
+- `packages/api/src/routes/chat.ts` for current shared-provider usage.
+- `packages/api/src/services/__tests__/packService.test.ts` for mocking OpenAI/provider behavior in service tests.
+
+**Test scenarios:**
+- Covers AE1. Happy path: image detection uses the shared provider and still passes image content to the AI SDK object generation call.
+- Happy path: wildlife identification uses the shared provider and preserves the current structured response schema.
+- Happy path: pack generation uses the shared provider and preserves count-driven concept generation.
+- Happy path: season suggestions use the shared provider and preserve inventory/location/date prompt inputs.
+- Error path: provider configuration failure surfaces as an AI/provider configuration error rather than a misleading missing OpenAI key when Cloudflare mode is active.
+- Regression: generated object schemas and temperatures stay equivalent to current behavior.
+
+**Verification:**
+- `rg "createOpenAI" packages/api/src` shows no remaining OpenAI direct runtime usage except intentionally excluded scripts/tests or direct fallback internals.
+- Service tests prove the direct OpenAI SDK imports are no longer needed in migrated runtime files.
+
+---
+
+### U4. Remove OpenAI-key hard requirements from shared-provider callers
+
+**Goal:** Update existing shared-provider call sites so OpenAI unified billing no longer fails before reaching the provider helper.
+
+**Requirements:** R1, R2, R4, R5, R6
+
+**Dependencies:** U2
+
+**Files:**
+- Modify: `packages/api/src/services/embeddingService.ts`
+- Modify: `packages/api/src/services/catalogService.ts`
+- Modify: `packages/api/src/services/etl/processValidItemsBatch.ts`
+- Modify: `packages/api/src/routes/chat.ts`
+- Modify: `packages/api/src/routes/packs/index.ts`
+- Modify: `packages/api/src/routes/catalog/index.ts`
+- Modify: `packages/api/src/services/__tests__/embeddingService.test.ts`
+- Modify: `packages/api/test/etl.test.ts`
+- Modify or create: `packages/api/test/catalog.test.ts`
+- Modify or create: `packages/api/test/packs.test.ts`
+
+**Approach:**
+- Stop checking `OPENAI_API_KEY` before invoking embedding or chat provider helpers when Cloudflare unified billing is configured.
+- Pass a normalized provider config or env-derived provider object rather than raw OpenAI key assumptions through embedding and route layers.
+- Preserve direct OpenAI fallback checks inside the provider helper so missing-key errors remain clear when direct mode is selected.
+- Add billing-path logging around high-value shared-provider entry points, especially chat and embedding generation.
+
+**Patterns to follow:**
+- Existing embedding normalization and empty-input behavior in `packages/api/src/services/embeddingService.ts`.
+- Existing route-level error handling in `packages/api/src/routes/packs/index.ts` and `packages/api/src/routes/catalog/index.ts`.
+- Existing ETL embedding failure fallback logging in `packages/api/src/services/etl/processValidItemsBatch.ts`.
+
+**Test scenarios:**
+- Covers AE1. Happy path: chat route can create a stream in Cloudflare billing mode without an OpenAI key.
+- Covers AE3. Happy path: chat and embedding flows can use direct OpenAI mode locally when an OpenAI key is present.
+- Happy path: catalog item creation and update can generate embeddings in Cloudflare billing mode without an OpenAI key.
+- Happy path: pack item creation and update can generate embeddings in Cloudflare billing mode without an OpenAI key.
+- Error path: direct mode without an OpenAI key returns or throws the existing clear service-unavailable style error.
+- Regression: empty embedding inputs still return `null` or `[]` without creating a provider.
+- Integration: ETL valid-item processing still falls back gracefully when embedding generation fails.
+
+**Verification:**
+- No in-scope runtime route blocks unified billing solely because `OPENAI_API_KEY` is absent.
+- Existing API tests continue to cover direct-mode behavior through test setup.
+
+---
+
+### U5. Preserve non-OpenAI direct-provider exceptions
+
+**Goal:** Keep Google/Gemini pack-template analysis and Perplexity web search working exactly as direct-provider integrations, while making their exception status explicit.
+
+**Requirements:** R3, R7
+
+**Dependencies:** U1
+
+**Files:**
+- Modify: `packages/api/src/routes/packTemplates/index.ts`
+- Modify: `packages/api/src/services/aiService.ts`
+- Modify or create: `packages/api/src/routes/packTemplates/__tests__/generateFromOnlineContent.test.ts`
+- Modify or create: `packages/api/src/services/__tests__/aiService.test.ts`
+
+**Approach:**
+- Avoid migrating Google/Gemini and Perplexity in this implementation pass.
+- Add lightweight comments or logs only where useful to prevent future confusion that these direct-provider paths were accidentally skipped.
+- Ensure env validation and tests still prove these providers require their direct keys.
+
+**Patterns to follow:**
+- Existing `AIService.perplexitySearch` direct-provider pattern.
+- Existing `packTemplates` Google/Gemini object generation path.
+
+**Test scenarios:**
+- Covers AE2. Happy path: Google/Gemini template generation still uses the configured Google provider path.
+- Happy path: Perplexity web search still uses the configured Perplexity provider path.
+- Regression: OpenAI billing mode changes do not alter Google or Perplexity provider setup.
+- Error path: missing Google or Perplexity keys continue to fail through the direct-provider configuration path, not the OpenAI billing mode.
+
+**Verification:**
+- Non-OpenAI tests demonstrate that OpenAI unified billing configuration does not intercept or break Google/Gemini or Perplexity usage.
+
+---
+
+### U6. Add operator documentation and rollout notes
+
+**Goal:** Document setup, coverage, fallback, spend controls, and troubleshooting for operators.
+
+**Requirements:** R5, R6, R7
+
+**Dependencies:** U1, U2, U3, U4, U5
+
+**Files:**
+- Create or modify: `docs/runbooks/ai-gateway-unified-billing.md`
+- Modify: `README.md`
+- Modify: `packages/api/README.md`
+
+**Approach:**
+- Document the production setup path: Cloudflare credits, spend limits, AI Gateway authentication token, gateway ID, and chosen billing mode.
+- List covered OpenAI runtime features and direct-provider exceptions.
+- Describe rollback to direct OpenAI mode and what secret is required for that fallback.
+- Explain how to correlate PackRat logs with Cloudflare AI Gateway observability using the metadata available after implementation.
+- Note that Gemini is a follow-up candidate because Google AI Studio is unified-billing supported, while Perplexity needs billing verification.
+
+**Patterns to follow:**
+- Existing operational style in `docs/runbooks/etl-pipeline.md`.
+- Existing setup guidance in `README.md` and `packages/api/README.md`.
+
+**Test scenarios:**
+- Test expectation: none -- documentation-only unit.
+
+**Verification:**
+- A developer or operator can identify which AI features are covered, which secrets are needed for each mode, and how to roll back without reading source code.
+
+---
+
+## System-Wide Impact
+
+- **Interaction graph:** Shared OpenAI provider creation affects chat, object generation services, embeddings, catalog/vector flows, pack item routes, and ETL embedding jobs.
+- **Error propagation:** Provider configuration errors should identify the billing mode so operators can distinguish Cloudflare token/gateway issues from direct OpenAI key issues.
+- **State lifecycle risks:** Embedding generation failures already have fallback paths in ETL and some catalog flows; the migration must preserve those paths and avoid partial writes caused by earlier configuration checks.
+- **API surface parity:** Public API response shapes and mobile/web client behavior should not change.
+- **Integration coverage:** Unit tests can verify provider selection, but route/service integration tests are needed to prove existing flows no longer pre-block on `OPENAI_API_KEY`.
+- **Unchanged invariants:** Model IDs, prompt text, schemas, embedding dimensions, database columns, and AI feature UX are intentionally unchanged.
+
+---
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Cloudflare AI Gateway provider wrapper does not support one PackRat call shape, especially embeddings or object generation | Verify model creation against each AI SDK function during U2/U4; if a call shape is unsupported, use the closest Cloudflare-documented OpenAI-compatible provider path for that specific shape while preserving the shared helper boundary |
+| Unified billing model IDs differ from current OpenAI provider-native IDs | Confirm exact chat and embedding model IDs during implementation and keep mapping localized to the provider helper |
+| Env validation accidentally weakens direct-provider failures | Add explicit tests for both Cloudflare mode and direct mode, including missing-secret cases |
+| Production loses the emergency OpenAI rollback path | Require direct mode to remain supported and document the rollback variable/secret set in U6 |
+| Observability promises exceed what the AI SDK exposes | Log billing path, provider, model, and gateway ID unconditionally; add Cloudflare request correlation only when available |
+| Google/Gemini support through unified billing tempts scope creep | Keep Gemini in documentation as follow-up work, not active implementation |
+
+---
+
+## Documentation Plan
+
+- Add an AI Gateway unified billing runbook under `docs/runbooks/`.
+- Update setup docs to describe the new Cloudflare token and direct OpenAI fallback.
+- Include a provider coverage table: OpenAI covered, Google/Gemini deferred, Perplexity direct pending verification, Workers AI billed separately.
+
+---
+
+## Operational / Rollout Notes
+
+- Configure Cloudflare AI Gateway credits, spend limits, and gateway authentication before production cutover.
+- Roll out in a non-production environment first with direct OpenAI key intentionally absent to prove unified billing is not accidentally depending on it.
+- Keep the direct OpenAI key available only for rollback environments or direct billing mode.
+- During initial rollout, monitor Cloudflare AI Gateway logs and PackRat structured logs for matching provider/model/billing-path metadata.
+
+---
+
+## Sources & References
+
+- Origin requirements: `docs/brainstorms/2026-05-23-cf-gateway-unified-billing-openai-requirements.md`
+- Cloudflare Unified Billing: <https://developers.cloudflare.com/ai-gateway/features/unified-billing/>
+- Cloudflare Vercel AI SDK integration: <https://developers.cloudflare.com/ai-gateway/integrations/vercel-ai-sdk/>
+- Cloudflare supported models: <https://developers.cloudflare.com/ai-gateway/supported-models/>

--- a/docs/runbooks/ai-gateway-unified-billing.md
+++ b/docs/runbooks/ai-gateway-unified-billing.md
@@ -1,0 +1,79 @@
+# Cloudflare AI Gateway Unified Billing
+
+PackRat prefers Cloudflare AI Gateway Unified Billing for OpenAI-backed and Google AI Studio-backed runtime AI calls when the Cloudflare configuration is complete. Provider keys are still required in the environment so direct fallback and rollback are always available.
+
+## Configuration
+
+Unified billing is active when all of these values are present:
+
+- `CLOUDFLARE_ACCOUNT_ID`
+- `CLOUDFLARE_AI_GATEWAY_ID`
+- `CLOUDFLARE_API_TOKEN`
+
+Direct provider fallback is active when the Cloudflare unified billing configuration is incomplete. `OPENAI_API_KEY` must be present and start with `sk-`, `GOOGLE_GENERATIVE_AI_API_KEY` must be present for Gemini-backed pack-template generation, and `PERPLEXITY_API_KEY` must be present for Perplexity search.
+
+There is intentionally no separate billing-mode environment variable. Complete Cloudflare configuration wins; otherwise the runtime uses direct OpenAI.
+
+For local development, put these values in the root `.env.local` and regenerate `packages/api/.dev.vars` with `bun install` or `bun run env`.
+
+For production, store `CLOUDFLARE_API_TOKEN` and any direct-provider fallback keys as Cloudflare Worker secrets. Keep `CLOUDFLARE_ACCOUNT_ID` and `CLOUDFLARE_AI_GATEWAY_ID` aligned with the AI Gateway configured in the Cloudflare dashboard.
+
+## Operational Setup
+
+Before production cutover:
+
+1. Load Cloudflare AI Gateway credits.
+2. Configure spend limits on the AI Gateway.
+3. Enable authenticated gateway access and provision `CLOUDFLARE_API_TOKEN`.
+4. Deploy with `CLOUDFLARE_ACCOUNT_ID`, `CLOUDFLARE_AI_GATEWAY_ID`, and `CLOUDFLARE_API_TOKEN`.
+5. Keep direct provider keys configured as emergency fallback even when Cloudflare is the active path.
+
+Cloudflare Unified Billing applies to third-party provider models. Workers AI models remain billed through Workers AI pricing.
+
+## Covered Runtime Paths
+
+The shared OpenAI provider path is used for:
+
+- Chat route streaming.
+- Catalog embeddings and vector search helpers.
+- Pack item embedding generation.
+- ETL embedding generation.
+- AI-generated pack concepts.
+- Image gear detection.
+- Wildlife identification.
+- Season suggestions.
+- Gemini pack-template generation.
+
+The active billing path is selected in `packages/api/src/utils/ai/provider.ts`. Environment validation is in `packages/api/src/utils/env-validation.ts`.
+
+## Observability
+
+Provider logs can include:
+
+- `billingPath`
+- `provider`
+- `model`
+- `cloudflareGatewayId` when unified billing is active
+- `cloudflareLogId` when a Cloudflare AI Gateway response header is available
+
+`billingPath` values are:
+
+- `cloudflare-unified` for Cloudflare AI Gateway Unified Billing.
+- `cloudflare-gateway-byok` for Cloudflare AI Gateway routing with provider-key billing.
+- `direct-provider` for direct provider fallback.
+
+Use `billingPath` first when triaging AI failures. A `cloudflare-unified` failure points to Cloudflare credits, spend limits, gateway authentication, gateway ID, or model availability. A `cloudflare-gateway-byok` failure points to gateway routing or provider-key authentication through Cloudflare. A `direct-provider` failure points to direct provider auth, quota, or provider-side availability.
+
+## Provider Scope
+
+OpenAI and Google AI Studio are migrated in this pass.
+
+Gemini/Google pack-template generation uses Cloudflare AI Gateway Unified Billing when Cloudflare config is complete, with direct Google AI Studio fallback when it is not.
+
+Perplexity is routed through Cloudflare AI Gateway when the Cloudflare account and gateway ID are configured, but it remains BYOK/direct-provider billing because Cloudflare's Perplexity provider docs require an active Perplexity API token and Perplexity was not listed in the unified-billing HTTP API provider set verified during this implementation. If Cloudflare gateway config is absent, PackRat calls Perplexity directly with `PERPLEXITY_API_KEY`.
+
+## References
+
+- Cloudflare Unified Billing: https://developers.cloudflare.com/ai-gateway/features/unified-billing/
+- Cloudflare Vercel AI SDK integration: https://developers.cloudflare.com/ai-gateway/integrations/vercel-ai-sdk/
+- Cloudflare supported models: https://developers.cloudflare.com/ai-gateway/supported-models/

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -9,4 +9,10 @@ bun run dev
 ```
 
 open http://localhost:8787
+
+## AI Billing
+
+AI-backed routes and services use Cloudflare AI Gateway when `CLOUDFLARE_ACCOUNT_ID`, `CLOUDFLARE_AI_GATEWAY_ID`, and `CLOUDFLARE_API_TOKEN` are configured. Direct provider keys such as `OPENAI_API_KEY`, `GOOGLE_GENERATIVE_AI_API_KEY`, and `PERPLEXITY_API_KEY` are still required for fallback and rollback.
+
+The root `.env.local` is copied into `packages/api/.dev.vars` by `bun install` / `bun run env`. See `../../docs/runbooks/ai-gateway-unified-billing.md` for the production setup and fallback runbook.
 # packrat-v2-api

--- a/packages/api/src/routes/catalog/index.ts
+++ b/packages/api/src/routes/catalog/index.ts
@@ -315,13 +315,14 @@ export const catalogRoutes = new Elysia({ prefix: '/catalog' })
     async ({ body }) => {
       const db = createDb();
       const data = body;
-      const { OPENAI_API_KEY, AI_PROVIDER, CLOUDFLARE_ACCOUNT_ID, CLOUDFLARE_AI_GATEWAY_ID, AI } =
-        getEnv();
-
-      if (!OPENAI_API_KEY) {
-        // Configuration error: surface as a 500 with a clear message
-        throw new Error('Service unavailable: OpenAI API key not configured');
-      }
+      const {
+        OPENAI_API_KEY,
+        AI_PROVIDER,
+        CLOUDFLARE_ACCOUNT_ID,
+        CLOUDFLARE_AI_GATEWAY_ID,
+        CLOUDFLARE_API_TOKEN,
+        AI,
+      } = getEnv();
 
       const embeddingText = getEmbeddingText({ item: data });
       const embedding = await generateEmbedding({
@@ -330,6 +331,7 @@ export const catalogRoutes = new Elysia({ prefix: '/catalog' })
         provider: AI_PROVIDER,
         cloudflareAccountId: CLOUDFLARE_ACCOUNT_ID,
         cloudflareGatewayId: CLOUDFLARE_AI_GATEWAY_ID,
+        cloudflareApiToken: CLOUDFLARE_API_TOKEN,
         cloudflareAiBinding: AI,
       });
 
@@ -503,13 +505,14 @@ export const catalogRoutes = new Elysia({ prefix: '/catalog' })
         throw new NotFoundError('Catalog item not found');
       }
       const data = body;
-      const { OPENAI_API_KEY, AI_PROVIDER, CLOUDFLARE_ACCOUNT_ID, CLOUDFLARE_AI_GATEWAY_ID, AI } =
-        getEnv();
-
-      if (!OPENAI_API_KEY) {
-        // Configuration error: surface as a 500 with a clear message
-        throw new Error('Service unavailable: OpenAI API key not configured');
-      }
+      const {
+        OPENAI_API_KEY,
+        AI_PROVIDER,
+        CLOUDFLARE_ACCOUNT_ID,
+        CLOUDFLARE_AI_GATEWAY_ID,
+        CLOUDFLARE_API_TOKEN,
+        AI,
+      } = getEnv();
 
       const existingItem = await db.query.catalogItems.findFirst({
         where: eq(catalogItems.id, itemId),
@@ -530,6 +533,7 @@ export const catalogRoutes = new Elysia({ prefix: '/catalog' })
           provider: AI_PROVIDER,
           cloudflareAccountId: CLOUDFLARE_ACCOUNT_ID,
           cloudflareGatewayId: CLOUDFLARE_AI_GATEWAY_ID,
+          cloudflareApiToken: CLOUDFLARE_API_TOKEN,
           cloudflareAiBinding: AI,
         });
       }

--- a/packages/api/src/routes/chat.ts
+++ b/packages/api/src/routes/chat.ts
@@ -72,6 +72,7 @@ export const chatRoutes = new Elysia({ prefix: '/chat' })
         OPENAI_API_KEY,
         CLOUDFLARE_ACCOUNT_ID,
         CLOUDFLARE_AI_GATEWAY_ID,
+        CLOUDFLARE_API_TOKEN,
         AI,
         TOKEN_RATE_LIMITER,
       } = getEnv();
@@ -90,6 +91,7 @@ export const chatRoutes = new Elysia({ prefix: '/chat' })
         provider: AI_PROVIDER,
         cloudflareAccountId: CLOUDFLARE_ACCOUNT_ID,
         cloudflareGatewayId: CLOUDFLARE_AI_GATEWAY_ID,
+        cloudflareApiToken: CLOUDFLARE_API_TOKEN,
         cloudflareAiBinding: AI,
       });
 

--- a/packages/api/src/routes/packTemplates/index.ts
+++ b/packages/api/src/routes/packTemplates/index.ts
@@ -1,8 +1,8 @@
-import { createGoogleGenerativeAI } from '@ai-sdk/google';
 import { getContainer } from '@cloudflare/containers';
 import { createDb } from '@packrat/api/db';
 import { adminAuthPlugin, authPlugin } from '@packrat/api/middleware/auth';
 import { CatalogService } from '@packrat/api/services/catalogService';
+import { createGoogleAIProvider } from '@packrat/api/utils/ai/provider';
 import { getEnv } from '@packrat/api/utils/env-validation';
 import { type PackTemplate, packTemplateItems, packTemplates } from '@packrat/db';
 import { assertDefined } from '@packrat/guards';
@@ -200,8 +200,20 @@ export const packTemplatesRoutes = new Elysia({ prefix: '/pack-templates' })
           return status(400, { error: 'contentUrl must be a valid URL' });
         }
 
-        const { GOOGLE_GENERATIVE_AI_API_KEY } = getEnv();
-        const google = createGoogleGenerativeAI({ apiKey: GOOGLE_GENERATIVE_AI_API_KEY });
+        const {
+          GOOGLE_GENERATIVE_AI_API_KEY,
+          CLOUDFLARE_ACCOUNT_ID,
+          CLOUDFLARE_AI_GATEWAY_ID,
+          CLOUDFLARE_API_TOKEN,
+          AI,
+        } = getEnv();
+        const google = createGoogleAIProvider({
+          googleApiKey: GOOGLE_GENERATIVE_AI_API_KEY,
+          cloudflareAccountId: CLOUDFLARE_ACCOUNT_ID,
+          cloudflareGatewayId: CLOUDFLARE_AI_GATEWAY_ID,
+          cloudflareApiToken: CLOUDFLARE_API_TOKEN,
+          cloudflareAiBinding: AI,
+        });
 
         let imageUrls: string[] = [];
         let videoUrl: string | undefined;

--- a/packages/api/src/routes/packs/index.ts
+++ b/packages/api/src/routes/packs/index.ts
@@ -563,14 +563,21 @@ Limit to maximum 6 recommendations, prioritizing the most important gaps. Only s
         const { generateObject } = await import('ai');
         const { DEFAULT_MODELS } = await import('@packrat/api/utils/ai/models');
 
-        const { AI_PROVIDER, OPENAI_API_KEY, CLOUDFLARE_ACCOUNT_ID, CLOUDFLARE_AI_GATEWAY_ID, AI } =
-          getEnv();
+        const {
+          AI_PROVIDER,
+          OPENAI_API_KEY,
+          CLOUDFLARE_ACCOUNT_ID,
+          CLOUDFLARE_AI_GATEWAY_ID,
+          CLOUDFLARE_API_TOKEN,
+          AI,
+        } = getEnv();
 
         const aiProvider = createAIProvider({
           openAiApiKey: OPENAI_API_KEY,
           provider: AI_PROVIDER,
           cloudflareAccountId: CLOUDFLARE_ACCOUNT_ID,
           cloudflareGatewayId: CLOUDFLARE_AI_GATEWAY_ID,
+          cloudflareApiToken: CLOUDFLARE_API_TOKEN,
           cloudflareAiBinding: AI,
         });
 
@@ -661,10 +668,14 @@ Limit to maximum 6 recommendations, prioritizing the most important gaps. Only s
       const db = createDb();
       const packId = params.packId;
       const data = body;
-      const { OPENAI_API_KEY, AI_PROVIDER, CLOUDFLARE_ACCOUNT_ID, CLOUDFLARE_AI_GATEWAY_ID, AI } =
-        getEnv();
-
-      if (!OPENAI_API_KEY) return status(400, { error: 'OpenAI API key not configured' });
+      const {
+        OPENAI_API_KEY,
+        AI_PROVIDER,
+        CLOUDFLARE_ACCOUNT_ID,
+        CLOUDFLARE_AI_GATEWAY_ID,
+        CLOUDFLARE_API_TOKEN,
+        AI,
+      } = getEnv();
       const itemId = data.id;
 
       const embeddingText = getEmbeddingText({ item: data });
@@ -674,6 +685,7 @@ Limit to maximum 6 recommendations, prioritizing the most important gaps. Only s
         provider: AI_PROVIDER,
         cloudflareAccountId: CLOUDFLARE_ACCOUNT_ID,
         cloudflareGatewayId: CLOUDFLARE_AI_GATEWAY_ID,
+        cloudflareApiToken: CLOUDFLARE_API_TOKEN,
         cloudflareAiBinding: AI,
       });
 
@@ -758,10 +770,14 @@ Limit to maximum 6 recommendations, prioritizing the most important gaps. Only s
       const db = createDb();
       const itemId = params.itemId;
       const data = body;
-      const { OPENAI_API_KEY, AI_PROVIDER, CLOUDFLARE_ACCOUNT_ID, CLOUDFLARE_AI_GATEWAY_ID, AI } =
-        getEnv();
-
-      if (!OPENAI_API_KEY) return status(500, { error: 'OpenAI API key not configured' });
+      const {
+        OPENAI_API_KEY,
+        AI_PROVIDER,
+        CLOUDFLARE_ACCOUNT_ID,
+        CLOUDFLARE_AI_GATEWAY_ID,
+        CLOUDFLARE_API_TOKEN,
+        AI,
+      } = getEnv();
 
       const existingItem = await db.query.packItems.findFirst({
         where: and(eq(packItems.id, itemId), eq(packItems.userId, user.userId)),
@@ -792,6 +808,7 @@ Limit to maximum 6 recommendations, prioritizing the most important gaps. Only s
           provider: AI_PROVIDER,
           cloudflareAccountId: CLOUDFLARE_ACCOUNT_ID,
           cloudflareGatewayId: CLOUDFLARE_AI_GATEWAY_ID,
+          cloudflareApiToken: CLOUDFLARE_API_TOKEN,
           cloudflareAiBinding: AI,
         });
       }

--- a/packages/api/src/routes/seasonSuggestions.ts
+++ b/packages/api/src/routes/seasonSuggestions.ts
@@ -1,6 +1,6 @@
-import { createOpenAI } from '@ai-sdk/openai';
 import { createDb } from '@packrat/api/db';
 import { authPlugin } from '@packrat/api/middleware/auth';
+import { createAIProvider } from '@packrat/api/utils/ai/provider';
 import { getEnv } from '@packrat/api/utils/env-validation';
 import { type PackItem, packItems } from '@packrat/db';
 import { SeasonSuggestionsRequestSchema } from '@packrat/schemas/seasonSuggestions';
@@ -53,10 +53,24 @@ Date: ${date}
 Available Inventory Items:
 ${inventoryFormatted}`;
 
-      const { OPENAI_API_KEY } = getEnv();
-      const openai = createOpenAI({ apiKey: OPENAI_API_KEY });
+      const {
+        OPENAI_API_KEY,
+        AI_PROVIDER,
+        CLOUDFLARE_ACCOUNT_ID,
+        CLOUDFLARE_AI_GATEWAY_ID,
+        CLOUDFLARE_API_TOKEN,
+        AI,
+      } = getEnv();
+      const aiProvider = createAIProvider({
+        openAiApiKey: OPENAI_API_KEY,
+        provider: AI_PROVIDER,
+        cloudflareAccountId: CLOUDFLARE_ACCOUNT_ID,
+        cloudflareGatewayId: CLOUDFLARE_AI_GATEWAY_ID,
+        cloudflareApiToken: CLOUDFLARE_API_TOKEN,
+        cloudflareAiBinding: AI,
+      });
       const { object } = await generateObject({
-        model: openai(DEFAULT_MODELS.OPENAI_CHAT),
+        model: aiProvider(DEFAULT_MODELS.OPENAI_CHAT),
         schema: z.object({
           season: z.string(),
           suggestions: z.array(

--- a/packages/api/src/services/__tests__/embeddingService.test.ts
+++ b/packages/api/src/services/__tests__/embeddingService.test.ts
@@ -29,6 +29,7 @@ const baseParams = {
   provider: 'openai' as const,
   cloudflareAccountId: 'test-account',
   cloudflareGatewayId: 'test-gateway',
+  cloudflareApiToken: 'cf-token',
   cloudflareAiBinding: {} as any,
 };
 
@@ -115,6 +116,7 @@ describe('embeddingService', () => {
         provider: 'openai',
         cloudflareAccountId: 'test-account',
         cloudflareGatewayId: 'test-gateway',
+        cloudflareApiToken: 'cf-token',
         cloudflareAiBinding: expect.anything(),
       });
     });

--- a/packages/api/src/services/__tests__/imageDetectionService.test.ts
+++ b/packages/api/src/services/__tests__/imageDetectionService.test.ts
@@ -1,0 +1,73 @@
+import { generateObject } from 'ai';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ImageDetectionService } from '../imageDetectionService';
+
+const { mockCreateAIProvider, mockModel } = vi.hoisted(() => {
+  const mockModel = vi.fn((modelName: string) => ({ name: modelName }));
+  return {
+    mockCreateAIProvider: vi.fn(() => mockModel),
+    mockModel,
+  };
+});
+
+vi.mock('@packrat/api/utils/ai/provider', () => ({
+  createAIProvider: mockCreateAIProvider,
+}));
+
+vi.mock('@packrat/api/utils/env-validation', () => ({
+  getEnv: vi.fn(() => ({
+    OPENAI_API_KEY: undefined,
+    AI_PROVIDER: 'openai',
+    CLOUDFLARE_ACCOUNT_ID: 'test-account',
+    CLOUDFLARE_AI_GATEWAY_ID: 'test-gateway',
+    CLOUDFLARE_API_TOKEN: 'cf-token',
+    AI: {},
+  })),
+}));
+
+vi.mock('ai', () => ({
+  generateObject: vi.fn(),
+}));
+
+describe('ImageDetectionService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('analyzes images through the shared AI provider without a direct OpenAI key', async () => {
+    vi.mocked(generateObject).mockResolvedValue({
+      object: {
+        items: [
+          {
+            name: 'Tent',
+            description: 'One-person backpacking tent',
+            quantity: 1,
+            category: 'Shelter',
+            consumable: false,
+            worn: false,
+            notes: null,
+            confidence: 0.9,
+          },
+        ],
+      },
+    } as Awaited<ReturnType<typeof generateObject>>);
+
+    const result = await new ImageDetectionService().analyzeImage('https://example.com/gear.jpg');
+
+    expect(result.items).toHaveLength(1);
+    expect(mockCreateAIProvider).toHaveBeenCalledWith({
+      openAiApiKey: undefined,
+      provider: 'openai',
+      cloudflareAccountId: 'test-account',
+      cloudflareGatewayId: 'test-gateway',
+      cloudflareApiToken: 'cf-token',
+      cloudflareAiBinding: {},
+    });
+    expect(mockModel).toHaveBeenCalledWith('gpt-4o');
+    expect(generateObject).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model: { name: 'gpt-4o' },
+      }),
+    );
+  });
+});

--- a/packages/api/src/services/__tests__/packService.test.ts
+++ b/packages/api/src/services/__tests__/packService.test.ts
@@ -1,3 +1,5 @@
+import { createAIProvider } from '@packrat/api/utils/ai/provider';
+import { generateObject } from 'ai';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { PackService } from '../packService';
 
@@ -22,8 +24,8 @@ vi.mock('@packrat/api/db', () => ({
 }));
 
 // Prevent real AI calls
-vi.mock('@ai-sdk/openai', () => ({
-  createOpenAI: vi.fn(() => vi.fn((modelName) => ({ name: modelName }))),
+vi.mock('@packrat/api/utils/ai/provider', () => ({
+  createAIProvider: vi.fn(() => vi.fn((modelName) => ({ name: modelName }))),
 }));
 
 vi.mock('ai', () => ({
@@ -44,6 +46,10 @@ vi.mock('@packrat/api/utils/env-validation', () => ({
   getEnv: vi.fn(() => ({
     OPENAI_API_KEY: 'test-key',
     AI_PROVIDER: 'openai',
+    CLOUDFLARE_ACCOUNT_ID: 'test-account',
+    CLOUDFLARE_AI_GATEWAY_ID: 'test-gateway',
+    CLOUDFLARE_API_TOKEN: 'cf-token',
+    AI: {},
   })),
 }));
 
@@ -145,6 +151,35 @@ describe('PackService', () => {
 
     it('throws for negative count', async () => {
       await expect(service.generatePacks(-1)).rejects.toThrow('Count must be a positive integer');
+    });
+
+    it('creates the AI provider with Cloudflare gateway configuration', async () => {
+      vi.mocked(generateObject).mockResolvedValue({
+        object: [
+          {
+            name: 'Weekend Hiking Kit',
+            description: 'A compact day-hike setup',
+            category: 'hiking',
+            tags: ['hiking'],
+            items: [],
+          },
+        ],
+      } as Awaited<ReturnType<typeof generateObject>>);
+
+      await (
+        service as unknown as {
+          generatePackConcepts(count: number): Promise<unknown>;
+        }
+      ).generatePackConcepts(1);
+
+      expect(createAIProvider).toHaveBeenCalledWith({
+        openAiApiKey: 'test-key',
+        provider: 'openai',
+        cloudflareAccountId: 'test-account',
+        cloudflareGatewayId: 'test-gateway',
+        cloudflareApiToken: 'cf-token',
+        cloudflareAiBinding: {},
+      });
     });
   });
 });

--- a/packages/api/src/services/__tests__/wildlifeIdentificationService.test.ts
+++ b/packages/api/src/services/__tests__/wildlifeIdentificationService.test.ts
@@ -1,0 +1,76 @@
+import { generateObject } from 'ai';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { WildlifeIdentificationService } from '../wildlifeIdentificationService';
+
+const { mockCreateAIProvider, mockModel } = vi.hoisted(() => {
+  const mockModel = vi.fn((modelName: string) => ({ name: modelName }));
+  return {
+    mockCreateAIProvider: vi.fn(() => mockModel),
+    mockModel,
+  };
+});
+
+vi.mock('@packrat/api/utils/ai/provider', () => ({
+  createAIProvider: mockCreateAIProvider,
+}));
+
+vi.mock('@packrat/api/utils/env-validation', () => ({
+  getEnv: vi.fn(() => ({
+    OPENAI_API_KEY: undefined,
+    AI_PROVIDER: 'openai',
+    CLOUDFLARE_ACCOUNT_ID: 'test-account',
+    CLOUDFLARE_AI_GATEWAY_ID: 'test-gateway',
+    CLOUDFLARE_API_TOKEN: 'cf-token',
+    AI: {},
+  })),
+}));
+
+vi.mock('ai', () => ({
+  generateObject: vi.fn(),
+}));
+
+describe('WildlifeIdentificationService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('identifies species through the shared AI provider without a direct OpenAI key', async () => {
+    vi.mocked(generateObject).mockResolvedValue({
+      object: {
+        results: [
+          {
+            commonName: 'Douglas Fir',
+            scientificName: 'Pseudotsuga menziesii',
+            category: 'tree',
+            description: 'Conifer with flat needles and distinctive cones',
+            habitat: ['forest'],
+            regions: ['western North America'],
+            dangerLevel: 'safe',
+            characteristics: ['flat needles'],
+            confidence: 0.86,
+          },
+        ],
+      },
+    } as Awaited<ReturnType<typeof generateObject>>);
+
+    const result = await new WildlifeIdentificationService().identifySpecies(
+      'https://example.com/tree.jpg',
+    );
+
+    expect(result.results).toHaveLength(1);
+    expect(mockCreateAIProvider).toHaveBeenCalledWith({
+      openAiApiKey: undefined,
+      provider: 'openai',
+      cloudflareAccountId: 'test-account',
+      cloudflareGatewayId: 'test-gateway',
+      cloudflareApiToken: 'cf-token',
+      cloudflareAiBinding: {},
+    });
+    expect(mockModel).toHaveBeenCalledWith('gpt-4o');
+    expect(generateObject).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model: { name: 'gpt-4o' },
+      }),
+    );
+  });
+});

--- a/packages/api/src/services/aiService.ts
+++ b/packages/api/src/services/aiService.ts
@@ -1,5 +1,5 @@
-import { createPerplexity } from '@ai-sdk/perplexity';
 import { DEFAULT_MODELS } from '@packrat/api/utils/ai/models';
+import { createPerplexityAIProvider } from '@packrat/api/utils/ai/provider';
 import type { Env } from '@packrat/api/utils/env-validation';
 import { getEnv } from '@packrat/api/utils/env-validation';
 import { isFunction } from '@packrat/guards';
@@ -26,8 +26,12 @@ export class AIService {
   }
 
   async perplexitySearch(query: string): Promise<SearchResult> {
-    const perplexity = createPerplexity({
-      apiKey: this.env.PERPLEXITY_API_KEY,
+    const perplexity = createPerplexityAIProvider({
+      perplexityApiKey: this.env.PERPLEXITY_API_KEY,
+      cloudflareAccountId: this.env.CLOUDFLARE_ACCOUNT_ID,
+      cloudflareGatewayId: this.env.CLOUDFLARE_AI_GATEWAY_ID,
+      cloudflareApiToken: this.env.CLOUDFLARE_API_TOKEN,
+      cloudflareAiBinding: this.env.AI,
     });
 
     try {

--- a/packages/api/src/services/catalogService.ts
+++ b/packages/api/src/services/catalogService.ts
@@ -223,6 +223,7 @@ export class CatalogService {
       provider: this.env.AI_PROVIDER,
       cloudflareAccountId: this.env.CLOUDFLARE_ACCOUNT_ID,
       cloudflareGatewayId: this.env.CLOUDFLARE_AI_GATEWAY_ID,
+      cloudflareApiToken: this.env.CLOUDFLARE_API_TOKEN,
       cloudflareAiBinding: this.env.AI,
     });
 
@@ -283,6 +284,7 @@ export class CatalogService {
       openAiApiKey: this.env.OPENAI_API_KEY,
       cloudflareAccountId: this.env.CLOUDFLARE_ACCOUNT_ID,
       cloudflareGatewayId: this.env.CLOUDFLARE_AI_GATEWAY_ID,
+      cloudflareApiToken: this.env.CLOUDFLARE_API_TOKEN,
       provider: this.env.AI_PROVIDER,
       cloudflareAiBinding: this.env.AI,
     });
@@ -391,6 +393,7 @@ export class CatalogService {
         values: embeddingTexts,
         cloudflareAccountId: this.env.CLOUDFLARE_ACCOUNT_ID,
         cloudflareGatewayId: this.env.CLOUDFLARE_AI_GATEWAY_ID,
+        cloudflareApiToken: this.env.CLOUDFLARE_API_TOKEN,
         provider: this.env.AI_PROVIDER,
         cloudflareAiBinding: this.env.AI,
       });
@@ -491,6 +494,7 @@ export class CatalogService {
         values: embeddingTexts,
         cloudflareAccountId: this.env.CLOUDFLARE_ACCOUNT_ID,
         cloudflareGatewayId: this.env.CLOUDFLARE_AI_GATEWAY_ID,
+        cloudflareApiToken: this.env.CLOUDFLARE_API_TOKEN,
         provider: this.env.AI_PROVIDER,
         cloudflareAiBinding: this.env.AI,
       });

--- a/packages/api/src/services/embeddingService.ts
+++ b/packages/api/src/services/embeddingService.ts
@@ -7,10 +7,11 @@ import { embed, embedMany } from 'ai';
 const NEWLINE = /\n/g;
 
 type GenerateEmbeddingBaseParams = {
-  openAiApiKey: string;
+  openAiApiKey?: string;
   provider: AIProvider;
-  cloudflareAccountId: string;
-  cloudflareGatewayId: string;
+  cloudflareAccountId?: string;
+  cloudflareGatewayId?: string;
+  cloudflareApiToken?: string;
   cloudflareAiBinding: Env['AI'];
 };
 

--- a/packages/api/src/services/etl/processValidItemsBatch.ts
+++ b/packages/api/src/services/etl/processValidItemsBatch.ts
@@ -29,6 +29,7 @@ export async function processValidItemsBatch({
       values: embeddingTexts,
       cloudflareAccountId: env.CLOUDFLARE_ACCOUNT_ID,
       cloudflareGatewayId: env.CLOUDFLARE_AI_GATEWAY_ID,
+      cloudflareApiToken: env.CLOUDFLARE_API_TOKEN,
       provider: env.AI_PROVIDER,
       cloudflareAiBinding: env.AI,
     });

--- a/packages/api/src/services/imageDetectionService.ts
+++ b/packages/api/src/services/imageDetectionService.ts
@@ -1,5 +1,5 @@
-import { createOpenAI } from '@ai-sdk/openai';
 import { DEFAULT_MODELS } from '@packrat/api/utils/ai/models';
+import { createAIProvider } from '@packrat/api/utils/ai/provider';
 import { getEnv } from '@packrat/api/utils/env-validation';
 import type { CatalogItem } from '@packrat/db';
 import { generateObject } from 'ai';
@@ -49,13 +49,25 @@ export class ImageDetectionService {
    * Analyze an image to detect outdoor gear items
    */
   async analyzeImage(imageUrl: string): Promise<ImageAnalysisResult> {
-    const { OPENAI_API_KEY } = getEnv();
-    const openai = createOpenAI({
-      apiKey: OPENAI_API_KEY,
+    const {
+      OPENAI_API_KEY,
+      AI_PROVIDER,
+      CLOUDFLARE_ACCOUNT_ID,
+      CLOUDFLARE_AI_GATEWAY_ID,
+      CLOUDFLARE_API_TOKEN,
+      AI,
+    } = getEnv();
+    const aiProvider = createAIProvider({
+      openAiApiKey: OPENAI_API_KEY,
+      provider: AI_PROVIDER,
+      cloudflareAccountId: CLOUDFLARE_ACCOUNT_ID,
+      cloudflareGatewayId: CLOUDFLARE_AI_GATEWAY_ID,
+      cloudflareApiToken: CLOUDFLARE_API_TOKEN,
+      cloudflareAiBinding: AI,
     });
 
     const { object } = await generateObject({
-      model: openai(DEFAULT_MODELS.OPENAI_CHAT),
+      model: aiProvider(DEFAULT_MODELS.OPENAI_CHAT),
       schema: imageAnalysisSchema,
       system: ITEM_DETECTION_SYSTEM_PROMPT,
       prompt: [

--- a/packages/api/src/services/packService.ts
+++ b/packages/api/src/services/packService.ts
@@ -1,6 +1,6 @@
-import { createOpenAI } from '@ai-sdk/openai';
 import { createDb } from '@packrat/api/db';
 import { DEFAULT_MODELS } from '@packrat/api/utils/ai/models';
+import { createAIProvider } from '@packrat/api/utils/ai/provider';
 import { getEnv } from '@packrat/api/utils/env-validation';
 import { PACK_CATEGORIES } from '@packrat/constants';
 import { type NewPack, type NewPackItem, type PackWithItems, packItems, packs } from '@packrat/db';
@@ -110,11 +110,25 @@ export class PackService {
   }
 
   private async generatePackConcepts(count: number): Promise<PackConcept[]> {
-    const { OPENAI_API_KEY } = getEnv();
-    const openai = createOpenAI({ apiKey: OPENAI_API_KEY });
+    const {
+      OPENAI_API_KEY,
+      AI_PROVIDER,
+      CLOUDFLARE_ACCOUNT_ID,
+      CLOUDFLARE_AI_GATEWAY_ID,
+      CLOUDFLARE_API_TOKEN,
+      AI,
+    } = getEnv();
+    const aiProvider = createAIProvider({
+      openAiApiKey: OPENAI_API_KEY,
+      provider: AI_PROVIDER,
+      cloudflareAccountId: CLOUDFLARE_ACCOUNT_ID,
+      cloudflareGatewayId: CLOUDFLARE_AI_GATEWAY_ID,
+      cloudflareApiToken: CLOUDFLARE_API_TOKEN,
+      cloudflareAiBinding: AI,
+    });
 
     const { object } = await generateObject({
-      model: openai(DEFAULT_MODELS.OPENAI_CHAT),
+      model: aiProvider(DEFAULT_MODELS.OPENAI_CHAT),
       output: 'array',
       schema: packConceptSchema,
       system: PACK_CONCEPTS_SYSTEM_PROMPT,

--- a/packages/api/src/services/wildlifeIdentificationService.ts
+++ b/packages/api/src/services/wildlifeIdentificationService.ts
@@ -1,5 +1,5 @@
-import { createOpenAI } from '@ai-sdk/openai';
 import { DEFAULT_MODELS } from '@packrat/api/utils/ai/models';
+import { createAIProvider } from '@packrat/api/utils/ai/provider';
 import { getEnv } from '@packrat/api/utils/env-validation';
 import { generateObject } from 'ai';
 import { z } from 'zod';
@@ -57,12 +57,26 @@ export type IdentificationResponse = z.infer<typeof identificationResponseSchema
 
 export class WildlifeIdentificationService {
   async identifySpecies(imageUrl: string): Promise<IdentificationResponse> {
-    const { OPENAI_API_KEY } = getEnv();
-    const openai = createOpenAI({ apiKey: OPENAI_API_KEY });
+    const {
+      OPENAI_API_KEY,
+      AI_PROVIDER,
+      CLOUDFLARE_ACCOUNT_ID,
+      CLOUDFLARE_AI_GATEWAY_ID,
+      CLOUDFLARE_API_TOKEN,
+      AI,
+    } = getEnv();
+    const aiProvider = createAIProvider({
+      openAiApiKey: OPENAI_API_KEY,
+      provider: AI_PROVIDER,
+      cloudflareAccountId: CLOUDFLARE_ACCOUNT_ID,
+      cloudflareGatewayId: CLOUDFLARE_AI_GATEWAY_ID,
+      cloudflareApiToken: CLOUDFLARE_API_TOKEN,
+      cloudflareAiBinding: AI,
+    });
 
     try {
       const { object } = await generateObject({
-        model: openai(DEFAULT_MODELS.OPENAI_CHAT),
+        model: aiProvider(DEFAULT_MODELS.OPENAI_CHAT),
         schema: identificationResponseSchema,
         system: SPECIES_IDENTIFICATION_SYSTEM_PROMPT,
         messages: [

--- a/packages/api/src/utils/__tests__/env-validation.test.ts
+++ b/packages/api/src/utils/__tests__/env-validation.test.ts
@@ -1,5 +1,10 @@
 import { beforeEach, describe, expect, it } from 'vitest';
-import { apiEnvSchema, getEnv, validateCloudflareApiEnv } from '../env-validation';
+import {
+  apiEnvObjectSchema,
+  apiEnvSchema,
+  getEnv,
+  validateCloudflareApiEnv,
+} from '../env-validation';
 
 // Minimal helper – returns a plain record matching the shape of CF Worker env bindings.
 function makeRawEnv(overrides: Record<string, unknown> = {}): Record<string, unknown> {
@@ -32,6 +37,7 @@ function makeRawEnv(overrides: Record<string, unknown> = {}): Record<string, unk
     WEATHER_API_KEY: 'weather-api',
     CLOUDFLARE_ACCOUNT_ID: 'cf',
     CLOUDFLARE_AI_GATEWAY_ID: 'gateway',
+    CLOUDFLARE_API_TOKEN: 'cf-token',
     R2_ACCESS_KEY_ID: 'access',
     R2_SECRET_ACCESS_KEY: 'secret',
     PACKRAT_BUCKET_R2_BUCKET_NAME: 'bucket',
@@ -48,7 +54,9 @@ function makeRawEnv(overrides: Record<string, unknown> = {}): Record<string, unk
     ETL_QUEUE: {},
     LOGS_QUEUE: {},
     EMBEDDINGS_QUEUE: {},
+    ETL_WORKFLOW: {},
     APP_CONTAINER: {},
+    AUTH_KV: {},
     ...overrides,
   };
 }
@@ -72,47 +80,91 @@ describe('env-validation', () => {
     });
 
     it('validates SENTRY_DSN as URL', () => {
-      expect(apiEnvSchema.shape.SENTRY_DSN.safeParse('https://sentry.io/123').success).toBe(true);
+      expect(apiEnvObjectSchema.shape.SENTRY_DSN.safeParse('https://sentry.io/123').success).toBe(
+        true,
+      );
     });
 
     it('rejects invalid SENTRY_DSN', () => {
-      expect(apiEnvSchema.shape.SENTRY_DSN.safeParse('not-a-url').success).toBe(false);
+      expect(apiEnvObjectSchema.shape.SENTRY_DSN.safeParse('not-a-url').success).toBe(false);
     });
 
     it('accepts missing SENTRY_DSN for local development', () => {
-      expect(apiEnvSchema.shape.SENTRY_DSN.safeParse(undefined).success).toBe(true);
+      expect(apiEnvObjectSchema.shape.SENTRY_DSN.safeParse(undefined).success).toBe(true);
     });
 
     it('validates OPENAI_API_KEY starts with sk-', () => {
-      expect(apiEnvSchema.shape.OPENAI_API_KEY.safeParse('sk-test123').success).toBe(true);
+      expect(apiEnvObjectSchema.shape.OPENAI_API_KEY.safeParse('sk-test123').success).toBe(true);
     });
 
     it('rejects OPENAI_API_KEY without sk- prefix', () => {
-      expect(apiEnvSchema.shape.OPENAI_API_KEY.safeParse('invalid-key').success).toBe(false);
+      expect(apiEnvObjectSchema.shape.OPENAI_API_KEY.safeParse('invalid-key').success).toBe(false);
+    });
+
+    it('requires provider keys even when Cloudflare unified billing is configured', () => {
+      const result = apiEnvSchema.safeParse(
+        makeRawEnv({ OPENAI_API_KEY: undefined, GOOGLE_GENERATIVE_AI_API_KEY: undefined }),
+      );
+      expect(result.success).toBe(false);
+    });
+
+    it('validates direct OpenAI fallback with OPENAI_API_KEY and no Cloudflare token', () => {
+      const result = apiEnvSchema.safeParse(makeRawEnv({ CLOUDFLARE_API_TOKEN: undefined }));
+      expect(result.success).toBe(true);
+    });
+
+    it('validates direct OpenAI fallback without Cloudflare AI Gateway config', () => {
+      const result = apiEnvSchema.safeParse(
+        makeRawEnv({
+          CLOUDFLARE_AI_GATEWAY_ID: undefined,
+          CLOUDFLARE_API_TOKEN: undefined,
+        }),
+      );
+      expect(result.success).toBe(true);
+    });
+
+    it('requires OPENAI_API_KEY', () => {
+      const result = apiEnvSchema.safeParse(makeRawEnv({ OPENAI_API_KEY: undefined }));
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.message).toContain('Required');
+      }
+    });
+
+    it('requires GOOGLE_GENERATIVE_AI_API_KEY', () => {
+      const result = apiEnvSchema.safeParse(
+        makeRawEnv({ GOOGLE_GENERATIVE_AI_API_KEY: undefined }),
+      );
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.message).toContain('Required');
+      }
     });
 
     it('validates AI_PROVIDER enum', () => {
-      expect(apiEnvSchema.shape.AI_PROVIDER.safeParse('openai').success).toBe(true);
-      expect(apiEnvSchema.shape.AI_PROVIDER.safeParse('cloudflare-workers-ai').success).toBe(true);
-      expect(apiEnvSchema.shape.AI_PROVIDER.safeParse('invalid').success).toBe(false);
+      expect(apiEnvObjectSchema.shape.AI_PROVIDER.safeParse('openai').success).toBe(true);
+      expect(apiEnvObjectSchema.shape.AI_PROVIDER.safeParse('cloudflare-workers-ai').success).toBe(
+        true,
+      );
+      expect(apiEnvObjectSchema.shape.AI_PROVIDER.safeParse('invalid').success).toBe(false);
     });
 
     it('validates EMAIL_PROVIDER enum', () => {
-      expect(apiEnvSchema.shape.EMAIL_PROVIDER.safeParse('resend').success).toBe(true);
-      expect(apiEnvSchema.shape.EMAIL_PROVIDER.safeParse('ses').success).toBe(true);
-      expect(apiEnvSchema.shape.EMAIL_PROVIDER.safeParse('invalid').success).toBe(false);
+      expect(apiEnvObjectSchema.shape.EMAIL_PROVIDER.safeParse('resend').success).toBe(true);
+      expect(apiEnvObjectSchema.shape.EMAIL_PROVIDER.safeParse('ses').success).toBe(true);
+      expect(apiEnvObjectSchema.shape.EMAIL_PROVIDER.safeParse('invalid').success).toBe(false);
     });
 
     it('validates CONTAINER_PORT as numeric string', () => {
-      expect(apiEnvSchema.shape.CONTAINER_PORT.safeParse('8080').success).toBe(true);
+      expect(apiEnvObjectSchema.shape.CONTAINER_PORT.safeParse('8080').success).toBe(true);
     });
 
     it('rejects non-numeric CONTAINER_PORT', () => {
-      expect(apiEnvSchema.shape.CONTAINER_PORT.safeParse('not-a-port').success).toBe(false);
+      expect(apiEnvObjectSchema.shape.CONTAINER_PORT.safeParse('not-a-port').success).toBe(false);
     });
 
     it('makes CONTAINER_PORT optional', () => {
-      expect(apiEnvSchema.shape.CONTAINER_PORT.safeParse(undefined).success).toBe(true);
+      expect(apiEnvObjectSchema.shape.CONTAINER_PORT.safeParse(undefined).success).toBe(true);
     });
   });
 

--- a/packages/api/src/utils/ai/__tests__/logging.test.ts
+++ b/packages/api/src/utils/ai/__tests__/logging.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+import type { Env } from '../../env-validation';
+import { logAIRequest } from '../logging';
+
+const baseEnv = {
+  ENVIRONMENT: 'production',
+  AI_PROVIDER: 'openai',
+  OPENAI_API_KEY: 'sk-test',
+  CLOUDFLARE_ACCOUNT_ID: 'test-account',
+  CLOUDFLARE_AI_GATEWAY_ID: 'test-gateway',
+  CLOUDFLARE_API_TOKEN: 'cf-token',
+  AI: {},
+} as Env;
+
+describe('logAIRequest', () => {
+  it('records Cloudflare unified billing metadata when Cloudflare config is complete', () => {
+    const headers = new Headers({ 'cf-aig-log-id': 'log-123' });
+
+    const log = logAIRequest({
+      env: baseEnv,
+      opts: {
+        headers,
+        log: { model: 'gpt-4o' },
+      },
+    });
+
+    expect(log).toMatchObject({
+      provider: 'openai',
+      model: 'gpt-4o',
+      billingPath: 'cloudflare-unified',
+      cloudflareGatewayId: 'test-gateway',
+      cloudflareLogId: 'log-123',
+    });
+  });
+
+  it('records direct provider billing path when Cloudflare config is incomplete', () => {
+    const log = logAIRequest({
+      env: { ...baseEnv, CLOUDFLARE_API_TOKEN: undefined } as Env,
+      opts: {
+        headers: new Headers(),
+        log: { model: 'gpt-4o' },
+      },
+    });
+
+    expect(log.billingPath).toBe('direct-provider');
+    expect(log.cloudflareGatewayId).toBeUndefined();
+    expect(log.cloudflareLogId).toBeUndefined();
+  });
+
+  it('preserves computed billing metadata over caller-provided log fields', () => {
+    const log = logAIRequest({
+      env: baseEnv,
+      opts: {
+        headers: new Headers({ 'cf-aig-log-id': 'log-456' }),
+        log: {
+          billingPath: 'direct-provider',
+          provider: 'manual-provider',
+          model: 'gpt-4o-mini',
+          timestamp: new Date('2024-01-01T00:00:00.000Z'),
+        },
+      },
+    });
+
+    expect(log).toMatchObject({
+      provider: 'openai',
+      model: 'gpt-4o-mini',
+      billingPath: 'cloudflare-unified',
+      cloudflareGatewayId: 'test-gateway',
+      cloudflareLogId: 'log-456',
+    });
+    expect(log.timestamp.toISOString()).not.toBe('2024-01-01T00:00:00.000Z');
+  });
+});

--- a/packages/api/src/utils/ai/__tests__/provider.test.ts
+++ b/packages/api/src/utils/ai/__tests__/provider.test.ts
@@ -1,0 +1,232 @@
+import { createGoogleGenerativeAI } from '@ai-sdk/google';
+import { createOpenAI } from '@ai-sdk/openai';
+import { createPerplexity } from '@ai-sdk/perplexity';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  createAIProvider,
+  createGoogleAIProvider,
+  createPerplexityAIProvider,
+  getAIBillingPath,
+  getGoogleBillingPath,
+  getPerplexityBillingPath,
+} from '../provider';
+
+vi.mock('@ai-sdk/google', () => ({
+  createGoogleGenerativeAI: vi.fn(() => ({ provider: 'google-ai-studio' })),
+}));
+
+vi.mock('@ai-sdk/openai', () => ({
+  createOpenAI: vi.fn(() => ({ provider: 'openai' })),
+}));
+
+vi.mock('@ai-sdk/perplexity', () => ({
+  createPerplexity: vi.fn(() => ({ provider: 'perplexity' })),
+}));
+
+const baseConfig = {
+  provider: 'openai' as const,
+  openAiApiKey: 'sk-test',
+  googleApiKey: 'google-test',
+  perplexityApiKey: 'pplx-test',
+  cloudflareAccountId: 'test-account',
+  cloudflareGatewayId: 'test-gateway',
+  cloudflareApiToken: 'cf-token',
+  cloudflareAiBinding: {} as never,
+};
+
+const consoleInfoSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
+const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+describe('createAIProvider', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+  });
+
+  it('uses Cloudflare AI Gateway unified billing when Cloudflare config is complete', () => {
+    createAIProvider(baseConfig);
+
+    expect(createOpenAI).toHaveBeenCalledWith({
+      apiKey: 'cf-token',
+      baseURL: 'https://gateway.ai.cloudflare.com/v1/test-account/test-gateway/openai',
+    });
+    expect(consoleInfoSpy).toHaveBeenCalledWith('ai.provider.selected', {
+      provider: 'openai',
+      configuredProvider: 'openai',
+      billingPath: 'cloudflare-unified',
+      cloudflareGatewayId: 'test-gateway',
+    });
+  });
+
+  it('falls back to direct OpenAI when Cloudflare API token is absent', () => {
+    createAIProvider({ ...baseConfig, cloudflareApiToken: undefined });
+
+    expect(createOpenAI).toHaveBeenCalledWith({
+      apiKey: 'sk-test',
+    });
+    expect(consoleInfoSpy).toHaveBeenCalledWith('ai.provider.selected', {
+      provider: 'openai',
+      configuredProvider: 'openai',
+      billingPath: 'direct-provider',
+      cloudflareGatewayId: undefined,
+    });
+  });
+
+  it('throws a direct OpenAI configuration error when neither path is configured', () => {
+    expect(() =>
+      createAIProvider({ ...baseConfig, cloudflareApiToken: undefined, openAiApiKey: undefined }),
+    ).toThrow('OpenAI API key is required');
+  });
+
+  it('throws when a non-OpenAI provider is configured for an OpenAI-backed path', () => {
+    expect(() => createAIProvider({ ...baseConfig, provider: 'cloudflare-workers-ai' })).toThrow(
+      'Unsupported AI_PROVIDER "cloudflare-workers-ai"',
+    );
+
+    expect(consoleWarnSpy).toHaveBeenCalledWith('ai.provider.unsupported_openai_path', {
+      configuredProvider: 'cloudflare-workers-ai',
+      billingPath: 'cloudflare-unified',
+    });
+  });
+});
+
+describe('createPerplexityAIProvider', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+  });
+
+  it('uses Cloudflare AI Gateway BYOK routing when Cloudflare gateway config is present', () => {
+    createPerplexityAIProvider(baseConfig);
+
+    expect(createPerplexity).toHaveBeenCalledWith({
+      apiKey: 'pplx-test',
+      baseURL: 'https://gateway.ai.cloudflare.com/v1/test-account/test-gateway/perplexity-ai',
+      headers: {
+        'cf-aig-authorization': 'Bearer cf-token',
+      },
+    });
+    expect(consoleInfoSpy).toHaveBeenCalledWith('ai.provider.selected', {
+      provider: 'perplexity',
+      billingPath: 'cloudflare-gateway-byok',
+      cloudflareGatewayId: 'test-gateway',
+    });
+  });
+
+  it('falls back to direct Perplexity when Cloudflare gateway config is absent', () => {
+    createPerplexityAIProvider({
+      ...baseConfig,
+      cloudflareAccountId: undefined,
+      cloudflareGatewayId: undefined,
+    });
+
+    expect(createPerplexity).toHaveBeenCalledWith({
+      apiKey: 'pplx-test',
+    });
+  });
+
+  it('falls back to direct Perplexity when Cloudflare API token is absent', () => {
+    createPerplexityAIProvider({
+      ...baseConfig,
+      cloudflareApiToken: undefined,
+    });
+
+    expect(createPerplexity).toHaveBeenCalledWith({
+      apiKey: 'pplx-test',
+    });
+  });
+
+  it('throws when the Perplexity key is absent', () => {
+    expect(() =>
+      createPerplexityAIProvider({
+        ...baseConfig,
+        perplexityApiKey: undefined,
+      }),
+    ).toThrow('PERPLEXITY_API_KEY is required');
+  });
+});
+
+describe('createGoogleAIProvider', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+  });
+
+  it('uses Cloudflare AI Gateway unified billing when Cloudflare config is complete', () => {
+    createGoogleAIProvider(baseConfig);
+
+    expect(createGoogleGenerativeAI).toHaveBeenCalledWith({
+      apiKey: 'cf-token',
+      baseURL: 'https://gateway.ai.cloudflare.com/v1/test-account/test-gateway/google-ai-studio',
+    });
+    expect(consoleInfoSpy).toHaveBeenCalledWith('ai.provider.selected', {
+      provider: 'google-ai-studio',
+      billingPath: 'cloudflare-unified',
+      cloudflareGatewayId: 'test-gateway',
+    });
+  });
+
+  it('falls back to direct Google AI Studio when Cloudflare API token is absent', () => {
+    createGoogleAIProvider({ ...baseConfig, cloudflareApiToken: undefined });
+
+    expect(createGoogleGenerativeAI).toHaveBeenCalledWith({
+      apiKey: 'google-test',
+    });
+    expect(consoleInfoSpy).toHaveBeenCalledWith('ai.provider.selected', {
+      provider: 'google-ai-studio',
+      configuredProvider: undefined,
+      billingPath: 'direct-provider',
+      cloudflareGatewayId: undefined,
+    });
+  });
+
+  it('throws a Google configuration error when neither path is configured', () => {
+    expect(() =>
+      createGoogleAIProvider({
+        ...baseConfig,
+        cloudflareApiToken: undefined,
+        googleApiKey: undefined,
+      }),
+    ).toThrow('Google Generative AI API key is required');
+  });
+});
+
+describe('getAIBillingPath', () => {
+  it('returns cloudflare-unified when Cloudflare account, gateway, and token are present', () => {
+    expect(getAIBillingPath(baseConfig)).toBe('cloudflare-unified');
+  });
+
+  it('returns direct-provider when Cloudflare config is incomplete', () => {
+    expect(getAIBillingPath({ ...baseConfig, cloudflareGatewayId: '' })).toBe('direct-provider');
+  });
+});
+
+describe('getPerplexityBillingPath', () => {
+  it('returns cloudflare-gateway-byok when Cloudflare gateway config is present', () => {
+    expect(getPerplexityBillingPath(baseConfig)).toBe('cloudflare-gateway-byok');
+  });
+
+  it('returns direct-provider when Cloudflare gateway config is incomplete', () => {
+    expect(getPerplexityBillingPath({ ...baseConfig, cloudflareAccountId: undefined })).toBe(
+      'direct-provider',
+    );
+  });
+
+  it('returns direct-provider when Cloudflare API token is absent', () => {
+    expect(getPerplexityBillingPath({ ...baseConfig, cloudflareApiToken: undefined })).toBe(
+      'direct-provider',
+    );
+  });
+});
+
+describe('getGoogleBillingPath', () => {
+  it('returns cloudflare-unified when Cloudflare account, gateway, and token are present', () => {
+    expect(getGoogleBillingPath(baseConfig)).toBe('cloudflare-unified');
+  });
+
+  it('returns direct-provider when Cloudflare config is incomplete', () => {
+    expect(getGoogleBillingPath({ ...baseConfig, cloudflareApiToken: undefined })).toBe(
+      'direct-provider',
+    );
+  });
+});

--- a/packages/api/src/utils/ai/logging.ts
+++ b/packages/api/src/utils/ai/logging.ts
@@ -1,9 +1,11 @@
 import type { Env } from '@packrat/api/utils/env-validation';
-import { extractCloudflareLogId } from './provider';
+import { type AIBillingPath, extractCloudflareLogId, getAIBillingPath } from './provider';
 
 export interface AIRequestLog {
   provider: string;
   model: string;
+  billingPath: AIBillingPath;
+  cloudflareGatewayId?: string;
   cloudflareLogId?: string | null;
   timestamp: Date;
   userId?: string;
@@ -19,15 +21,24 @@ export function logAIRequest({
   opts: { headers: Headers; log: Partial<AIRequestLog> };
 }): AIRequestLog {
   const { headers, log: options } = opts;
+  const billingPath = getAIBillingPath({
+    openAiApiKey: env.OPENAI_API_KEY,
+    cloudflareAccountId: env.CLOUDFLARE_ACCOUNT_ID,
+    cloudflareGatewayId: env.CLOUDFLARE_AI_GATEWAY_ID,
+    cloudflareApiToken: env.CLOUDFLARE_API_TOKEN,
+    cloudflareAiBinding: env.AI,
+  });
   const log: AIRequestLog = {
+    ...options,
     provider: env.AI_PROVIDER || 'openai',
     model: options.model || 'gpt-4o',
+    billingPath,
     timestamp: new Date(),
-    ...options,
   };
 
   // Extract Cloudflare log ID if using Cloudflare Gateway
-  if (env.AI_PROVIDER === 'cloudflare-workers-ai') {
+  if (billingPath === 'cloudflare-unified') {
+    log.cloudflareGatewayId = env.CLOUDFLARE_AI_GATEWAY_ID;
     log.cloudflareLogId = extractCloudflareLogId(headers);
   }
 

--- a/packages/api/src/utils/ai/provider.ts
+++ b/packages/api/src/utils/ai/provider.ts
@@ -1,14 +1,18 @@
+import { createGoogleGenerativeAI, type GoogleGenerativeAIProvider } from '@ai-sdk/google';
 import type { OpenAIProvider } from '@ai-sdk/openai';
 import { createOpenAI } from '@ai-sdk/openai';
+import { createPerplexity, type PerplexityProvider } from '@ai-sdk/perplexity';
 import type { Env } from '@packrat/api/utils/env-validation';
-// import type { createWorkersAI } from 'workers-ai-provider';
 
 export type AIProvider = 'openai' | 'cloudflare-workers-ai';
 
 interface BaseProviderConfig {
-  openAiApiKey: string;
-  cloudflareAccountId: string;
-  cloudflareGatewayId: string;
+  openAiApiKey?: string;
+  googleApiKey?: string;
+  perplexityApiKey?: string;
+  cloudflareAccountId?: string;
+  cloudflareGatewayId?: string;
+  cloudflareApiToken?: string;
   cloudflareAiBinding: Env['AI'];
 }
 
@@ -22,43 +26,161 @@ interface WorkersAIProviderConfig extends BaseProviderConfig {
 
 export type AIProviderConfig = OpenAIProviderConfig | WorkersAIProviderConfig;
 
-// Define return type for Workers AI
-// type WorkersAIProvider = ReturnType<typeof createWorkersAI>;
-
 type CreateAIProviderReturn = OpenAIProvider;
+
+export type ProviderBillingPath =
+  | 'cloudflare-unified'
+  | 'cloudflare-gateway-byok'
+  | 'direct-provider';
+export type AIBillingPath = Extract<ProviderBillingPath, 'cloudflare-unified' | 'direct-provider'>;
+export type GoogleBillingPath = AIBillingPath;
+
+export function getAIBillingPath(config: BaseProviderConfig): AIBillingPath {
+  if (config.cloudflareAccountId && config.cloudflareGatewayId && config.cloudflareApiToken) {
+    return 'cloudflare-unified';
+  }
+
+  return 'direct-provider';
+}
+
+export function getGoogleBillingPath(config: BaseProviderConfig): GoogleBillingPath {
+  if (config.cloudflareAccountId && config.cloudflareGatewayId && config.cloudflareApiToken) {
+    return 'cloudflare-unified';
+  }
+
+  return 'direct-provider';
+}
+
+const providerSelectionLogKeys = new Set<string>();
+
+function logProviderSelectionOnce({
+  provider,
+  billingPath,
+  cloudflareGatewayId,
+  configuredProvider,
+}: {
+  provider: string;
+  billingPath: string;
+  cloudflareGatewayId?: string;
+  configuredProvider?: string;
+}): void {
+  const logKey = `${provider}:${configuredProvider ?? provider}:${billingPath}:${cloudflareGatewayId ?? ''}`;
+  if (providerSelectionLogKeys.has(logKey)) return;
+  providerSelectionLogKeys.add(logKey);
+
+  console.info('ai.provider.selected', {
+    provider,
+    configuredProvider,
+    billingPath,
+    cloudflareGatewayId,
+  });
+}
 
 // Function to create an AI provider based on the config
 export function createAIProvider(config: AIProviderConfig): CreateAIProviderReturn {
-  const { openAiApiKey, provider, cloudflareAccountId, cloudflareGatewayId } = config;
+  const { openAiApiKey, provider, cloudflareAccountId, cloudflareGatewayId, cloudflareApiToken } =
+    config;
+  const billingPath = getAIBillingPath(config);
 
-  // All providers go through Cloudflare Gateway if configured
-  if (!cloudflareAccountId || !cloudflareGatewayId) {
-    throw new Error('Cloudflare account ID and gateway ID are required');
+  if (provider !== 'openai') {
+    console.warn('ai.provider.unsupported_openai_path', {
+      configuredProvider: provider,
+      billingPath,
+    });
+    throw new Error(`Unsupported AI_PROVIDER "${provider}" for OpenAI-backed provider path`);
   }
 
-  // Route through Cloudflare AI Gateway based on provider
-  if (provider === 'cloudflare-workers-ai') {
-    // Future: When adding Cloudflare Workers AI support
-    // return createWorkersAI({
-    //   baseURL: `https://gateway.ai.cloudflare.com/v1/${cloudflareAccountId}/${cloudflareGatewayId}/workers-ai`,
-    // });
+  logProviderSelectionOnce({
+    provider: 'openai',
+    billingPath,
+    cloudflareGatewayId: billingPath === 'cloudflare-unified' ? cloudflareGatewayId : undefined,
+    configuredProvider: provider,
+  });
 
-    // For now, continue using OpenAI through gateway
+  if (billingPath === 'cloudflare-unified') {
     return createOpenAI({
-      apiKey: openAiApiKey,
+      apiKey: cloudflareApiToken,
       baseURL: `https://gateway.ai.cloudflare.com/v1/${cloudflareAccountId}/${cloudflareGatewayId}/openai`,
     });
   }
 
-  // OpenAI through Cloudflare Gateway
   if (!openAiApiKey) {
-    throw new Error('OpenAI API key is required for OpenAI provider');
+    throw new Error(
+      'OpenAI API key is required when Cloudflare AI Gateway unified billing is not configured',
+    );
   }
 
+  // Direct OpenAI fallback for local development and emergency rollback.
   return createOpenAI({
     apiKey: openAiApiKey,
-    baseURL: `https://gateway.ai.cloudflare.com/v1/${cloudflareAccountId}/${cloudflareGatewayId}/openai`,
   });
+}
+
+export function createGoogleAIProvider(config: BaseProviderConfig): GoogleGenerativeAIProvider {
+  const { googleApiKey, cloudflareAccountId, cloudflareGatewayId, cloudflareApiToken } = config;
+  const billingPath = getGoogleBillingPath(config);
+
+  logProviderSelectionOnce({
+    provider: 'google-ai-studio',
+    billingPath,
+    cloudflareGatewayId: billingPath === 'cloudflare-unified' ? cloudflareGatewayId : undefined,
+  });
+
+  if (billingPath === 'cloudflare-unified') {
+    return createGoogleGenerativeAI({
+      apiKey: cloudflareApiToken,
+      baseURL: `https://gateway.ai.cloudflare.com/v1/${cloudflareAccountId}/${cloudflareGatewayId}/google-ai-studio`,
+    });
+  }
+
+  if (!googleApiKey) {
+    throw new Error(
+      'Google Generative AI API key is required when Cloudflare AI Gateway unified billing is not configured',
+    );
+  }
+
+  return createGoogleGenerativeAI({ apiKey: googleApiKey });
+}
+
+export type PerplexityBillingPath = Extract<
+  ProviderBillingPath,
+  'cloudflare-gateway-byok' | 'direct-provider'
+>;
+
+export function getPerplexityBillingPath(config: BaseProviderConfig): PerplexityBillingPath {
+  if (config.cloudflareAccountId && config.cloudflareGatewayId && config.cloudflareApiToken) {
+    return 'cloudflare-gateway-byok';
+  }
+
+  return 'direct-provider';
+}
+
+export function createPerplexityAIProvider(config: BaseProviderConfig): PerplexityProvider {
+  const { perplexityApiKey, cloudflareAccountId, cloudflareGatewayId, cloudflareApiToken } = config;
+  const billingPath = getPerplexityBillingPath(config);
+
+  if (!perplexityApiKey) {
+    throw new Error('PERPLEXITY_API_KEY is required for Perplexity search');
+  }
+
+  logProviderSelectionOnce({
+    provider: 'perplexity',
+    billingPath,
+    cloudflareGatewayId:
+      billingPath === 'cloudflare-gateway-byok' ? cloudflareGatewayId : undefined,
+  });
+
+  if (billingPath === 'cloudflare-gateway-byok') {
+    return createPerplexity({
+      apiKey: perplexityApiKey,
+      baseURL: `https://gateway.ai.cloudflare.com/v1/${cloudflareAccountId}/${cloudflareGatewayId}/perplexity-ai`,
+      headers: {
+        'cf-aig-authorization': `Bearer ${cloudflareApiToken}`,
+      },
+    });
+  }
+
+  return createPerplexity({ apiKey: perplexityApiKey });
 }
 
 export function extractCloudflareLogId(headers: Headers): string | null {

--- a/packages/api/src/utils/env-validation.ts
+++ b/packages/api/src/utils/env-validation.ts
@@ -3,7 +3,7 @@ import { isObject } from '@packrat/guards';
 import { z } from 'zod';
 
 // Define the Zod schema for all environment variables
-export const apiEnvSchema = z.object({
+export const apiEnvObjectSchema = z.object({
   // Environment & Deployment
   ENVIRONMENT: z.enum(['development', 'production']).default('production'),
   SENTRY_DSN: z.string().url().optional(),
@@ -54,7 +54,8 @@ export const apiEnvSchema = z.object({
 
   // Cloudflare R2 Storage (config values)
   CLOUDFLARE_ACCOUNT_ID: z.string(),
-  CLOUDFLARE_AI_GATEWAY_ID: z.string(),
+  CLOUDFLARE_AI_GATEWAY_ID: z.string().optional(),
+  CLOUDFLARE_API_TOKEN: z.string().min(1).optional(),
   R2_ACCESS_KEY_ID: z.string(),
   R2_SECRET_ACCESS_KEY: z.string(),
   PACKRAT_BUCKET_R2_BUCKET_NAME: z.string(),
@@ -89,8 +90,10 @@ export const apiEnvSchema = z.object({
   AUTH_KV: z.unknown(),
 });
 
+export const apiEnvSchema = apiEnvObjectSchema;
+
 // Relaxed schema for test environments
-const testEnvSchema = apiEnvSchema.partial().extend({
+const testEnvSchema = apiEnvObjectSchema.partial().extend({
   ENVIRONMENT: z.enum(['development', 'production']).default('development'),
   SENTRY_DSN: z.string().url().optional().default('https://test@test.ingest.sentry.io/test'),
   NEON_DATABASE_URL: z.string().optional().default('postgres://user:pass@localhost/db'),

--- a/packages/api/test/etl.test.ts
+++ b/packages/api/test/etl.test.ts
@@ -74,6 +74,7 @@ const TEST_ENV = {
   AI_PROVIDER: 'openai',
   CLOUDFLARE_ACCOUNT_ID: 'test-account-id',
   CLOUDFLARE_AI_GATEWAY_ID: 'test-gateway-id',
+  CLOUDFLARE_API_TOKEN: 'test-cloudflare-token',
 } as unknown as Parameters<typeof processCatalogETL>[0]['env'];
 
 function makeMessage(jobId: string) {

--- a/packages/api/test/setup.ts
+++ b/packages/api/test/setup.ts
@@ -50,6 +50,7 @@ const testEnv = {
 
   CLOUDFLARE_ACCOUNT_ID: 'test-account-id',
   CLOUDFLARE_AI_GATEWAY_ID: 'test-gateway-id',
+  CLOUDFLARE_API_TOKEN: 'test-cloudflare-token',
   R2_ACCESS_KEY_ID: 'test-access-key',
   R2_SECRET_ACCESS_KEY: 'test-secret-key',
   PACKRAT_BUCKET_R2_BUCKET_NAME: 'test-bucket',


### PR DESCRIPTION
## Summary

AI traffic now prefers Cloudflare AI Gateway when gateway config is present while keeping direct provider keys available for fallback and rollback. OpenAI and Google AI Studio requests can use Cloudflare unified billing; Perplexity is routed through Cloudflare Gateway for BYOK observability when possible and falls back to direct Perplexity when gateway config is absent.

The provider setup is centralized so chat, embeddings, object generation, pack-template analysis, image detection, wildlife identification, season suggestions, ETL embeddings, and web search all follow the same routing rules instead of each call site managing provider clients independently.

## Routing Model

| Provider | Cloudflare path | Direct fallback | Key requirement |
| --- | --- | --- | --- |
| OpenAI | Unified billing via AI Gateway | `@ai-sdk/openai` direct | `OPENAI_API_KEY` remains required |
| Google AI Studio / Gemini | Unified billing via AI Gateway | `@ai-sdk/google` direct | `GOOGLE_GENERATIVE_AI_API_KEY` remains required |
| Perplexity | AI Gateway BYOK routing | `@ai-sdk/perplexity` direct | `PERPLEXITY_API_KEY` remains required |

Cloudflare routing is selected by existing config presence; no new billing-mode env var was added. Provider selection logs now include the billing path so operations can distinguish `cloudflare-unified`, `cloudflare-gateway-byok`, and direct-provider behavior.

## Operational Notes

The new runbook documents production setup, fallback behavior, and provider coverage. `.envrc` is ignored as local machine behavior, with `.envrc.example` checked in for direnv users.

## Testing

- `bun check-types`
- `bun test:api:unit` — 26 files, 395 tests
- focused `bun check` on touched env/provider/docs files
- pre-commit Biome check passed
- pre-push clean checks passed: route/schema checks, strict casts, circular dependency scan, package ordering, duplicate guard scan, protected route scan

## Post-Deploy Monitoring & Validation

Validation window: first staging deploy and first production deploy after merge. Owner: API deploy owner.

Log searches / dashboards:
- Cloudflare AI Gateway logs for the configured gateway ID.
- Worker logs for `event="ai.provider.selected"`.
- Worker/Sentry errors containing `cloudflare-unified`, `cloudflare-gateway-byok`, `direct-openai`, or `direct-perplexity`.

Smoke checks:
- Send one chat request and confirm OpenAI traffic appears in AI Gateway logs.
- Create/update one catalog or pack item and confirm embedding traffic appears in AI Gateway logs.
- Run one Gemini pack-template generation and confirm Google AI Studio traffic appears in AI Gateway logs.
- Run one Perplexity search and confirm Gateway BYOK routing appears in AI Gateway logs while Perplexity key auth remains valid.

Healthy signals:
- AI Gateway logs show OpenAI and Google requests under the configured gateway.
- Perplexity search succeeds through Gateway BYOK when gateway config is present.
- Worker logs include the expected billing path for each provider.
- No increase in AI auth/configuration errors.

Failure signals and rollback:
- Cloudflare 401/403, spend-limit errors, missing gateway logs, or model availability failures.
- Roll back by removing/incompleting Cloudflare gateway config to force direct provider SDK paths, with provider keys already present.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Cloudflare AI Gateway unified billing for AI requests
  * Optional direnv integration for automatic environment variable loading

* **Documentation**
  * Updated environment setup guidance for direnv usage
  * Added production runbooks documenting AI billing configuration and fallback behavior
  * Clarified requirements for direct provider keys (OpenAI, Google, Perplexity) for fallback/rollback scenarios

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PackRat-AI/PackRat/pull/2496?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->