### PR TITLE
fix(ai-chat): execute pack/item tools client-side to avoid server sync dependency

### DIFF
--- a/apps/expo/app/(app)/ai-chat.tsx
+++ b/apps/expo/app/(app)/ai-chat.tsx
@@ -1,7 +1,11 @@
 import { type UIMessage, useChat } from '@ai-sdk/react';
 import { clientEnvs } from '@packrat/env/expo-client';
 import { ActivityIndicator, Button, Text } from '@packrat/ui/nativewindui';
-import { DefaultChatTransport, type TextUIPart } from 'ai';
+import {
+  DefaultChatTransport,
+  lastAssistantMessageIsCompleteWithToolCalls,
+  type TextUIPart,
+} from 'ai';
 import * as Burnt from 'burnt';
 import { fetch as expoFetch } from 'expo/fetch';
 import { AiChatHeader } from 'expo-app/components/ai-chatHeader';
@@ -24,6 +28,8 @@ import {
   releaseLocalModel,
 } from 'expo-app/features/ai/lib/localModelManager';
 import { createLocalTools } from 'expo-app/features/ai/lib/tools';
+import { getPackItems, packItemsStore } from 'expo-app/features/packs/store/packItems';
+import { packsStore } from 'expo-app/features/packs/store/packs';
 import { useActiveLocation } from 'expo-app/features/weather/hooks';
 import type { WeatherLocation } from 'expo-app/features/weather/types';
 import { authClient } from 'expo-app/lib/auth-client';
