### PR TITLE
fix(gear-inventory): change presentation from modal to card to fix AI chat

### DIFF
--- a/apps/expo/app/(app)/_layout.tsx
+++ b/apps/expo/app/(app)/_layout.tsx
@@ -222,7 +222,7 @@ export default function AppLayout() {
           name="gear-inventory"
           options={{
             headerShown: false,
-            presentation: 'modal',
+            presentation: 'card',
             animation: 'slide_from_bottom',
           }}
         />


### PR DESCRIPTION
## Summary

- Changes `gear-inventory` screen presentation from `modal` to `card` in `apps/expo/app/(app)/_layout.tsx`

## Problem

On iOS, `presentation: 'modal'` causes spurious `keyboardDidHide` events during navigation push animations (e.g., opening item details from within the gear inventory). The custom `TextInput` component applies `useKeyboardHideBlur`, which calls `blur()` on every `keyboardDidHide` event — blurring the AI chat input mid-typing and making suggested questions appear unresponsive.

Pack detail screens use `presentation: 'card'` (the default), so they never trigger this behaviour, which is why AI chat worked correctly when opened from pack details but not from gear inventory.

## Fix

Changing `presentation` to `'card'` eliminates the spurious keyboard events while keeping the existing `slide_from_bottom` animation intact.

## Test plan

- [ ] Open Gear Inventory, tap an item to open item details, then open AI chat
- [ ] Verify typing in the chat input is stable (text does not wipe mid-keystroke)
- [ ] Verify tapping suggested questions produces a response
- [ ] Confirm AI chat still works normally when opened from Pack Details