### PR TITLE
fix(expo/upcoming-trips): fix misaligned "Not Started" status badge spacing

### DIFF
--- a/apps/expo/app/(app)/upcoming-trips.tsx
+++ b/apps/expo/app/(app)/upcoming-trips.tsx
@@ -186,7 +186,7 @@ function UpcomingTripsScreenInner() {
               {...info}
               // leftView={<TripImage uri={trip.imageUrl} />}
               rightView={
-                <View className="flex-row items-center">
+                <View className="flex-row items-center pr-4">
                   <PackStatus status={status} completion={completion} />
                 </View>
               }


### PR DESCRIPTION
## Summary

- Adds `pr-4` right padding to the `rightView` wrapper in the Upcoming Trips list
- `ListItem` intentionally removes its own `pr-4` content padding when a `rightView` is provided, leaving the status badge flush against the screen edge
- This one-line fix restores the 16 px gap that matches the rest of the list UI

Fixes #2516