### PR TITLE
fix(expo/ai): remove auth gate from local AI in pack/item detail screens

### DIFF
--- a/apps/expo/app/(app)/ai-chat.tsx
+++ b/apps/expo/app/(app)/ai-chat.tsx
@@ -449,7 +449,9 @@ export default function AIChat() {
               className="self-start ml-4 mb-8"
             />
           )}
-          {status === 'error' && <ErrorState error={error} onRetry={() => handleRetry()} />}
+          {status === 'error' && (
+            <ErrorState error={error} onRetry={() => handleRetry()} onClear={handleClear} />
+          )}
           {messages.length < 2 && (
             <View className="pl-4 pr-16">
               <Text className="mb-2 text-xs text-muted-foreground mt-0">{t('ai.suggestions')}</Text>

--- a/apps/expo/features/ai/components/ErrorState.tsx
+++ b/apps/expo/features/ai/components/ErrorState.tsx
@@ -38,26 +38,16 @@ export function ErrorState({ error, onRetry, onClear }: ErrorStateProps) {
           <Text variant="caption1" className="text-muted-foreground">
             {t('errors.contextOverflow.hint')}
           </Text>
-          <View className="flex-row gap-3 pt-1">
-            {onClear && (
-              <Pressable
-                onPress={onClear}
-                className="flex-1 items-center rounded-lg bg-destructive py-2"
-              >
-                <Text variant="caption1" className="font-medium text-white">
-                  {t('errors.contextOverflow.clearChat')}
-                </Text>
-              </Pressable>
-            )}
+          {onClear && (
             <Pressable
-              onPress={onRetry}
-              className="flex-1 items-center rounded-lg border border-border py-2"
+              onPress={onClear}
+              className="items-center rounded-lg bg-destructive py-2 px-4 self-start"
             >
-              <Text variant="caption1" className="font-medium text-foreground">
-                {t('errors.tryAgain')}
+              <Text variant="caption1" className="font-medium text-white">
+                {t('errors.contextOverflow.clearChat')}
               </Text>
             </Pressable>
-          </View>
+          )}
         </CardContent>
       </Card>
     );

--- a/apps/expo/features/ai/components/ErrorState.tsx
+++ b/apps/expo/features/ai/components/ErrorState.tsx
@@ -7,13 +7,61 @@ import { Pressable, View } from 'react-native';
 interface ErrorStateProps {
   error?: Error;
   onRetry: () => void;
+  onClear?: () => void;
 }
 
-export function ErrorState({ error, onRetry }: ErrorStateProps) {
+const CONTEXT_OVERFLOW_PATTERNS = ['Context is full', 'Context limit reached'];
+
+function isContextOverflow(error: Error): boolean {
+  return CONTEXT_OVERFLOW_PATTERNS.some((pattern) => error.message.includes(pattern));
+}
+
+export function ErrorState({ error, onRetry, onClear }: ErrorStateProps) {
   const { colors } = useColorScheme();
   const { t } = useTranslation();
 
   if (!error) return null;
+
+  if (isContextOverflow(error)) {
+    return (
+      <Card rootClassName="border border-border rounded-xl bg-inherit shadow-none mx-4">
+        <CardContent className="gap-3">
+          <View className="flex-row items-center gap-2">
+            <Ionicons name="warning-outline" size={20} color={colors.destructive} />
+            <Text variant="subhead" className="font-semibold text-foreground">
+              {t('errors.contextOverflow.title')}
+            </Text>
+          </View>
+          <Text variant="caption1" className="text-muted-foreground">
+            {t('errors.contextOverflow.description')}
+          </Text>
+          <Text variant="caption1" className="text-muted-foreground">
+            {t('errors.contextOverflow.hint')}
+          </Text>
+          <View className="flex-row gap-3 pt-1">
+            {onClear && (
+              <Pressable
+                onPress={onClear}
+                className="flex-1 items-center rounded-lg bg-destructive py-2"
+              >
+                <Text variant="caption1" className="font-medium text-white">
+                  {t('errors.contextOverflow.clearChat')}
+                </Text>
+              </Pressable>
+            )}
+            <Pressable
+              onPress={onRetry}
+              className="flex-1 items-center rounded-lg border border-border py-2"
+            >
+              <Text variant="caption1" className="font-medium text-foreground">
+                {t('errors.tryAgain')}
+              </Text>
+            </Pressable>
+          </View>
+        </CardContent>
+      </Card>
+    );
+  }
 
   return (
     <Card rootClassName="border border-border rounded-xl bg-inherit shadow-none mx-4">

--- a/apps/expo/features/pack-templates/screens/PackTemplateItemDetailScreen.tsx
+++ b/apps/expo/features/pack-templates/screens/PackTemplateItemDetailScreen.tsx
@@ -3,7 +3,6 @@ import { Button, Text, useColorScheme } from '@packrat/ui/nativewindui';
 import { Icon } from 'expo-app/components/Icon';
 import { Chip } from 'expo-app/components/initial/Chip';
 import { WeightBadge } from 'expo-app/components/initial/WeightBadge';
-import { isAuthed } from 'expo-app/features/auth/store';
 import { useTranslation } from 'expo-app/lib/hooks/useTranslation';
 import {
   calculateTotalWeight,
@@ -40,23 +39,6 @@ export function PackTemplateItemDetailScreen() {
   const itemNotes = getNotes(item);
 
   const navigateToChat = () => {
-    if (!isAuthed.peek()) {
-      return router.push({
-        pathname: '/auth',
-        params: {
-          redirectTo: JSON.stringify({
-            pathname: '/ai-chat',
-            params: {
-              itemId: item.id,
-              itemName: item.name,
-              contextType: 'templateItem',
-            },
-          }),
-          showSignInCopy: 'true',
-        },
-      });
-    }
-
     router.push({
       pathname: '/ai-chat',
       params: {

--- a/apps/expo/features/packs/screens/PackDetailScreen.tsx
+++ b/apps/expo/features/packs/screens/PackDetailScreen.tsx
@@ -281,22 +281,6 @@ export function PackDetailScreen() {
     cn(activeTab === tab ? 'text-primary' : 'text-muted-foreground');
 
   const handleAskAI = () => {
-    if (!isAuthed.peek()) {
-      return router.push({
-        pathname: '/auth',
-        params: {
-          redirectTo: JSON.stringify({
-            pathname: '/ai-chat',
-            params: {
-              packId: id,
-              packName: pack.name,
-              contextType: 'pack',
-            },
-          }),
-          showSignInCopy: 'true',
-        },
-      });
-    }
     router.push({
       pathname: '/ai-chat',
       params: {

--- a/apps/expo/features/packs/screens/PackItemDetailScreen.tsx
+++ b/apps/expo/features/packs/screens/PackItemDetailScreen.tsx
@@ -3,7 +3,6 @@ import { ActivityIndicator, Button, Text, useColorScheme } from '@packrat/ui/nat
 import { Icon } from 'expo-app/components/Icon';
 import { Chip } from 'expo-app/components/initial/Chip';
 import { WeightBadge } from 'expo-app/components/initial/WeightBadge';
-import { isAuthed } from 'expo-app/features/auth/store';
 import { useTranslation } from 'expo-app/lib/hooks/useTranslation';
 import {
   calculateTotalWeight,
@@ -107,22 +106,6 @@ export function ItemDetailScreen() {
   const itemNotes = getNotes(item);
 
   const navigateToChat = () => {
-    if (!isAuthed.peek()) {
-      return router.push({
-        pathname: '/auth',
-        params: {
-          redirectTo: JSON.stringify({
-            pathname: '/ai-chat',
-            params: {
-              itemId: item.id,
-              itemName: item.name,
-              contextType: 'item',
-            },
-          }),
-          showSignInCopy: 'true',
-        },
-      });
-    }
     router.push({
       pathname: '/ai-chat',
       params: {

--- a/apps/expo/lib/i18n/locales/en.json
+++ b/apps/expo/lib/i18n/locales/en.json
@@ -53,7 +53,13 @@
     "tryAgain": "Try again",
     "tryAgainButton": "Try Again",
     "unexpectedError": "The application encountered an unexpected error. You can try again or go back to the home screen.",
-    "error": "Error"
+    "error": "Error",
+    "contextOverflow": {
+      "title": "Conversation too long",
+      "description": "The on-device model ran out of context window. Local AI can only hold a limited amount of conversation history at once.",
+      "hint": "Clear the chat to start a fresh conversation, or switch to cloud mode for longer sessions.",
+      "clearChat": "Clear chat"
+    }
   },
   "auth": {
     "signIn": "Sign In",


### PR DESCRIPTION
## Summary

- Remove `isAuthed` redirect from `handleAskAI` in `PackDetailScreen` — navigates to `/ai-chat` which supports on-device local AI
- Remove `isAuthed` redirect from `navigateToChat` in `PackItemDetailScreen` and `PackTemplateItemDetailScreen`
- Drop now-unused `isAuthed` imports from both item detail screens
- `handleAnalyzeGapsPress` (gap analysis) retains its auth check — that path calls the server API

Local AI runs fully on-device via llama.rn / Apple Foundation Models and requires no server token, so blocking unauthenticated users from entering the chat was unnecessary.

## Test plan

- [x] Open a pack as a guest (not signed in) and tap "Ask AI" — should navigate to ai-chat without auth redirect
- [ ] Open a pack item detail as a guest and tap the AI chat button — should navigate without redirect
- [ ] Open a pack template item detail as a guest and tap the AI chat button — same
- [ ] Confirm "Analyze Gaps" on a pack still prompts sign-in when unauthenticated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented context overflow detection in AI chat with a dedicated error message and "clear chat" option to help users manage long conversations.

* **Improvements**
  * Simplified navigation to AI chat—users can now access the feature directly from pack and template screens without authentication redirects.

* **Localization**
  * Added localized error messages for context overflow scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->