### PR TITLE
test(web-e2e): close the last failures — 36/36 against a local Neon stack

### DIFF
--- a/apps/expo/app/(app)/ai-chat.tsx
+++ b/apps/expo/app/(app)/ai-chat.tsx
@@ -142,7 +142,9 @@ export default function AIChat() {
       headers: async () => {
         const { data } = await authClient.getSession();
         const token = data?.session?.token ?? '';
-        return token ? { Authorization: `Bearer ${token}` } : {};
+        const headers: Record<string, string> = {};
+        if (token) headers.Authorization = `Bearer ${token}`;
+        return headers;
       },
       body: () => ({
         contextType: contextRef.current.contextType,

--- a/apps/expo/app/(app)/ai-chat.tsx
+++ b/apps/expo/app/(app)/ai-chat.tsx
@@ -90,8 +90,14 @@ export default function AIChat() {
   const locationRef = React.useRef(context.location);
   locationRef.current = context.location;
 
-  const { data: _authSession } = authClient.useSession();
-  const token = _authSession?.session?.token ?? null;
+  // We deliberately don't read `useSession()` data into the transport
+  // closure. On first render `data?.session?.token` is null, the transport
+  // builds with `Authorization: Bearer null`, and the very first send hits
+  // /api/chat unauthenticated — the API responds 401 and useChat shows the
+  // generic "something went wrong" UI. Reading the token lazily via
+  // `authClient.getSession()` at each request (below) avoids that race
+  // entirely; getSession is cached after the first call so this is cheap.
+  authClient.useSession();
   const [input, setInput] = React.useState('');
   const [lastUserMessage, setLastUserMessage] = React.useState('');
   const [previousMessages, setPreviousMessages] = React.useState<UIMessage[]>([]);
@@ -133,8 +139,10 @@ export default function AIChat() {
     return new DefaultChatTransport({
       fetch: expoFetch as unknown as typeof globalThis.fetch,
       api: `${clientEnvs.EXPO_PUBLIC_API_URL}/api/chat`,
-      headers: {
-        Authorization: `Bearer ${token}`,
+      headers: async () => {
+        const { data } = await authClient.getSession();
+        const token = data?.session?.token ?? '';
+        return token ? { Authorization: `Bearer ${token}` } : {};
       },
       body: () => ({
         contextType: contextRef.current.contextType,
@@ -144,7 +152,7 @@ export default function AIChat() {
         date: new Date().toLocaleString(),
       }),
     });
-  }, [aiMode, isLocalReady, token, tools]);
+  }, [aiMode, isLocalReady, tools]);
 
   const { messages, setMessages, error, sendMessage, stop, status } = useChat({
     transport,

--- a/apps/expo/playwright/playwright.config.ts
+++ b/apps/expo/playwright/playwright.config.ts
@@ -7,23 +7,43 @@ export default defineConfig({
   globalSetup: './tests/globalSetup.ts',
   timeout: 30_000,
   expect: { timeout: 10_000 },
-  fullyParallel: false,
+  // Tests create their own data (timestamped names) and otherwise read shared
+  // catalog/profile data, so parallel runs are safe. Override with
+  // PW_WORKERS=1 if you suspect a flake is contention-related.
+  fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
-  workers: 1,
+  workers: Number(process.env.PW_WORKERS ?? (process.env.CI ? 2 : 4)),
   reporter: [['list'], ['html', { open: 'never' }]],
 
   use: {
     baseURL: BASE_URL,
     trace: 'on-first-retry',
     video: 'on-first-retry',
-    headless: true,
+    // Headless by default in CI; headed locally so you can watch the run.
+    // Override with PWHEADLESS=1 to force headless locally.
+    headless: !!process.env.CI || process.env.PWHEADLESS === '1',
   },
 
   projects: [
     {
       name: 'chromium',
-      use: { ...devices['Desktop Chrome'] },
+      // `channel: 'chrome'` uses the locally installed Google Chrome —
+      // Playwright's bundled chromium has no Ubuntu 26.04 build yet.
+      // Playwright already isolates each context with an ephemeral user-data
+      // dir, but `--incognito` makes that explicit.
+      use: {
+        ...devices['Desktop Chrome'],
+        channel: 'chrome',
+        launchOptions: {
+          args: [
+            '--incognito',
+            '--no-default-browser-check',
+            '--no-first-run',
+            '--password-store=basic',
+          ],
+        },
+      },
     },
   ],
 });

--- a/apps/expo/playwright/playwright.config.ts
+++ b/apps/expo/playwright/playwright.config.ts
@@ -20,9 +20,10 @@ export default defineConfig({
     baseURL: BASE_URL,
     trace: 'on-first-retry',
     video: 'on-first-retry',
-    // Headless by default in CI; headed locally so you can watch the run.
-    // Override with PWHEADLESS=1 to force headless locally.
-    headless: !!process.env.CI || process.env.PWHEADLESS === '1',
+    // Headless by default everywhere. Opt into a visible browser with
+    // `PWHEADED=1` — never have the run pop windows on the dev's desktop
+    // unless explicitly requested.
+    headless: process.env.PWHEADED !== '1',
   },
 
   projects: [

--- a/apps/expo/playwright/tests/core.spec.ts
+++ b/apps/expo/playwright/tests/core.spec.ts
@@ -239,7 +239,8 @@ test('settings screen loads', async ({ authedPage: page }) => {
   await page.goto(`${BASE_URL}/settings`);
   await expect(page.getByText('AI Models')).toBeVisible();
   await expect(page.getByText('Danger Zone')).toBeVisible();
-  await expect(page.getByText(/PackRat v/i)).toBeVisible();
+  // Dev/preview builds prepend an environment tag, e.g. "PackRat (Dev) v2.0.26"
+  await expect(page.getByText(/PackRat(?: \([^)]+\))? v\d/i)).toBeVisible();
 });
 
 // ─── AI Chat ──────────────────────────────────────────────────────────────────
@@ -269,6 +270,21 @@ test('AI chat sends message and gets response', async ({ authedPage: page }) => 
 
   // Send a message
   await page.getByRole('textbox', { name: /Ask about this pack/i }).fill('List 3 essential items.');
+  // The chat transport's Authorization header is sourced from
+  // `authClient.useSession()`, which starts as null and resolves on the first
+  // GET /api/auth/get-session. We need both: the network response AND a beat
+  // for React to flush the state update so the memoized transport rebuilds
+  // with the real token. Without the post-response settle, the send fires
+  // with `Bearer null` and the server returns 401.
+  await page
+    .waitForResponse((r) => r.url().includes('/api/auth/get-session') && r.status() === 200, {
+      timeout: 10_000,
+    })
+    .catch(() => {
+      // Session may already be cached on the page — fall through.
+    });
+  // Let React commit the session-loaded state into the chat transport.
+  await page.waitForTimeout(500);
   // Send button is icon-only with no accessible name; use the arrow-up icon character
   await page.getByText('󰁝').click();
 

--- a/apps/expo/playwright/tests/core.spec.ts
+++ b/apps/expo/playwright/tests/core.spec.ts
@@ -270,21 +270,6 @@ test('AI chat sends message and gets response', async ({ authedPage: page }) => 
 
   // Send a message
   await page.getByRole('textbox', { name: /Ask about this pack/i }).fill('List 3 essential items.');
-  // The chat transport's Authorization header is sourced from
-  // `authClient.useSession()`, which starts as null and resolves on the first
-  // GET /api/auth/get-session. We need both: the network response AND a beat
-  // for React to flush the state update so the memoized transport rebuilds
-  // with the real token. Without the post-response settle, the send fires
-  // with `Bearer null` and the server returns 401.
-  await page
-    .waitForResponse((r) => r.url().includes('/api/auth/get-session') && r.status() === 200, {
-      timeout: 10_000,
-    })
-    .catch(() => {
-      // Session may already be cached on the page — fall through.
-    });
-  // Let React commit the session-loaded state into the chat transport.
-  await page.waitForTimeout(500);
   // Send button is icon-only with no accessible name; use the arrow-up icon character
   await page.getByText('󰁝').click();
 

--- a/apps/expo/playwright/tests/globalSetup.ts
+++ b/apps/expo/playwright/tests/globalSetup.ts
@@ -15,7 +15,12 @@ export default async function setup() {
 
   fs.mkdirSync(path.dirname(AUTH_STATE_PATH), { recursive: true });
 
-  const browser = await chromium.launch();
+  const headless = !!process.env.CI || process.env.PWHEADLESS === '1';
+  const browser = await chromium.launch({
+    channel: 'chrome',
+    headless,
+    args: ['--incognito', '--no-default-browser-check', '--no-first-run', '--password-store=basic'],
+  });
   const context = await browser.newContext();
   const page = await context.newPage();
 

--- a/apps/expo/playwright/tests/globalSetup.ts
+++ b/apps/expo/playwright/tests/globalSetup.ts
@@ -15,10 +15,10 @@ export default async function setup() {
 
   fs.mkdirSync(path.dirname(AUTH_STATE_PATH), { recursive: true });
 
-  const headless = !!process.env.CI || process.env.PWHEADLESS === '1';
+  // Headless by default; opt into a visible browser with PWHEADED=1.
   const browser = await chromium.launch({
     channel: 'chrome',
-    headless,
+    headless: process.env.PWHEADED !== '1',
     args: ['--incognito', '--no-default-browser-check', '--no-first-run', '--password-store=basic'],
   });
   const context = await browser.newContext();

--- a/bun.lock
+++ b/bun.lock
@@ -643,7 +643,7 @@
       "name": "@packrat/ui",
       "version": "2.0.25",
       "dependencies": {
-        "@packrat-ai/nativewindui": "^2.0.5",
+        "@packrat-ai/nativewindui": "^2.0.6",
       },
     },
     "packages/units": {

--- a/packages/api/docker-compose.test.yml
+++ b/packages/api/docker-compose.test.yml
@@ -9,7 +9,7 @@ services:
       POSTGRES_PASSWORD: test_password
       POSTGRES_HOST_AUTH_METHOD: trust
     ports:
-      - "5433:5432"
+      - "${POSTGRES_TEST_HOST_PORT:-5433}:5432"
     volumes:
       - postgres_test_data:/var/lib/postgresql/data
     healthcheck:
@@ -32,7 +32,7 @@ services:
       ALLOW_ADDR_REGEX: ".*"
       LOG_CONN_INFO: "true"
     ports:
-      - "5434:80"
+      - "${WSPROXY_HOST_PORT:-5434}:80"
     depends_on:
       postgres-test:
         condition: service_healthy
@@ -48,7 +48,7 @@ services:
     environment:
       PG_CONNECTION_STRING: postgres://test_user:test_password@postgres-test:5432/packrat_test
     ports:
-      - "4444:4444"
+      - "${NEON_PROXY_HOST_PORT:-4444}:4444"
     depends_on:
       postgres-test:
         condition: service_healthy

--- a/packages/api/docker-compose.test.yml
+++ b/packages/api/docker-compose.test.yml
@@ -23,8 +23,8 @@ services:
       -c log_duration=on
       -c max_connections=100
 
-  # Neon-compatible WebSocket proxy so tests use the same @neondatabase/serverless
-  # driver as production — eliminates pg-cloudflare / cloudflare:sockets workarounds.
+  # Neon-compatible WebSocket proxy used by the vitest integration suite
+  # (`packages/api/test/setup.ts`) — speaks WebSocket only.
   wsproxy:
     image: ghcr.io/neondatabase/wsproxy:latest
     environment:
@@ -33,6 +33,22 @@ services:
       LOG_CONN_INFO: "true"
     ports:
       - "5434:80"
+    depends_on:
+      postgres-test:
+        condition: service_healthy
+
+  # Official Neon HTTP+WS local proxy
+  # (https://neon.com/guides/local-development-with-neon). Lets the
+  # `@neondatabase/serverless` HTTP driver (neon(url)) and WebSocket Pool
+  # talk to local Postgres on a single port (4444), so wrangler dev hits the
+  # exact same code paths as prod — no per-request WebSocket lifetime issues.
+  # Used by the Playwright E2E stack.
+  neon-proxy:
+    image: ghcr.io/timowilhelm/local-neon-http-proxy:main
+    environment:
+      PG_CONNECTION_STRING: postgres://test_user:test_password@postgres-test:5432/packrat_test
+    ports:
+      - "4444:4444"
     depends_on:
       postgres-test:
         condition: service_healthy

--- a/packages/api/src/auth/index.ts
+++ b/packages/api/src/auth/index.ts
@@ -202,16 +202,10 @@ export async function getAuth(env: ValidatedEnv): Promise<any> {
     trustedOrigins: [
       env.BETTER_AUTH_URL,
       'packrat://',
-      // Local web dev (Expo web on 8081/8082, Next admin on 3000). Gated on
+      // Local web dev — accept any localhost port so parallel agents on
+      // bumped ports (e.g. 18082) don't need an allowlist update. Gated on
       // the API URL pointing at localhost so prod never widens trust.
-      ...(env.BETTER_AUTH_URL.startsWith('http://localhost')
-        ? [
-            'http://localhost:8081',
-            'http://localhost:8082',
-            'http://localhost:3000',
-            'http://localhost:19006',
-          ]
-        : []),
+      ...(env.BETTER_AUTH_URL.startsWith('http://localhost') ? ['http://localhost:*'] : []),
     ],
   });
 

--- a/packages/api/src/auth/index.ts
+++ b/packages/api/src/auth/index.ts
@@ -199,7 +199,20 @@ export async function getAuth(env: ValidatedEnv): Promise<any> {
       storage: 'secondary-storage',
     },
 
-    trustedOrigins: [env.BETTER_AUTH_URL, 'packrat://'],
+    trustedOrigins: [
+      env.BETTER_AUTH_URL,
+      'packrat://',
+      // Local web dev (Expo web on 8081/8082, Next admin on 3000). Gated on
+      // the API URL pointing at localhost so prod never widens trust.
+      ...(env.BETTER_AUTH_URL.startsWith('http://localhost')
+        ? [
+            'http://localhost:8081',
+            'http://localhost:8082',
+            'http://localhost:3000',
+            'http://localhost:19006',
+          ]
+        : []),
+    ],
   });
 
   authCache.set(env as object, auth);

--- a/packages/api/src/db/index.ts
+++ b/packages/api/src/db/index.ts
@@ -13,8 +13,16 @@ const isStandardPostgresUrl = (url: string) => {
     const host = u.hostname.toLowerCase();
     const isNeonTech = host === 'neon.tech' || host.endsWith('.neon.tech');
     const isNeonCom = host === 'neon.com' || host.endsWith('.neon.com');
+    // `db.localtest.me` is the hostname the local Neon HTTP proxy uses (see
+    // packages/api/docker-compose.test.yml). The URL looks like raw Postgres
+    // but the proxy fronts the real connection and speaks Neon's HTTP/WS
+    // wire format, so we route through the neon driver — same path as prod.
+    const isLocalNeonProxy = host === 'db.localtest.me';
     return (
-      (u.protocol === 'postgres:' || u.protocol === 'postgresql:') && !isNeonTech && !isNeonCom
+      (u.protocol === 'postgres:' || u.protocol === 'postgresql:') &&
+      !isNeonTech &&
+      !isNeonCom &&
+      !isLocalNeonProxy
     );
   } catch {
     return false;

--- a/packages/api/src/db/seed-e2e-catalog.ts
+++ b/packages/api/src/db/seed-e2e-catalog.ts
@@ -155,7 +155,7 @@ async function embedAll(values: string[], openAiKey: string): Promise<number[][]
 
 async function seedCatalog() {
   const dbUrl = nodeEnv.NEON_DATABASE_URL;
-  const openAiKey = process.env.OPENAI_API_KEY;
+  const openAiKey = nodeEnv.OPENAI_API_KEY;
   if (!dbUrl) throw new Error('NEON_DATABASE_URL is required');
   if (!openAiKey) throw new Error('OPENAI_API_KEY is required');
 

--- a/packages/api/src/db/seed-e2e-catalog.ts
+++ b/packages/api/src/db/seed-e2e-catalog.ts
@@ -1,0 +1,214 @@
+/**
+ * Seed a handful of catalog items so the catalog-tab and catalog-search
+ * Playwright tests have data to render and filter against. Idempotent on
+ * SKU — re-running won't duplicate rows.
+ *
+ * Usage:
+ *   NEON_DATABASE_URL=<url> OPENAI_API_KEY=<key> \
+ *     bun run packages/api/src/db/seed-e2e-catalog.ts
+ *
+ * Why this script exists: in production the `catalog_items` table is
+ * populated by the ETL workflow scraping product pages. Local dev DBs
+ * (docker-compose.test.yml) start empty, so anything that scrolls the
+ * catalog tab or runs a similarity search has nothing to find.
+ */
+
+import { neon, neonConfig } from '@neondatabase/serverless';
+import { nodeEnv } from '@packrat/env/node';
+import { drizzle, type NeonHttpDatabase } from 'drizzle-orm/neon-http';
+import { drizzle as drizzlePg, type NodePgDatabase } from 'drizzle-orm/node-postgres';
+import { Client } from 'pg';
+import WebSocket from 'ws';
+import * as schema from './schema';
+
+neonConfig.webSocketConstructor = WebSocket;
+
+const isStandardPostgresUrl = (url: string) => {
+  try {
+    const u = new URL(url);
+    const host = u.hostname.toLowerCase();
+    const isNeonTech = host === 'neon.tech' || host.endsWith('.neon.tech');
+    const isNeonCom = host === 'neon.com' || host.endsWith('.neon.com');
+    return u.protocol === 'postgres:' && !isNeonTech && !isNeonCom;
+  } catch {
+    return false;
+  }
+};
+
+type SeedItem = {
+  sku: string;
+  name: string;
+  description: string;
+  weight: number;
+  weightUnit: 'g' | 'oz';
+  categories: string[];
+  brand?: string;
+};
+
+// A small, hand-picked set covering distinct gear categories so the catalog
+// search test ("sleeping bag") and the add-from-catalog test (just needs at
+// least one item) both have meaningful hits.
+const ITEMS: SeedItem[] = [
+  {
+    sku: 'e2e-sleeping-bag-20f',
+    name: 'Mountain Loft Down Sleeping Bag 20°F',
+    description: 'Lightweight down sleeping bag rated to 20°F for 3-season backpacking.',
+    weight: 980,
+    weightUnit: 'g',
+    categories: ['Sleep System'],
+    brand: 'TrailLab',
+  },
+  {
+    sku: 'e2e-sleeping-bag-30f',
+    name: 'Sierra Lite Sleeping Bag 30°F',
+    description: 'Compact synthetic sleeping bag for summer hiking.',
+    weight: 720,
+    weightUnit: 'g',
+    categories: ['Sleep System'],
+    brand: 'PackRat Gear',
+  },
+  {
+    sku: 'e2e-tent-2p',
+    name: 'Cascade 2P Backpacking Tent',
+    description: 'Two-person freestanding tent, 1.6 kg packed weight, double-wall.',
+    weight: 1600,
+    weightUnit: 'g',
+    categories: ['Shelter'],
+    brand: 'TrailLab',
+  },
+  {
+    sku: 'e2e-backpack-55l',
+    name: '55L Hiking Backpack',
+    description: 'Internal frame pack with hydration sleeve and rain cover.',
+    weight: 1500,
+    weightUnit: 'g',
+    categories: ['Packs'],
+    brand: 'PackRat Gear',
+  },
+  {
+    sku: 'e2e-stove-canister',
+    name: 'Spark Mini Canister Stove',
+    description: 'Pocket-sized canister stove, boils 500ml in 3:30.',
+    weight: 78,
+    weightUnit: 'g',
+    categories: ['Cooking'],
+  },
+  {
+    sku: 'e2e-headlamp',
+    name: 'Beam 350 Headlamp',
+    description: 'Rechargeable 350-lumen headlamp with red-light mode.',
+    weight: 68,
+    weightUnit: 'g',
+    categories: ['Lighting'],
+  },
+  {
+    sku: 'e2e-water-filter',
+    name: 'Squeeze Water Filter',
+    description: 'Hollow-fiber filter that removes 99.99% of bacteria and protozoa.',
+    weight: 90,
+    weightUnit: 'g',
+    categories: ['Water'],
+  },
+  {
+    sku: 'e2e-rain-jacket',
+    name: 'Stormshield Rain Jacket',
+    description: 'Three-layer waterproof breathable shell with pit zips.',
+    weight: 320,
+    weightUnit: 'g',
+    categories: ['Apparel'],
+  },
+  {
+    sku: 'e2e-puffy',
+    name: 'Featherlite 800-Fill Down Jacket',
+    description: 'Insulated puffy jacket for cold belays and camp wear.',
+    weight: 290,
+    weightUnit: 'g',
+    categories: ['Apparel'],
+    brand: 'PackRat Gear',
+  },
+  {
+    sku: 'e2e-sleeping-pad',
+    name: 'Aircell Insulated Sleeping Pad',
+    description: 'R-value 4.2 inflatable sleeping pad, 460 g packed.',
+    weight: 460,
+    weightUnit: 'g',
+    categories: ['Sleep System'],
+  },
+];
+
+async function embedAll(values: string[], openAiKey: string): Promise<number[][]> {
+  const res = await fetch('https://api.openai.com/v1/embeddings', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${openAiKey}`,
+    },
+    body: JSON.stringify({ model: 'text-embedding-3-small', input: values }),
+  });
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`OpenAI embeddings failed ${res.status}: ${body.slice(0, 200)}`);
+  }
+  const json = (await res.json()) as { data: Array<{ embedding: number[] }> };
+  return json.data.map((d) => d.embedding);
+}
+
+async function seedCatalog() {
+  const dbUrl = nodeEnv.NEON_DATABASE_URL;
+  const openAiKey = process.env.OPENAI_API_KEY;
+  if (!dbUrl) throw new Error('NEON_DATABASE_URL is required');
+  if (!openAiKey) throw new Error('OPENAI_API_KEY is required');
+
+  type SeedDatabase = NodePgDatabase<typeof schema> | NeonHttpDatabase<typeof schema>;
+  let db: SeedDatabase;
+  let pgClient: Client | undefined;
+
+  if (isStandardPostgresUrl(dbUrl)) {
+    pgClient = new Client({ connectionString: dbUrl });
+    await pgClient.connect();
+    db = drizzlePg(pgClient, { schema });
+  } else {
+    db = drizzle(neon(dbUrl), { schema });
+  }
+
+  try {
+    const existing = await db.select({ sku: schema.catalogItems.sku }).from(schema.catalogItems);
+    const knownSkus = new Set(existing.map((r) => r.sku));
+    const newItems = ITEMS.filter((i) => !knownSkus.has(i.sku));
+    if (newItems.length === 0) {
+      console.log(`Catalog already seeded (${existing.length} rows).`);
+      return;
+    }
+
+    console.log(`Generating ${newItems.length} embeddings via OpenAI...`);
+    const embeddings = await embedAll(
+      newItems.map((i) => `${i.name}. ${i.description}`),
+      openAiKey,
+    );
+
+    for (let i = 0; i < newItems.length; i++) {
+      const item = newItems[i];
+      const embedding = embeddings[i];
+      if (!item || !embedding) continue;
+      await db.insert(schema.catalogItems).values({
+        name: item.name,
+        productUrl: `https://example.com/${item.sku}`,
+        sku: item.sku,
+        weight: item.weight,
+        weightUnit: item.weightUnit,
+        description: item.description,
+        categories: item.categories,
+        brand: item.brand ?? null,
+        embedding,
+      });
+    }
+    console.log(`Seeded ${newItems.length} catalog items.`);
+  } finally {
+    await pgClient?.end();
+  }
+}
+
+seedCatalog().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/packages/api/src/db/seed-e2e-user.ts
+++ b/packages/api/src/db/seed-e2e-user.ts
@@ -11,7 +11,7 @@
 
 import { neon, neonConfig } from '@neondatabase/serverless';
 import { nodeEnv } from '@packrat/env/node';
-import { eq } from 'drizzle-orm';
+import { and, eq } from 'drizzle-orm';
 import { drizzle, type NeonHttpDatabase } from 'drizzle-orm/neon-http';
 import { drizzle as drizzlePg, type NodePgDatabase } from 'drizzle-orm/node-postgres';
 import { Client } from 'pg';
@@ -64,13 +64,15 @@ async function seedE2EUser() {
       .where(eq(schema.users.email, normalizedEmail))
       .limit(1);
 
+    let userId: string;
     const existingUser = existing[0];
     if (existingUser) {
+      userId = existingUser.id;
       await db
         .update(schema.users)
         .set({ passwordHash, emailVerified: true, updatedAt: new Date() })
-        .where(eq(schema.users.id, existingUser.id));
-      console.log(`E2E user refreshed: ${normalizedEmail} (id=${existingUser.id})`);
+        .where(eq(schema.users.id, userId));
+      console.log(`E2E user refreshed: ${normalizedEmail} (id=${userId})`);
     } else {
       const [inserted] = await db
         .insert(schema.users)
@@ -85,7 +87,37 @@ async function seedE2EUser() {
           role: 'USER',
         })
         .returning();
-      console.log(`E2E user created: ${normalizedEmail} (id=${inserted?.id})`);
+      if (!inserted) throw new Error('users insert returned no row');
+      userId = inserted.id;
+      console.log(`E2E user created: ${normalizedEmail} (id=${userId})`);
+    }
+
+    // Better Auth's email/password sign-in reads the password from the
+    // `account` table (providerId='credential'), not `users.password_hash`.
+    // The 0042 data-migration only copies users → account at migrate time, so
+    // any user created after that migration (this seed, fresh dev DBs) needs
+    // an explicit credential row to be sign-in-able.
+    const existingAccount = await db
+      .select({ id: schema.account.id })
+      .from(schema.account)
+      .where(and(eq(schema.account.userId, userId), eq(schema.account.providerId, 'credential')))
+      .limit(1);
+
+    if (existingAccount[0]) {
+      await db
+        .update(schema.account)
+        .set({ password: passwordHash, updatedAt: new Date() })
+        .where(eq(schema.account.id, existingAccount[0].id));
+      console.log(`Credential account refreshed for ${normalizedEmail}`);
+    } else {
+      await db.insert(schema.account).values({
+        id: crypto.randomUUID(),
+        accountId: userId,
+        providerId: 'credential',
+        userId,
+        password: passwordHash,
+      });
+      console.log(`Credential account created for ${normalizedEmail}`);
     }
   } finally {
     await pgClient?.end();

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -29,7 +29,7 @@ import type { CatalogETLMessage } from './services/etl/types';
 // WebSocket /v2 endpoint (used by neon-serverless Pool) — so prod and local
 // share the exact same driver code paths with no adapter switch.
 let neonLocalConfigured = false;
-function maybeConfigureLocalNeon(databaseUrl: string): void {
+function maybeConfigureLocalNeon(databaseUrl: string, proxyPortOverride?: string): void {
   if (neonLocalConfigured) return;
   try {
     const u = new URL(databaseUrl);
@@ -40,7 +40,7 @@ function maybeConfigureLocalNeon(databaseUrl: string): void {
       host === 'neon.com' ||
       host.endsWith('.neon.com');
     if (isNeon) return;
-    const proxyPort = process.env.NEON_LOCAL_PROXY_PORT ?? '4444';
+    const proxyPort = proxyPortOverride ?? '4444';
     neonConfig.fetchEndpoint = (h) =>
       h === 'db.localtest.me' ? `http://${h}:${proxyPort}/sql` : `https://${h}/sql`;
     neonConfig.wsProxy = (h) => (h === 'db.localtest.me' ? `${h}:${proxyPort}/v2` : `${h}/v2`);
@@ -122,7 +122,7 @@ export default {
   async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
     const e = enrichEnv(env);
     setWorkerEnv(e as unknown as Record<string, unknown>); // safe-cast: setWorkerEnv accepts Record; ValidatedEnv has no index signature by design
-    maybeConfigureLocalNeon(e.NEON_DATABASE_URL);
+    maybeConfigureLocalNeon(e.NEON_DATABASE_URL, e.NEON_LOCAL_PROXY_PORT);
 
     // Route /api/auth/** to Better Auth before Elysia sees it.
     const url = new URL(request.url);

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -8,6 +8,7 @@
 
 import type { MessageBatch } from '@cloudflare/workers-types';
 import { cors } from '@elysiajs/cors';
+import { neonConfig } from '@neondatabase/serverless';
 import { getAuth } from '@packrat/api/auth';
 import { AppContainer } from '@packrat/api/containers';
 import { routes } from '@packrat/api/routes';
@@ -19,6 +20,35 @@ import { packratOpenApi } from '@packrat/api/utils/openapi';
 import { Elysia } from 'elysia';
 import { CloudflareAdapter } from 'elysia/adapter/cloudflare-worker';
 import type { CatalogETLMessage } from './services/etl/types';
+
+// Local-dev hook: route `@neondatabase/serverless` through Neon's official
+// local proxy (`ghcr.io/timowilhelm/local-neon-http-proxy`, recommended by
+// https://neon.com/guides/local-development-with-neon) when NEON_DATABASE_URL
+// points at the local `db.localtest.me` host. The proxy serves both the HTTP
+// /sql API (used by neon-http, which is what auth/index.ts uses) and the
+// WebSocket /v2 endpoint (used by neon-serverless Pool) — so prod and local
+// share the exact same driver code paths with no adapter switch.
+let neonLocalConfigured = false;
+function maybeConfigureLocalNeon(databaseUrl: string): void {
+  if (neonLocalConfigured) return;
+  try {
+    const u = new URL(databaseUrl);
+    const host = u.hostname.toLowerCase();
+    const isNeon =
+      host === 'neon.tech' ||
+      host.endsWith('.neon.tech') ||
+      host === 'neon.com' ||
+      host.endsWith('.neon.com');
+    if (isNeon) return;
+    const proxyPort = process.env.NEON_LOCAL_PROXY_PORT ?? '4444';
+    neonConfig.fetchEndpoint = (h) =>
+      h === 'db.localtest.me' ? `http://${h}:${proxyPort}/sql` : `https://${h}/sql`;
+    neonConfig.wsProxy = (h) => (h === 'db.localtest.me' ? `${h}:${proxyPort}/v2` : `${h}/v2`);
+    neonConfig.useSecureWebSocket = host !== 'db.localtest.me';
+  } finally {
+    neonLocalConfigured = true;
+  }
+}
 
 export const app = new Elysia({ adapter: CloudflareAdapter })
   .use(
@@ -92,13 +122,62 @@ export default {
   async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
     const e = enrichEnv(env);
     setWorkerEnv(e as unknown as Record<string, unknown>); // safe-cast: setWorkerEnv accepts Record; ValidatedEnv has no index signature by design
+    maybeConfigureLocalNeon(e.NEON_DATABASE_URL);
 
     // Route /api/auth/** to Better Auth before Elysia sees it.
     const url = new URL(request.url);
     if (url.pathname.startsWith('/api/auth')) {
+      // Better Auth does not implement CORS preflight (OPTIONS) responses, so
+      // we mirror the Elysia CORS allowlist here. Without this, browser-based
+      // sign-in calls from the web app (a different origin than the API) fail
+      // the preflight and never reach Better Auth.
+      const origin = request.headers.get('Origin');
+      const isAllowedOrigin =
+        !!origin &&
+        [
+          /^https:\/\/(www\.)?packrat\.world$/,
+          /^https:\/\/[\w-]+\.packrat\.world$/,
+          /^https:\/\/[\w-]+\.packratai\.com$/,
+          /^https?:\/\/[\w-]+\.workers\.dev$/,
+          /^http:\/\/localhost:\d+$/,
+          /^exp:\/\//,
+        ].some((re) => re.test(origin));
+
+      const corsHeaders: Record<string, string> = isAllowedOrigin
+        ? {
+            'Access-Control-Allow-Origin': origin,
+            'Access-Control-Allow-Credentials': 'true',
+            Vary: 'Origin',
+          }
+        : {};
+
+      if (request.method === 'OPTIONS') {
+        return new Response(null, {
+          status: 204,
+          headers: {
+            ...corsHeaders,
+            'Access-Control-Allow-Methods': 'GET, POST, PUT, PATCH, DELETE, OPTIONS',
+            'Access-Control-Allow-Headers':
+              request.headers.get('Access-Control-Request-Headers') ??
+              'Content-Type, Authorization, X-API-Key',
+            'Access-Control-Max-Age': '86400',
+          },
+        });
+      }
+
       const validatedEnv = getEnv();
       const auth = await getAuth(validatedEnv);
-      return auth.handler(request);
+      const authResponse = await auth.handler(request);
+      if (!isAllowedOrigin) return authResponse;
+      // Copy Better Auth's response and append CORS headers so cookies/JSON
+      // payloads reach the cross-origin caller.
+      const headers = new Headers(authResponse.headers);
+      for (const [k, v] of Object.entries(corsHeaders)) headers.set(k, v);
+      return new Response(authResponse.body, {
+        status: authResponse.status,
+        statusText: authResponse.statusText,
+        headers,
+      });
     }
 
     return (app.fetch as unknown as CfFetchFn)(request, e, ctx); // safe-cast: Elysia's fetch has Cloudflare-specific env/ctx params not in the standard type

--- a/packages/api/src/utils/env-validation.ts
+++ b/packages/api/src/utils/env-validation.ts
@@ -15,6 +15,10 @@ export const apiEnvSchema = z.object({
   // Optional: trail routes return 503 when absent. For Cloudflare Workers,
   // set to env.OSM_HYPERDRIVE.connectionString (Hyperdrive binding).
   OSM_DATABASE_URL: z.string().url().optional(),
+  // Local-only override for the host port of the local-neon-http-proxy
+  // (docker-compose.test.yml). Worker entry routes the neon driver to this
+  // port when NEON_DATABASE_URL points at db.localtest.me. Defaults to 4444.
+  NEON_LOCAL_PROXY_PORT: z.string().regex(/^\d+$/).optional(),
 
   // Better Auth
   BETTER_AUTH_SECRET: z.string().min(32),

--- a/packages/env/src/node.ts
+++ b/packages/env/src/node.ts
@@ -72,6 +72,9 @@ export const nodeEnvSchema = z.object({
   // ── E2E test credentials ──────────────────────────────────────────
   E2E_TEST_EMAIL: z.string().email().optional(),
   E2E_TEST_PASSWORD: z.string().min(1).optional(),
+
+  // ── OpenAI (packages/api/src/db/seed-e2e-catalog.ts) ──────────────
+  OPENAI_API_KEY: z.string().min(1).optional(),
 });
 
 export type NodeEnv = z.infer<typeof nodeEnvSchema>;
@@ -107,4 +110,5 @@ export const nodeEnv = nodeEnvSchema.parse({
   DEBUG: process.env.DEBUG,
   E2E_TEST_EMAIL: process.env.E2E_TEST_EMAIL,
   E2E_TEST_PASSWORD: process.env.E2E_TEST_PASSWORD,
+  OPENAI_API_KEY: process.env.OPENAI_API_KEY,
 });

--- a/patches/@packrat-ai%2Fnativewindui@2.0.3.patch
+++ b/patches/@packrat-ai%2Fnativewindui@2.0.3.patch
@@ -17,7 +17,7 @@ index 786b62c4a216c360beb193b96092186319a634cb..741aefba1ddf080c103cfca27b14b10c
  import type MaterialIcons from '@expo/vector-icons/MaterialIcons';
  import type { SymbolViewProps } from 'expo-symbols';
 diff --git a/src/components/LargeTitleHeader/LargeTitleHeader.tsx b/src/components/LargeTitleHeader/LargeTitleHeader.tsx
-index 95c66bbdece307542084c2e510c847543134f63e..d9bf7337f45a9b49f69863a16a24672363a3b8af 100644
+index 95c66bbdece307542084c2e510c847543134f63e..1d51bc059291f852567c8123ee93ef5f433a9dfb 100644
 --- a/src/components/LargeTitleHeader/LargeTitleHeader.tsx
 +++ b/src/components/LargeTitleHeader/LargeTitleHeader.tsx
 @@ -1,3 +1,4 @@
@@ -25,3 +25,11 @@ index 95c66bbdece307542084c2e510c847543134f63e..d9bf7337f45a9b49f69863a16a246723
  import { useRoute } from '@react-navigation/native';
  import { useAugmentedRef } from '@rn-primitives/hooks';
  import { Portal } from '@rn-primitives/portal';
+@@ -157,6 +158,7 @@ export function LargeTitleHeader(props: LargeTitleHeaderProps) {
+           <View className="flex-row justify-center gap-3 pr-2">
+             {!!props.searchBar && (
+               <Button
++                testID={props.searchBar.testID}
+                 onPress={() => {
+                   setShowSearchBar(true);
+                   props.searchBar?.onSearchButtonPress?.();


### PR DESCRIPTION
## Summary

Brings the Playwright web suite from **0/36** (couldn't even start against this branch's setup) to **36/36** running headless on a fully local stack — and unblocks running it from `wrangler dev` against a local Postgres at all.

Sits on top of `feat/web-e2e-fix` so the diff is focused on what's new: local-dev infrastructure, two genuine product bugs surfaced by E2E, and a few test polish items.

## What's in here (in commit order)

### Local Neon stack for `wrangler dev`

- 🐳 `docker-compose.test.yml` adds `ghcr.io/timowilhelm/local-neon-http-proxy` on port 4444 alongside the existing wsproxy. Lets `@neondatabase/serverless` (the HTTP driver Better Auth uses, plus the WS Pool) talk to the local pg without any driver/adapter switch. No code change to `auth/index.ts`'s DB connection.
- 🐛 Worker entry sets `neonConfig.fetchEndpoint` + `wsProxy` when `NEON_DATABASE_URL` host is `db.localtest.me`, and `src/db/index.ts` excludes that host from the standard-pg routing so every component (Better Auth + Eden Treaty + queue workers) stays on the same `neon-http` driver path as prod. Also adds CORS preflight handling for `/api/auth/*` — Better Auth's handler returns 404 on `OPTIONS`, so browser-based sign-in from a different origin never reached it.
- 🔒 Better Auth `trustedOrigins` accepts `http://localhost:*` (gated on `BETTER_AUTH_URL.startsWith('http://localhost')`), so any local port works for parallel dev agents without an allowlist update.
- 🔧 `docker-compose.test.yml` host ports are env-var overrideable (`POSTGRES_TEST_HOST_PORT`, `WSPROXY_HOST_PORT`, `NEON_PROXY_HOST_PORT`) — defaults unchanged. Lets two worktrees / two agents bring up the stack on the same box without colliding.

### Seed fixes

- 🌱 `seed-e2e-user.ts` now also inserts the `account` credential row. Better Auth's email/password flow reads the password from `account.password`, not `users.password_hash`. Migration `0042_migrate_auth_data` copies users → account at migrate time — before the E2E user exists — so the seeded user was silently un-signable against a fresh local DB.
- 🌱 New `seed-e2e-catalog.ts` — 10 hand-picked items spanning Sleep System / Shelter / Packs / Cooking / Lighting / Water / Apparel, embeddings via OpenAI `text-embedding-3-small`, idempotent on SKU. Production populates `catalog_items` via the ETL workflow; a fresh local DB has zero rows, which broke every catalog test.

### Two real product bugs surfaced by the E2E pass

- 🏷️ **NativeWindUI `LargeTitleHeader`** — `searchBar.testID` was set on the JSX prop object but never propagated to the rendered icon Button. Patched in `patches/@packrat-ai%2Fnativewindui@2.0.3.patch` so the testID lands on the actual DOM element. Worth a parallel upstream PR (see Follow-ups).
- 🐛 **Expo AI chat** — the chat transport's `Authorization` header was captured from `authClient.useSession()` data at transport-build time. On first render that's `null` → the very first send went out as `Bearer null` → 401 → useChat showed the generic "something went wrong" banner. Switched to `DefaultChatTransport`'s `Resolvable<Record<string, string>>` form: read the token from `authClient.getSession()` lazily at each send (it's cached on native via SecureStore, on web via Better Auth's session atom).

### Test polish

- ✅ Playwright config: `channel: 'chrome'` (Playwright's bundled chromium has no Ubuntu 26.04 build yet), `--incognito`+`--no-default-browser-check`+`--no-first-run`+`--password-store=basic` so the test browser never reads from the dev's real Chrome profile, `fullyParallel: true`, 4 workers (override via `PW_WORKERS`).
- 🔒 **Headless by default everywhere.** Opt into a visible browser with `PWHEADED=1`. Previously local dev was headed by default which pops Chrome windows on the dev's desktop unexpectedly.
- 🩹 `settings screen loads` regex tolerates the `(Dev)` build tag — production builds render `PackRat v…`, dev/preview render `PackRat (Dev) v…`.
- 🔧 New typed-env entries: `OPENAI_API_KEY` in `nodeEnvSchema` for the catalog seed; `NEON_LOCAL_PROXY_PORT` (optional) in `apiEnvSchema` so the local proxy port comes from the validated Worker env, not raw `process.env`.

## Test plan

Verified locally:

- [x] `bun test:expo` — 326/326 pass
- [x] `bun test:api:unit` — 215/215 pass
- [x] `bunx tsc --noEmit` in `apps/expo` — no new errors (1 pre-existing `uuid` type def issue)
- [x] Playwright suite (headless, parallel × 4) — **36/36 in ~60s** on bumped ports (18082 / 18787 / 14444 / 15433 / 15434) and on default ports
- [x] Sign-in works against local pg through neon-http-proxy (HTTP `/sql` endpoint)
- [x] No `.maestro/**` flow files touched; only runtime change in `apps/expo` is the chat transport, which uses the same `authClient` API on iOS/Android

## Local quickstart

```bash
# 1. Bring up pg + wsproxy + neon-proxy
cd packages/api
docker compose -f docker-compose.test.yml up -d

# 2. Point env at the local stack
# (root .env.local)
NEON_DATABASE_URL=postgres://test_user:test_password@db.localtest.me:5433/packrat_test
NEON_DATABASE_URL_READONLY=postgres://test_user:test_password@db.localtest.me:5433/packrat_test
EXPO_PUBLIC_API_URL=http://localhost:8787

# 3. Migrate + seed
bun run db:migrate
NEON_DATABASE_URL=$NEON_DATABASE_URL E2E_TEST_EMAIL=… E2E_TEST_PASSWORD=… bun run db:seed:e2e-user
NEON_DATABASE_URL=$NEON_DATABASE_URL OPENAI_API_KEY=… bun run packages/api/src/db/seed-e2e-catalog.ts

# 4. Bring up API + Expo web
bun api                          # wrangler dev on :8787
bun --cwd apps/expo web          # expo on :8081

# 5. Run the suite
cd apps/expo
TEST_EMAIL=… TEST_PASSWORD=… bun test:web
```

For a parallel agent / second worktree, bump ports:

```bash
POSTGRES_TEST_HOST_PORT=15433 WSPROXY_HOST_PORT=15434 NEON_PROXY_HOST_PORT=14444 \
  COMPOSE_PROJECT_NAME=packrat-playwright \
  docker compose -f docker-compose.test.yml up -d
# Then point NEON_DATABASE_URL at :15433, set NEON_LOCAL_PROXY_PORT=14444,
# wrangler dev --port 18787, expo --port 18082.
```

## Follow-ups (not in this PR)

- Open the parallel upstream PR on `PackRat-AI/nativewindui` for the `searchBar.testID` propagation fix so the local patch can be deleted on next release.
- The chat transport's `useSession()` call is left in place purely to keep the session-fetch on mount; consider removing it once the call-side migration is complete elsewhere.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added E2E catalog seeding with AI-generated product embeddings.
  * Enhanced local development support for configurable database proxy.

* **Bug Fixes**
  * Improved session initialization to prevent authentication race conditions.

* **Tests**
  * Enabled parallel test execution with dynamic worker configuration.
  * Expanded version matching to support environment-tagged build strings.

* **Chores**
  * Updated authentication CORS handling for cross-origin requests.
  * Added environment variable support for local development configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PackRat-AI/PackRat/pull/2511?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->