### PR TITLE
fix(ai-chat): remove double-counted safe area from header spacer

### DIFF
--- a/apps/expo/app/(app)/ai-chat.tsx
+++ b/apps/expo/app/(app)/ai-chat.tsx
@@ -359,7 +359,11 @@ export default function AIChat() {
           }}
         >
           <View>
-            <View style={{ height: HEADER_HEIGHT + insets.top }} />
+            <View
+              style={{
+                height: Platform.OS === 'ios' ? insets.top + 44 : HEADER_HEIGHT + insets.top,
+              }}
+            />
             <LocationContext location={location} onSetLocation={setLocation} />
             <DateSeparator
               date={new Date().toLocaleDateString('en-US', {

--- a/apps/expo/app/(app)/ai-chat.tsx
+++ b/apps/expo/app/(app)/ai-chat.tsx
@@ -361,7 +361,7 @@ export default function AIChat() {
           <View>
             <View
               style={{
-                height: Platform.OS === 'ios' ? insets.top + 44 : HEADER_HEIGHT + insets.top,
+                height: Platform.OS === 'ios' ? insets.top + 52 : HEADER_HEIGHT + insets.top,
               }}
             />
             <LocationContext location={location} onSetLocation={setLocation} />


### PR DESCRIPTION
## Summary

- The AI chat scroll view had a blank space below the header because the top spacer used `HEADER_HEIGHT (88) + insets.top`, double-counting the safe area on iOS
- The `AiChatHeader` BlurView's actual height is `insets.top + ~44pt` (nav bar), so the spacer is now `insets.top + 44` on iOS
- Android is unchanged — its header has an explicit height of `HEADER_HEIGHT + insets.top` so that formula is correct

## Test plan

- [ ] Open AI chat on an iPhone with notch (insets.top ≈ 44) — no blank gap below header
- [ ] Open AI chat on a Dynamic Island iPhone (insets.top ≈ 59) — content sits flush below header
- [ ] Open AI chat on Android — header and scroll content spacing unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Adjusted vertical spacing in the AI chat interface for iOS devices to ensure proper layout alignment across content sections.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PackRat-AI/PackRat/pull/2513?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->