### PR TITLE
feat(pack-stats): add pack picker with search

### DIFF
--- a/apps/expo/app/(app)/_layout.tsx
+++ b/apps/expo/app/(app)/_layout.tsx
@@ -164,7 +164,6 @@ export default function AppLayout() {
         <Stack.Screen
           name="pack-stats/[id]"
           options={{
-            headerShown: false,
             presentation: 'modal',
             animation: 'slide_from_bottom',
           }}

--- a/apps/expo/app/(app)/pack-stats/[id].tsx
+++ b/apps/expo/app/(app)/pack-stats/[id].tsx
@@ -32,7 +32,7 @@ export default function PackStatsScreen() {
 
   return (
     <SafeAreaView className="flex-1" edges={['bottom']}>
-      <LargeTitleHeader title={t('packs.packStats')} />
+      <LargeTitleHeader title={pack?.name ?? t('packs.packStats')} />
       {weightHistory || CATEGORY_DISTRIBUTION ? (
         <ScrollView className="flex-1 px-4" contentInsetAdjustmentBehavior="automatic">
           {/* Weight History Section */}

--- a/apps/expo/features/ai/components/LocationContext.tsx
+++ b/apps/expo/features/ai/components/LocationContext.tsx
@@ -19,7 +19,7 @@ export function LocationContext({ location, onSetLocation }: LocationContextProp
 
   if (!location) {
     return (
-      <View className="px-4 py-2">
+      <View className="px-4 pb-2 pt-4">
         <TouchableOpacity
           onPress={() => router.push('/weather')}
           className="bg-muted/30 flex-row items-center gap-2 rounded-full px-3 py-2"
@@ -34,7 +34,7 @@ export function LocationContext({ location, onSetLocation }: LocationContextProp
 
   return (
     <>
-      <View className="px-4 py-2">
+      <View className="px-4 pb-2 pt-4">
         <TouchableOpacity
           onPress={() => setShowLocationPicker(true)}
           className="bg-muted/30 flex-row items-center gap-2 rounded-full px-3 py-2"

--- a/apps/expo/features/packs/components/PackStatsTile.tsx
+++ b/apps/expo/features/packs/components/PackStatsTile.tsx
@@ -1,30 +1,60 @@
 import type { AlertMethods } from '@packrat/ui/nativewindui';
-import { Alert, ListItem } from '@packrat/ui/nativewindui';
+import { Alert, ListItem, Text } from '@packrat/ui/nativewindui';
 import { Icon } from 'expo-app/components/Icon';
+import { SearchInput } from 'expo-app/components/SearchInput';
 import { useColorScheme } from 'expo-app/lib/hooks/useColorScheme';
 import { useTranslation } from 'expo-app/lib/hooks/useTranslation';
-import { type Href, useRouter } from 'expo-router';
-import { useRef } from 'react';
-import { Platform, View } from 'react-native';
+import { useRouter } from 'expo-router';
+import { useRef, useState } from 'react';
+import { Modal, Platform, Pressable, ScrollView, TouchableOpacity, View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { usePacks } from '../hooks';
+import type { PackInStore } from '../types';
+
+const CATEGORY_ICONS: Record<string, string> = {
+  hiking: 'walk',
+  backpacking: 'bag-personal',
+  camping: 'tent',
+  climbing: 'image-filter-hdr',
+  winter: 'snowflake',
+  skiing: 'ski',
+  'water sports': 'waves',
+  desert: 'weather-sunny',
+  custom: 'cog',
+};
 
 export function PackStatsTile() {
   const { t } = useTranslation();
   const router = useRouter();
+  const { colors } = useColorScheme();
+  const insets = useSafeAreaInsets();
 
   const packs = usePacks();
-  const currentPack = packs[0];
-
   const alertRef = useRef<AlertMethods>(null);
+  const [pickerVisible, setPickerVisible] = useState(false);
+  const [query, setQuery] = useState('');
 
-  const route: Href | null = currentPack ? `/pack-stats/${currentPack.id}` : null;
+  const filteredPacks = query.trim()
+    ? packs.filter((p) => p.name.toLowerCase().includes(query.toLowerCase()))
+    : packs;
 
   const handlePress = () => {
-    if (!route) {
+    if (packs.length === 0) {
       alertRef.current?.show();
       return;
     }
-    router.push(route);
+    if (packs.length === 1) {
+      const only = packs[0];
+      if (only) router.push(`/pack-stats/${only.id}`);
+      return;
+    }
+    setQuery('');
+    setPickerVisible(true);
+  };
+
+  const handlePickPack = (pack: PackInStore) => {
+    setPickerVisible(false);
+    router.push(`/pack-stats/${pack.id}`);
   };
 
   return (
@@ -44,27 +74,84 @@ export function PackStatsTile() {
             <ChevronRight />
           </View>
         }
-        item={{
-          title: t('packs.packStats'),
-        }}
+        item={{ title: t('packs.packStats') }}
         onPress={handlePress}
         target="Cell"
         index={0}
         removeSeparator={Platform.OS === 'ios'}
       />
+
       <Alert
         title={t('packs.noPacksYet')}
         message={t('packs.createPackForStats')}
         materialIcon={{ name: 'information-outline' }}
         materialWidth={370}
-        buttons={[
-          {
-            text: t('packs.gotIt'),
-            style: 'default',
-          },
-        ]}
+        buttons={[{ text: t('packs.gotIt'), style: 'default' }]}
         ref={alertRef}
       />
+
+      <Modal
+        visible={pickerVisible}
+        animationType="slide"
+        presentationStyle="pageSheet"
+        onRequestClose={() => setPickerVisible(false)}
+      >
+        <View className="flex-1 bg-background">
+          {/* Header */}
+          <View className="flex-row items-center gap-3 border-b border-border px-4 py-3">
+            <TouchableOpacity onPress={() => setPickerVisible(false)}>
+              <Icon name="close" size={20} color={colors.foreground} />
+            </TouchableOpacity>
+            <Text className="text-lg font-semibold">{t('packs.selectPack')}</Text>
+          </View>
+
+          {/* Search bar */}
+          <View className="border-b border-border px-4 py-2">
+            <SearchInput
+              value={query}
+              onChangeText={setQuery}
+              placeholder={t('packs.searchPacks')}
+              autoCorrect={false}
+            />
+          </View>
+
+          {/* Pack list */}
+          <ScrollView contentContainerStyle={{ padding: 16, gap: 8 }}>
+            {filteredPacks.length === 0 ? (
+              <View className="items-center py-12">
+                <Text className="text-muted-foreground">{t('packs.noPacksFound')}</Text>
+              </View>
+            ) : (
+              filteredPacks.map((pack) => {
+                const icon = CATEGORY_ICONS[pack.category] ?? 'bag-personal';
+                return (
+                  <Pressable
+                    key={pack.id}
+                    onPress={() => handlePickPack(pack)}
+                    className="flex-row items-center rounded-xl border border-border bg-card p-4"
+                    style={({ pressed }) => (pressed ? { opacity: 0.7 } : {})}
+                  >
+                    <View className="mr-3 h-10 w-10 items-center justify-center rounded-full bg-blue-500/10">
+                      <Icon name={icon} size={20} color={colors.primary} />
+                    </View>
+                    <View className="flex-1">
+                      <Text className="font-semibold">{pack.name}</Text>
+                      {pack.category ? (
+                        <Text variant="footnote" className="capitalize text-muted-foreground">
+                          {pack.category}
+                        </Text>
+                      ) : null}
+                    </View>
+                    <Icon name="chevron-right" size={16} color={colors.grey} />
+                  </Pressable>
+                );
+              })
+            )}
+          </ScrollView>
+
+          <View style={{ height: insets.bottom }} />
+        </View>
+      </Modal>
     </>
   );
 }

--- a/apps/expo/lib/i18n/locales/en.json
+++ b/apps/expo/lib/i18n/locales/en.json
@@ -260,6 +260,7 @@
     "noCategorizedItems": "Either there are no items in this pack or they aren't categorized yet.",
     "organizeGear": "Organize your gear by functional categories",
     "packStats": "Pack Stats",
+    "selectPack": "Select a Pack",
     "weightHistory": "Weight History",
     "categoryDistribution": "Category Distribution",
     "packWeightOverMonths": "Pack weight over the last 6 months (g)",


### PR DESCRIPTION
## Summary

- **Pack picker modal**: Tapping Pack Stats now opens a `pageSheet` modal listing all packs (name + category icon) instead of silently navigating to the first pack in the store. When only one pack exists it still navigates directly.
- **Search**: The modal includes a `SearchInput` bar that filters packs by name live, with a "No packs found" empty state.
- **Pack name in header**: The stats screen now shows the selected pack's name as the large title instead of the generic "Pack Stats" string. On iOS this required removing `headerShown: false` from the layout route so `LargeTitleHeader` can set the native nav bar title.
- **Missing translation key**: Added `packs.selectPack` to `en.json`; it was previously rendering as the raw key string.

## Test plan

- [ ] With 0 packs: tapping Pack Stats tile shows the "No Packs Yet" alert
- [ ] With 1 pack: tapping navigates directly to that pack's stats (no picker shown)
- [ ] With 2+ packs: picker modal opens, all packs listed with name and category
- [ ] Search filters the list correctly; clearing search restores full list
- [ ] Selecting a pack navigates to the correct pack's stats screen
- [ ] Stats screen title shows the pack name on both iOS and Android
- [ ] Modal title shows "Select a Pack" (not the raw translation key)