### PR TITLE
fix(expo/pack-stats): meaningful empty states with Open Pack action

### DIFF
--- a/apps/expo/app/(app)/pack-stats/[id].tsx
+++ b/apps/expo/app/(app)/pack-stats/[id].tsx
@@ -1,21 +1,22 @@
-import { LargeTitleHeader, Text } from '@packrat/ui/nativewindui';
+import { Button, LargeTitleHeader, Text } from '@packrat/ui/nativewindui';
 import { featureFlags } from 'expo-app/config';
 import { userStore } from 'expo-app/features/auth/store';
 import { usePackDetailsFromStore } from 'expo-app/features/packs/hooks/usePackDetailsFromStore';
 import { usePackWeightHistory } from 'expo-app/features/packs/hooks/usePackWeightHistory';
 import { computeCategorySummaries } from 'expo-app/features/packs/utils';
 import { useTranslation } from 'expo-app/lib/hooks/useTranslation';
-import { useLocalSearchParams } from 'expo-router';
+import { useLocalSearchParams, useRouter } from 'expo-router';
 import { ScrollView, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
 export default function PackStatsScreen() {
   const params = useLocalSearchParams();
-  const packId = params.id;
+  const packId = params.id as string;
   const { t } = useTranslation();
+  const router = useRouter();
 
-  const pack = usePackDetailsFromStore(params.id as string);
-  const weightHistory = usePackWeightHistory(packId as string);
+  const pack = usePackDetailsFromStore(packId);
+  const weightHistory = usePackWeightHistory(packId);
 
   const categories = computeCategorySummaries(pack);
   const CATEGORY_DISTRIBUTION = categories.map((category) => ({
@@ -33,61 +34,69 @@ export default function PackStatsScreen() {
   return (
     <SafeAreaView className="flex-1" edges={['bottom']}>
       <LargeTitleHeader title={pack?.name ?? t('packs.packStats')} />
-      {weightHistory || CATEGORY_DISTRIBUTION ? (
-        <ScrollView className="flex-1 px-4" contentInsetAdjustmentBehavior="automatic">
-          {/* Weight History Section */}
-          {WEIGHT_HISTORY && (
-            <View className="my-4 rounded-lg bg-card p-4">
-              <Text variant="heading" className="mb-12 font-semibold">
-                {t('packs.weightHistory')}
-              </Text>
+      <ScrollView className="flex-1 px-4" contentInsetAdjustmentBehavior="automatic">
+        {/* Weight History Section */}
+        <View className="my-4 rounded-lg bg-card p-4">
+          <Text variant="heading" className="mb-4 font-semibold">
+            {t('packs.weightHistory')}
+          </Text>
 
+          {WEIGHT_HISTORY && WEIGHT_HISTORY.length > 0 ? (
+            <>
               <View className="mb-2 h-40 flex-row items-end justify-between">
-                {WEIGHT_HISTORY.length ? (
-                  WEIGHT_HISTORY.map((item) => {
-                    const maxWeight = Math.max(...WEIGHT_HISTORY.map((w) => w.weight));
-                    const minWeight = Math.min(...WEIGHT_HISTORY.map((w) => w.weight));
-                    const range = maxWeight - minWeight || 1;
-                    const heightPercentage = ((item.weight - minWeight) / range) * 80 + 20;
+                {WEIGHT_HISTORY.map((item) => {
+                  const maxWeight = Math.max(...WEIGHT_HISTORY.map((w) => w.weight));
+                  const minWeight = Math.min(...WEIGHT_HISTORY.map((w) => w.weight));
+                  const range = maxWeight - minWeight || 1;
+                  const heightPercentage = ((item.weight - minWeight) / range) * 80 + 20;
 
-                    return (
-                      <View key={`${item.month}-${item.weight}`} className="flex-1 items-center">
-                        <View
-                          className="w-6 rounded-t-md bg-primary"
-                          style={{ height: `${heightPercentage}%` }}
-                        />
-                        <Text variant="caption2" className="mt-1">
-                          {item.month}
-                        </Text>
-                        <Text variant="caption2" className="text-muted-foreground">
-                          {item.weight.toFixed(1)} g
-                        </Text>
-                      </View>
-                    );
-                  })
-                ) : (
-                  <Text
-                    variant="largeTitle"
-                    className="mx-auto mt-2 self-center text-center text-muted-foreground"
-                  >
-                    N/A
-                  </Text>
-                )}
+                  return (
+                    <View key={`${item.month}-${item.weight}`} className="flex-1 items-center">
+                      <View
+                        className="w-6 rounded-t-md bg-primary"
+                        style={{ height: `${heightPercentage}%` }}
+                      />
+                      <Text variant="caption2" className="mt-1">
+                        {item.month}
+                      </Text>
+                      <Text variant="caption2" className="text-muted-foreground">
+                        {item.weight.toFixed(1)} g
+                      </Text>
+                    </View>
+                  );
+                })}
               </View>
-
               <Text variant="footnote" className="mt-2 text-center text-muted-foreground">
                 {t('packs.packWeightOverMonths')}
               </Text>
+            </>
+          ) : (
+            <View className="items-center gap-3 py-6">
+              <Text variant="subhead" className="text-center font-medium">
+                No weight history yet
+              </Text>
+              <Text variant="footnote" className="text-center text-muted-foreground">
+                Add gear to your pack — your pack weight over time will appear here.
+              </Text>
+              <Button
+                variant="secondary"
+                size="sm"
+                onPress={() => router.push({ pathname: '/pack/[id]', params: { id: packId } })}
+              >
+                <Text>Open Pack</Text>
+              </Button>
             </View>
           )}
+        </View>
 
-          {/* Category Distribution Section */}
-          {CATEGORY_DISTRIBUTION && (
-            <View className="my-4 rounded-lg bg-card p-4">
-              <Text variant="heading" className="mb-4 font-semibold">
-                {t('packs.categoryDistribution')}
-              </Text>
+        {/* Category Distribution Section */}
+        <View className="my-4 rounded-lg bg-card p-4">
+          <Text variant="heading" className="mb-4 font-semibold">
+            {t('packs.categoryDistribution')}
+          </Text>
 
+          {CATEGORY_DISTRIBUTION.length > 0 ? (
+            <>
               <View className="mb-4">
                 {CATEGORY_DISTRIBUTION.map((item) => (
                   <View key={item.name} className="mb-2">
@@ -110,54 +119,65 @@ export default function PackStatsScreen() {
                   </View>
                 ))}
               </View>
-
               <Text variant="footnote" className="mt-2 text-center text-muted-foreground">
                 {t('packs.weightDistribution')}
               </Text>
-            </View>
-          )}
-
-          {/* Pack Insights Section */}
-          {featureFlags.enablePackInsights && (
-            <View className="my-4 mb-8 rounded-lg bg-card p-4">
-              <Text variant="heading" className="mb-4 font-semibold">
-                {t('packs.packInsights')}
+            </>
+          ) : (
+            <View className="items-center gap-3 py-6">
+              <Text variant="subhead" className="text-center font-medium">
+                No categorized items
               </Text>
-
-              <View className="mb-3 rounded-md bg-muted p-3 dark:bg-gray-100/5">
-                <Text variant="subhead" className="font-medium">
-                  {t('packs.lighterThanSimilar')}
-                </Text>
-                <Text variant="footnote" className="mt-1 text-muted-foreground">
-                  {t('packs.basedOnData')}
-                </Text>
-              </View>
-
-              <View className="mb-3 rounded-md bg-muted p-3 dark:bg-gray-100/5">
-                <Text variant="subhead" className="font-medium">
-                  {t('packs.reducedWeight')}
-                </Text>
-                <Text variant="footnote" className="mt-1 text-muted-foreground">
-                  {t('packs.weightReduction')}
-                </Text>
-              </View>
-
-              <View className="rounded-md bg-muted p-3 dark:bg-gray-100/5">
-                <Text variant="subhead" className="font-medium">
-                  {t('packs.heaviestCategory')}
-                </Text>
-                <Text variant="footnote" className="mt-1 text-muted-foreground">
-                  {t('packs.considerUltralight')}
-                </Text>
-              </View>
+              <Text variant="footnote" className="text-center text-muted-foreground">
+                Add items to your pack and assign categories to see weight distribution.
+              </Text>
+              <Button
+                variant="secondary"
+                size="sm"
+                onPress={() => router.push({ pathname: '/pack/[id]', params: { id: packId } })}
+              >
+                <Text>Open Pack</Text>
+              </Button>
             </View>
           )}
-        </ScrollView>
-      ) : (
-        <View className="flex-1 items-center justify-center">
-          <Text>{t('packs.noStatsAvailable')}</Text>
         </View>
-      )}
+
+        {/* Pack Insights Section */}
+        {featureFlags.enablePackInsights && (
+          <View className="my-4 mb-8 rounded-lg bg-card p-4">
+            <Text variant="heading" className="mb-4 font-semibold">
+              {t('packs.packInsights')}
+            </Text>
+
+            <View className="mb-3 rounded-md bg-muted p-3 dark:bg-gray-100/5">
+              <Text variant="subhead" className="font-medium">
+                {t('packs.lighterThanSimilar')}
+              </Text>
+              <Text variant="footnote" className="mt-1 text-muted-foreground">
+                {t('packs.basedOnData')}
+              </Text>
+            </View>
+
+            <View className="mb-3 rounded-md bg-muted p-3 dark:bg-gray-100/5">
+              <Text variant="subhead" className="font-medium">
+                {t('packs.reducedWeight')}
+              </Text>
+              <Text variant="footnote" className="mt-1 text-muted-foreground">
+                {t('packs.weightReduction')}
+              </Text>
+            </View>
+
+            <View className="rounded-md bg-muted p-3 dark:bg-gray-100/5">
+              <Text variant="subhead" className="font-medium">
+                {t('packs.heaviestCategory')}
+              </Text>
+              <Text variant="footnote" className="mt-1 text-muted-foreground">
+                {t('packs.considerUltralight')}
+              </Text>
+            </View>
+          </View>
+        )}
+      </ScrollView>
     </SafeAreaView>
   );
 }

--- a/apps/expo/app/(app)/pack-stats/[id].tsx
+++ b/apps/expo/app/(app)/pack-stats/[id].tsx
@@ -81,7 +81,7 @@ export default function PackStatsScreen() {
               <Button
                 variant="secondary"
                 size="sm"
-                onPress={() => router.push({ pathname: '/pack/[id]', params: { id: packId } })}
+                onPress={() => router.dismissTo({ pathname: '/pack/[id]', params: { id: packId } })}
               >
                 <Text>Open Pack</Text>
               </Button>
@@ -134,7 +134,7 @@ export default function PackStatsScreen() {
               <Button
                 variant="secondary"
                 size="sm"
-                onPress={() => router.push({ pathname: '/pack/[id]', params: { id: packId } })}
+                onPress={() => router.dismissTo({ pathname: '/pack/[id]', params: { id: packId } })}
               >
                 <Text>Open Pack</Text>
               </Button>


### PR DESCRIPTION
## Summary

- Replace the bare "N/A" in the Weight History card with an explanatory message and an **Open Pack** button
- Add an empty state to the Category Distribution card (previously rendered nothing) with the same explanation + action pattern
- Both **Open Pack** buttons navigate to the pack detail screen (`/pack/[id]`)
- Removed the now-redundant outer truthy-array guard that was never actually hiding either section

## Test plan

- [ ] Open a pack with no weight history — Weight History card shows "No weight history yet" with a subtitle and **Open Pack** button
- [ ] Open a pack with no categorized items — Category Distribution card shows "No categorized items" with a subtitle and **Open Pack** button
- [ ] Tapping **Open Pack** navigates to the correct pack detail screen
- [ ] Packs with existing data still render the charts/bars correctly