### PR TITLE
fix(cached-image): self-heal corrupted cache entries on render failure

### DIFF
--- a/apps/expo/features/packs/components/CachedImage.tsx
+++ b/apps/expo/features/packs/components/CachedImage.tsx
@@ -11,6 +11,17 @@ interface CachedImageProps extends Omit<ImageProps, 'source'> {
   placeholderColor?: string;
 }
 
+const CLIENT_ERROR_STATUS_RE = /^Failed to download image: 4\d\d/;
+
+// Errors caused by bad content (wrong content-type, 4xx) are permanent — retrying won't help.
+// Network timeouts and 5xx are transient and worth retrying.
+function isPermanentDownloadError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  return (
+    error.message.startsWith('Invalid content type') || CLIENT_ERROR_STATUS_RE.test(error.message)
+  );
+}
+
 export const CachedImage: React.FC<CachedImageProps> = ({
   imageObjectKey,
   imageRemoteUrl,
@@ -20,6 +31,7 @@ export const CachedImage: React.FC<CachedImageProps> = ({
   const [imageLocalUri, setImageLocalUri] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
   const [hasError, setHasError] = useState(false);
+  const [isPermanentError, setIsPermanentError] = useState(false);
   const [retryCount, setRetryCount] = useState(0);
   const hasClearedCorruptedCache = useRef(false);
 
@@ -46,6 +58,8 @@ export const CachedImage: React.FC<CachedImageProps> = ({
       }
       setRetryCount((c) => c + 1);
     } else {
+      // Second failure after auto-heal attempt — the image content itself is broken.
+      setIsPermanentError(true);
       setHasError(true);
     }
   }, [imageObjectKey]);
@@ -57,6 +71,7 @@ export const CachedImage: React.FC<CachedImageProps> = ({
     const loadImage = async () => {
       setLoading(true);
       setHasError(false);
+      setIsPermanentError(false);
       setImageLocalUri(null);
 
       try {
@@ -88,7 +103,10 @@ export const CachedImage: React.FC<CachedImageProps> = ({
           tags: { feature: 'cachedImage', action: 'loadImage' },
           extra: { imageObjectKey },
         });
-        if (!cancelled) setHasError(true);
+        if (!cancelled) {
+          setIsPermanentError(isPermanentDownloadError(error));
+          setHasError(true);
+        }
       } finally {
         if (!cancelled) setLoading(false);
       }
@@ -112,11 +130,25 @@ export const CachedImage: React.FC<CachedImageProps> = ({
   }
 
   if (hasError) {
+    if (isPermanentError) {
+      return (
+        <View
+          className={placeholderClass}
+          style={placeholderStyle}
+          accessibilityLabel="Image unavailable"
+        >
+          <Icon name="image-off" size={20} color="#999" />
+        </View>
+      );
+    }
     return (
       <Pressable
         className={placeholderClass}
         style={placeholderStyle}
-        onPress={() => setRetryCount((c) => c + 1)}
+        onPress={() => {
+          hasClearedCorruptedCache.current = false;
+          setRetryCount((c) => c + 1);
+        }}
         accessibilityLabel="Tap to retry loading image"
         accessibilityRole="button"
       >

--- a/apps/expo/features/packs/components/CachedImage.tsx
+++ b/apps/expo/features/packs/components/CachedImage.tsx
@@ -2,7 +2,7 @@ import * as Sentry from '@sentry/react-native';
 import { Icon } from 'expo-app/components/Icon';
 import ImageCacheManager from 'expo-app/lib/utils/ImageCacheManager';
 import type React from 'react';
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { ActivityIndicator, Image, type ImageProps, Pressable, View } from 'react-native';
 
 interface CachedImageProps extends Omit<ImageProps, 'source'> {
@@ -21,6 +21,34 @@ export const CachedImage: React.FC<CachedImageProps> = ({
   const [loading, setLoading] = useState(true);
   const [hasError, setHasError] = useState(false);
   const [retryCount, setRetryCount] = useState(0);
+  const hasClearedCorruptedCache = useRef(false);
+
+  useEffect(() => {
+    hasClearedCorruptedCache.current = false;
+  }, [imageObjectKey]);
+
+  const handleImageError = useCallback(async () => {
+    if (!hasClearedCorruptedCache.current) {
+      hasClearedCorruptedCache.current = true;
+      Sentry.addBreadcrumb({
+        category: 'cachedImage',
+        message: 'Cached image failed to render — clearing corrupted cache entry',
+        level: 'warning',
+        data: { imageObjectKey },
+      });
+      try {
+        await ImageCacheManager.clearImage(imageObjectKey);
+      } catch (error) {
+        Sentry.captureException(error, {
+          tags: { feature: 'cachedImage', action: 'clearCorruptedCache' },
+          extra: { imageObjectKey },
+        });
+      }
+      setRetryCount((c) => c + 1);
+    } else {
+      setHasError(true);
+    }
+  }, [imageObjectKey]);
 
   useEffect(() => {
     if (!imageObjectKey || !imageRemoteUrl) return;
@@ -97,5 +125,7 @@ export const CachedImage: React.FC<CachedImageProps> = ({
     );
   }
 
-  return <Image source={{ uri: imageLocalUri ?? undefined }} {...props} />;
+  return (
+    <Image source={{ uri: imageLocalUri ?? undefined }} onError={handleImageError} {...props} />
+  );
 };


### PR DESCRIPTION
## Summary

- Previously cached image files that were downloaded before the content-type validation fix (e.g. HTML error pages stored as image files) would pass the `getCachedImageUri` existence check and be served to `<Image>`, rendering nothing.
- `CachedImage` now handles `Image.onError` by deleting the corrupted cached file and triggering one automatic re-download, which goes through the existing content-type validation in `cacheRemoteImage`.
- A `hasClearedCorruptedCache` ref prevents infinite retry loops — if the fresh download also fails to render, the component falls through to the existing error state (tap-to-retry icon).

## Test plan

- [x] Open a pack item that has a locally cached image — it renders normally
- [x] Corrupt the cache file manually (e.g. write HTML bytes to the cache path) and re-open the item — it should flash a spinner, auto-heal, and display the correct image
- [ ] If the remote URL itself is broken, the component shows the tap-to-retry error state rather than looping

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced cached image stability with improved error handling. When an image fails to load due to cache corruption, the app now automatically clears the problematic cache and retries the load. If the issue persists, users see a retry option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->