### PR TITLE
fix(ai-chat): resolve unresponsive gear inventory AI chat and input glitches

### DIFF
--- a/apps/expo/app/(app)/ai-chat.tsx
+++ b/apps/expo/app/(app)/ai-chat.tsx
@@ -88,16 +88,17 @@ export default function AIChat() {
       packId: params.packId as string,
       packName: params.packName as string,
       contextType: (params.contextType as 'item' | 'pack' | 'general') || 'general',
-      location: location ? location.name : undefined,
     }),
-    [params.itemId, params.itemName, params.packId, params.packName, params.contextType, location],
+    [params.itemId, params.itemName, params.packId, params.packName, params.contextType],
   );
-  const locationRef = React.useRef(context.location);
-  locationRef.current = context.location;
+  const locationRef = React.useRef(location?.name);
+  locationRef.current = location?.name;
 
   const { data: _authSession } = authClient.useSession();
   const token = _authSession?.session?.token ?? null;
   const userId = _authSession?.user?.id ?? '';
+  const tokenRef = React.useRef(token);
+  tokenRef.current = token;
   const [input, setInput] = React.useState('');
   const [lastUserMessage, setLastUserMessage] = React.useState('');
   const [previousMessages, setPreviousMessages] = React.useState<UIMessage[]>([]);
@@ -178,8 +179,8 @@ export default function AIChat() {
           systemPrompt += `\n- You are currently helping with an item with ID: ${contextRef.current.itemId}.`;
         }
 
-        if (contextRef.current.location) {
-          systemPrompt += `\n- The current location of the user is: ${contextRef.current.location}.`;
+        if (locationRef.current) {
+          systemPrompt += `\n- The current location of the user is: ${locationRef.current}.`;
         }
 
         return {
@@ -193,9 +194,9 @@ export default function AIChat() {
       transport: new DefaultChatTransport({
         fetch: expoFetch as unknown as typeof globalThis.fetch,
         api: `${clientEnvs.EXPO_PUBLIC_API_URL}/api/chat`,
-        headers: {
-          Authorization: `Bearer ${token}`,
-        },
+        headers: () => ({
+          Authorization: `Bearer ${tokenRef.current}`,
+        }),
         body: () => ({
           contextType: contextRef.current.contextType,
           itemId: contextRef.current.itemId,
@@ -206,7 +207,7 @@ export default function AIChat() {
       }),
       transportKey: 'remote',
     };
-  }, [aiMode, isLocalReady, modelStatus, token, tools, userId]);
+  }, [aiMode, isLocalReady, modelStatus, tools, userId]);
 
   // transportKey forces useChat to remount when the transport type switches,
   // since useChat captures the transport reference on mount and won't update it.

--- a/apps/expo/features/pack-templates/screens/PackTemplateItemDetailScreen.tsx
+++ b/apps/expo/features/pack-templates/screens/PackTemplateItemDetailScreen.tsx
@@ -49,7 +49,7 @@ export function PackTemplateItemDetailScreen() {
             params: {
               itemId: item.id,
               itemName: item.name,
-              contextType: 'templateItem',
+              contextType: 'item',
             },
           }),
           showSignInCopy: 'true',
@@ -62,7 +62,7 @@ export function PackTemplateItemDetailScreen() {
       params: {
         itemId: item.id,
         itemName: item.name,
-        contextType: 'templateItem',
+        contextType: 'item',
       },
     });
   };


### PR DESCRIPTION
## Summary

Fixes #2503 — AI chat launched from **Gear Inventory → Ask AI About This Item** was unresponsive (no response to suggestions or typed input) and caused UI glitches.

Three root causes were found and fixed:

- **Auth token captured at transport creation time** (`ai-chat.tsx`): `DefaultChatTransport` was initialised with a static `Authorization` header using the token value at `useMemo` evaluation time. Because `useChat` captures the transport reference on mount and never re-reads it, any request made before `authClient.useSession()` resolved from SecureStore (async on navigation) used a `null` token, returned 401, and silently swallowed the error — so the user saw nothing. Fixed by storing the token in a `tokenRef` and passing `headers` as a lazy function so the live token is read at request time.

- **`location` in `context` causing effect loops** (`ai-chat.tsx`): `location` from `useActiveLocation` was included in the `context` `useMemo`, so every time the active location resolved it changed the `context` reference, re-triggered the persisted-message load effect mid-conversation, and set `isLoadingPersistedRef = true` (blocking message saves). Location is already handled via `locationRef` for the transport body; removing it from `context` eliminates the spurious re-triggers and the resulting input glitches.

- **`contextType: 'templateItem'` unrecognised** (`PackTemplateItemDetailScreen.tsx`): the template item detail screen was passing `contextType='templateItem'`, which fell through every branch in `getContextualSuggestions`, `getChatStorageKey`, and the API system-prompt builder — giving no suggestions and using `chat:general` as the storage key. Changed to `'item'` to match the existing handlers.

## Test plan

- [ ] Open Gear Inventory, tap any item → tap **Ask AI About This Item**
- [ ] Tap a suggested question — confirm AI responds
- [ ] Type a custom message and submit — confirm AI responds and input clears correctly
- [ ] Open a pack template item detail → tap **Ask AI About This Item** — confirm item-specific suggestions appear and AI responds
- [ ] Verify general AI chat (from home dashboard) still works normally