@@ -210,12 +216,55 @@ export default function AIChat() {
 
   // transportKey forces useChat to remount when the transport type switches,
   // since useChat captures the transport reference on mount and won't update it.
-  const { messages, setMessages, error, sendMessage, stop, status } = useChat({
+  const { messages, setMessages, error, sendMessage, stop, status, addToolOutput } = useChat({
     id: transportKey,
     transport,
     onError: (error: Error) => console.log(error, 'ERROR'),
     experimental_throttle: 200,
     messages: initialMessages,
+    sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithToolCalls,
+    onToolCall: ({ toolCall }) => {
+      if (!toolCall.dynamic) return;
+
+      if (toolCall.toolName === 'getPackDetails') {
+        const { packId } = toolCall.input as { packId: string };
+        const pack = packsStore.get()[packId];
+        if (!pack || pack.deleted) {
+          addToolOutput({
+            tool: 'getPackDetails',
+            toolCallId: toolCall.toolCallId,
+            output: { success: false, error: 'Pack not found' },
+          });
+          return;
+        }
+        const items = getPackItems(packId);
+        const categories = Array.from(new Set(items.map((i) => i.category || 'Uncategorized')));
+        addToolOutput({
+          tool: 'getPackDetails',
+          toolCallId: toolCall.toolCallId,
+          output: { success: true, data: { ...pack, items, categories } },
+        });
+        return;
+      }
+
+      if (toolCall.toolName === 'getPackItemDetails') {
+        const { itemId } = toolCall.input as { itemId: string };
+        const item = packItemsStore.get()[itemId];
+        if (!item || item.deleted) {
+          addToolOutput({
+            tool: 'getPackItemDetails',
+            toolCallId: toolCall.toolCallId,
+            output: { success: false, error: 'Item not found' },
+          });
+          return;
+        }
+        addToolOutput({
+          tool: 'getPackItemDetails',
+          toolCallId: toolCall.toolCallId,
+          output: { success: true, data: item },
+        });
+      }
+    },
   });
 
   // Load persisted messages on mount and when context changes

--- a/apps/expo/app/(app)/ai-chat.tsx
+++ b/apps/expo/app/(app)/ai-chat.tsx
@@ -224,7 +224,7 @@ export default function AIChat() {
     messages: initialMessages,
     sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithToolCalls,
     onToolCall: ({ toolCall }) => {
-      if (!toolCall.dynamic) return;
+      if (toolCall.dynamic) return;
 
       if (toolCall.toolName === 'getPackDetails') {
         const { packId } = toolCall.input as { packId: string };

--- a/packages/api/src/routes/chat.ts
+++ b/packages/api/src/routes/chat.ts
@@ -58,9 +58,9 @@ export const chatRoutes = new Elysia({ prefix: '/chat' })
       - Current date is ${date}`;
 
       if (contextType === 'pack' && packId) {
-        systemPrompt += `\n- You are currently helping with a pack with ID: ${packId}.`;
+        systemPrompt += `\n- You are currently helping with a pack with ID: ${packId}. Use the getPackDetails tool to fetch its contents.`;
       } else if (contextType === 'item' && itemId) {
-        systemPrompt += `\n- You are currently helping with an item with ID: ${itemId}.`;
+        systemPrompt += `\n- You are currently helping with an item with ID: ${itemId}. Use the getPackItemDetails tool to fetch its details.`;
       }
 
       if (location) {

--- a/packages/api/src/utils/ai/tools.ts
+++ b/packages/api/src/utils/ai/tools.ts
@@ -1,17 +1,9 @@
-import {
-  AIService,
-  CatalogService,
-  PackItemService,
-  PackService,
-  WeatherService,
-} from '@packrat/api/services';
+import { AIService, CatalogService, WeatherService } from '@packrat/api/services';
 import { executeSqlAiTool } from '@packrat/api/services/executeSqlAiTool';
 import { tool } from 'ai';
 import { z } from 'zod';
 
 export function createTools(userId: string) {
-  const packService = new PackService(userId);
-  const packItemService = new PackItemService(userId);
   const weatherService = new WeatherService();
   const catalogService = new CatalogService();
   const aiService = new AIService();
@@ -19,49 +11,18 @@ export function createTools(userId: string) {
   return {
     getPackDetails: tool({
       description:
-        'Get detailed information about a specific pack including all items, weights, and categories.',
+        'Get detailed information about a specific pack including all items, weights, and categories. Executed client-side from local device data.',
       inputSchema: z.object({
         packId: z.string().describe('The ID of the pack to get details for'),
       }),
-      execute: async ({ packId }) => {
-        try {
-          const pack = await packService.getPackDetails(packId);
-          if (!pack) return { success: false, error: 'Pack not found' };
-
-          const categories = Array.from(
-            new Set(pack.items.map((item) => item.category || 'Uncategorized')),
-          );
-
-          return { success: true, data: { ...pack, categories } };
-        } catch (error) {
-          console.error('getPackDetails tool error', error);
-          return {
-            success: false,
-            error: error instanceof Error ? error.message : 'Failed to get pack details',
-          };
-        }
-      },
     }),
 
     getPackItemDetails: tool({
       description:
-        'Get detailed information about a specific item in a pack including its catalog details.',
+        'Get detailed information about a specific item in a pack including its catalog details. Executed client-side from local device data.',
       inputSchema: z.object({
         itemId: z.string().describe('The ID of the item to get details for'),
       }),
-      execute: async ({ itemId }) => {
-        try {
-          const item = await packItemService.getPackItemDetails(itemId);
-          if (!item) return { success: false, error: 'Item not found' };
-          return { success: true, data: item };
-        } catch (error) {
-          console.error('getPackItemDetails tool error', error);
-          return {
-            success: false,
-            error: error instanceof Error ? error.message : 'Failed to get item details',
-          };
-        }
-      },
     }),
 
     getWeatherForLocation: tool({


### PR DESCRIPTION
## Summary

- `getPackDetails` and `getPackItemDetails` tools no longer have `execute` functions on the server — the AI SDK forwards the calls to the device instead of running them server-side
- `onToolCall` handler added to `ai-chat.tsx` reads directly from `packsStore` / `packItemsStore` (Legend State), which are always current on the device regardless of server sync state
- `sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithToolCalls` wired up so the conversation resumes automatically once client-side tool results are returned

## Why

In cloud mode, starting AI chat for a pack or item that hadn't synced to the server yet caused the server-side tool to return "not found", which errored out the chat. Moving these two tools to client-side execution eliminates the sync dependency entirely — the device always has the data.

All other tools (weather, catalog, RAG, web-search, SQL) continue to execute server-side. Local (on-device) AI mode is unaffected — `CustomChatTransport` runs tools directly via their `execute` functions and never triggers `onToolCall`.

## Test plan

- [ ] Open AI chat from a pack that has not yet synced to the server — chat should start and respond with pack details without error
- [ ] Open AI chat from a pack item that has not yet synced — same expectation
- [ ] Open AI chat from a fully synced pack/item — still works correctly
- [ ] Switch to local (on-device) AI mode — tools still function, `onToolCall` not triggered
- [ ] Ask about weather / catalog / web search in cloud mode — server-side tools still respond correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Enhanced AI Chat tool integration for pack and item details. The system now retrieves information from local device data for improved response accuracy and faster performance when discussing packs and items.
  * Optimized AI assistant tool awareness, enabling more contextually relevant and accurate responses during conversations about pack and item information.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PackRat-AI/PackRat/pull/2514?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->