### PR TITLE
fix(image-cache): prevent infinite spinner and blank renders on bad URLs

### DIFF
--- a/apps/expo/lib/utils/ImageCacheManager.ts
+++ b/apps/expo/lib/utils/ImageCacheManager.ts
@@ -61,7 +61,13 @@ export class ImageCacheManager {
           Accept: 'image/webp,image/apng,image/*,*/*;q=0.8',
         },
       };
-      const downloadResult = await FileSystem.downloadAsync(remoteUrl, localUri, downloadOptions);
+      const timeout = new Promise<never>((_, reject) =>
+        setTimeout(() => reject(new Error('Image download timed out')), 15_000),
+      );
+      const downloadResult = await Promise.race([
+        FileSystem.downloadAsync(remoteUrl, localUri, downloadOptions),
+        timeout,
+      ]);
 
       if (downloadResult.status !== 200) {
         // downloadAsync writes the error response body to disk even on failure;

--- a/apps/expo/lib/utils/ImageCacheManager.ts
+++ b/apps/expo/lib/utils/ImageCacheManager.ts
@@ -69,14 +69,23 @@ export class ImageCacheManager {
         timeout,
       ]);
 
-      if (downloadResult.status !== 200) {
-        // downloadAsync writes the error response body to disk even on failure;
+      const contentType =
+        downloadResult.headers?.['content-type'] ?? downloadResult.headers?.['Content-Type'] ?? '';
+      const invalidContent =
+        downloadResult.status !== 200 || (!contentType.startsWith('image/') && contentType !== '');
+
+      if (invalidContent) {
+        // downloadAsync writes the response body to disk even on failure or wrong content type;
         // delete it so subsequent getCachedImageUri calls don't treat it as a valid cache hit.
         const partialFile = await FileSystem.getInfoAsync(localUri);
         if (partialFile.exists) {
           await FileSystem.deleteAsync(localUri);
         }
-        throw new Error(`Failed to download image: ${downloadResult.status}`);
+        throw new Error(
+          downloadResult.status !== 200
+            ? `Failed to download image: ${downloadResult.status}`
+            : `Invalid content type: ${contentType}`,
+        );
       }
     }
 


### PR DESCRIPTION
## Summary

Two bugs fixed in `ImageCacheManager.cacheRemoteImage`:

- **Infinite spinner with no internet** — `FileSystem.downloadAsync` has no built-in timeout, so with no connectivity and an uncached image the promise never settled and the loading spinner in `CachedImage` spun forever. Fixed by racing the download against a 15-second timeout.

- **Blank image on non-image URLs** — `downloadAsync` returns status 200 for any URL, including ones that serve HTML or JSON. The response body was written to disk and cached, then `Image` rendered it blank. Fixed by validating the `Content-Type` response header and deleting the cached file + throwing if it is not an `image/*` type.

Both failures now surface as the retry state in `CachedImage` instead of a broken/blank UI.

## Test plan

- [ ] Turn off internet, open a screen with an uncached `CachedImage` — confirm spinner stops after ~15s and retry icon appears
- [ ] Re-enable internet, tap retry — confirm image loads and caches successfully
- [ ] Pass a non-image URL (e.g. a webpage) as `imageRemoteUrl` — confirm retry icon appears instead of a blank image
- [ ] Confirm already-cached images still load instantly with no internet