### PR TITLE
🐛 fix(ci): complete max-params migration — green CI on main (api, mcp, checks)

### DIFF
--- a/apps/expo/lib/utils/__tests__/getRelativeTime.test.ts
+++ b/apps/expo/lib/utils/__tests__/getRelativeTime.test.ts
@@ -116,4 +116,19 @@ describe('getRelativeTime', () => {
     getRelativeTime({ dateValue: 'not-a-date', t: t as never });
     expect(t).toHaveBeenCalledWith('common.timeAgo.justNow');
   });
+
+  it('accepts a Date object input', () => {
+    vi.setSystemTime(new Date('2024-01-01T12:05:00Z'));
+    const result = getRelativeTime({ dateValue: new Date('2024-01-01T12:00:00Z') });
+    expect(result).toBe('5 minutes ago');
+  });
+
+  it('returns "Just now" for an invalid Date object with no translator', () => {
+    expect(getRelativeTime({ dateValue: new Date('not-a-real-date') })).toBe('Just now');
+  });
+
+  it('returns "Just now" for null/undefined with no translator', () => {
+    expect(getRelativeTime({ dateValue: null })).toBe('Just now');
+    expect(getRelativeTime({ dateValue: undefined })).toBe('Just now');
+  });
 });

--- a/packages/analytics/test/core/cache-metadata.test.ts
+++ b/packages/analytics/test/core/cache-metadata.test.ts
@@ -1,6 +1,7 @@
 import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import {
+  dbPath,
   loadMetadata,
   metadataPath,
   needsUpdate,
@@ -45,6 +46,15 @@ describe('cache metadata', () => {
     expect(result).not.toBeNull();
     expect(result?.record_count).toBe(5);
     expect(result?.sites).toEqual([]);
+  });
+
+  it('returns null when the metadata file is not valid JSON', () => {
+    writeFileSync(metadataPath(TEST_DIR), 'not valid json{');
+    expect(loadMetadata(TEST_DIR)).toBeNull();
+  });
+
+  it('dbPath resolves the duckdb file inside the cache dir', () => {
+    expect(dbPath(TEST_DIR)).toBe(join(TEST_DIR, 'packrat_cache.duckdb'));
   });
 
   describe('needsUpdate', () => {

--- a/packages/analytics/test/core/spec-parser.test.ts
+++ b/packages/analytics/test/core/spec-parser.test.ts
@@ -228,7 +228,7 @@ describe('SpecParser DB queries', () => {
       limit: 5,
     });
     expect(specs).toEqual([{ name: 'Tent' }]);
-    const sql = runAndReadAll.mock.calls[0][0] as string;
+    const sql = String(runAndReadAll.mock.calls[0]?.[0]);
     expect(sql).toContain('WHERE');
     expect(sql).toContain('weight_grams IS NOT NULL');
     expect(sql).toContain('ORDER BY price');
@@ -238,7 +238,7 @@ describe('SpecParser DB queries', () => {
     const { parser, runAndReadAll } = makeParser([], []);
     const specs = await parser.filterProducts({});
     expect(specs).toEqual([]);
-    const sql = runAndReadAll.mock.calls[0][0] as string;
+    const sql = String(runAndReadAll.mock.calls[0]?.[0]);
     expect(sql).not.toContain('WHERE');
     expect(sql).toContain('ORDER BY weight_grams');
   });

--- a/packages/analytics/test/core/spec-parser.test.ts
+++ b/packages/analytics/test/core/spec-parser.test.ts
@@ -1,3 +1,4 @@
+import type { DuckDBConnection } from '@duckdb/node-api';
 import {
   extractSpecsFromRow,
   parseCapacityLiters,
@@ -7,8 +8,9 @@ import {
   parseTempRatingF,
   parseWaterproofRating,
   parseWeightGrams,
+  SpecParser,
 } from '@packrat/analytics/core/spec-parser';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 describe('parseWeightGrams', () => {
   it('parses compound lbs + oz', () => {
@@ -184,5 +186,60 @@ describe('extractSpecsFromRow', () => {
     expect(specs.weight_grams).toBeNull();
     expect(specs.fill_power).toBeNull();
     expect(specs.seasons).toBeNull();
+  });
+});
+
+describe('SpecParser DB queries', () => {
+  const makeParser = (columns: string[], rows: unknown[][]) => {
+    const runAndReadAll = vi.fn().mockResolvedValue({
+      columnNames: () => columns,
+      getRows: () => rows,
+    });
+    const conn = { runAndReadAll } as unknown as DuckDBConnection;
+    return { parser: new SpecParser({ conn }), runAndReadAll };
+  };
+
+  it('getProductSpecs maps result rows to objects by column name', async () => {
+    const { parser } = makeParser(
+      ['name', 'brand'],
+      [
+        ['Half Dome', 'REI'],
+        ['Hornet', 'NEMO'],
+      ],
+    );
+    const specs = await parser.getProductSpecs({ query: "tent's" });
+    expect(specs).toEqual([
+      { name: 'Half Dome', brand: 'REI' },
+      { name: 'Hornet', brand: 'NEMO' },
+    ]);
+  });
+
+  it('filterProducts builds a WHERE clause from every provided filter', async () => {
+    const { parser, runAndReadAll } = makeParser(['name'], [['Tent']]);
+    const specs = await parser.filterProducts({
+      category: 'tent',
+      maxWeightG: 1500,
+      maxTempF: 30,
+      maxPrice: 600,
+      minPrice: 50,
+      gender: "women's",
+      seasons: '3-season',
+      sortBy: 'price',
+      limit: 5,
+    });
+    expect(specs).toEqual([{ name: 'Tent' }]);
+    const sql = runAndReadAll.mock.calls[0][0] as string;
+    expect(sql).toContain('WHERE');
+    expect(sql).toContain('weight_grams IS NOT NULL');
+    expect(sql).toContain('ORDER BY price');
+  });
+
+  it('filterProducts omits WHERE and uses defaults when no filters are given', async () => {
+    const { parser, runAndReadAll } = makeParser([], []);
+    const specs = await parser.filterProducts({});
+    expect(specs).toEqual([]);
+    const sql = runAndReadAll.mock.calls[0][0] as string;
+    expect(sql).not.toContain('WHERE');
+    expect(sql).toContain('ORDER BY weight_grams');
   });
 });

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -177,7 +177,7 @@ const handler: ExportedHandler<Env> = {
     setWorkerEnv(enrichEnv(env) as unknown as Record<string, unknown>); // safe-cast: same as fetch handler above
 
     if (controller.cron === '0 9 * * *') {
-      const result = await sweepInvalidItemLogs(env);
+      const result = await sweepInvalidItemLogs({ env });
       console.log(
         `[retention] invalid_item_logs sweep: deleted=${result.deleted} ` +
           `iterations=${result.iterations} capped=${result.capped} ` +

--- a/packages/api/src/services/etl/processLogsBatch.ts
+++ b/packages/api/src/services/etl/processLogsBatch.ts
@@ -26,13 +26,16 @@ export async function processLogsBatch({
       },
     });
 
-    logger.info('etl.invalid_logs.persisted', { jobId, count: logs.length });
+    logger.info({ event: 'etl.invalid_logs.persisted', ctx: { jobId, count: logs.length } });
   } catch (error) {
     // Rethrow — invalid_item_logs is the forensic record of what failed
     // validation. Silently swallowing a DB write loss here means an
     // operator chasing a data-quality complaint has no trail. Closes
     // audit P2 #2.
-    logger.error('etl.invalid_logs.persist_failed', { jobId, count: logs.length, err: error });
+    logger.error({
+      event: 'etl.invalid_logs.persist_failed',
+      ctx: { jobId, count: logs.length, err: error },
+    });
     throw error;
   }
 }

--- a/packages/api/src/services/etl/processValidItemsBatch.ts
+++ b/packages/api/src/services/etl/processValidItemsBatch.ts
@@ -60,10 +60,13 @@ export async function processValidItemsBatch({
     // items minus their vectors), but we record the degradation on
     // etl_jobs.total_embedding_failures so operators see the count via
     // the admin endpoint without trawling logs. Closes audit P2 #3.
-    logger.warn('etl.embedding.fallback', {
-      jobId,
-      skuCount: items.length,
-      errorName: error instanceof Error ? error.name : 'unknown',
+    logger.warn({
+      event: 'etl.embedding.fallback',
+      ctx: {
+        jobId,
+        skuCount: items.length,
+        errorName: error instanceof Error ? error.name : 'unknown',
+      },
     });
 
     const upsertedItems = await catalogService.upsertCatalogItems(mergedItems);
@@ -85,6 +88,6 @@ export async function processValidItemsBatch({
       })
       .where(eq(etlJobs.id, jobId));
   } finally {
-    logger.info('etl.valid_items.batch_complete', { jobId, count: items.length });
+    logger.info({ event: 'etl.valid_items.batch_complete', ctx: { jobId, count: items.length } });
   }
 }

--- a/packages/api/src/services/retention/__tests__/invalidLogRetention.test.ts
+++ b/packages/api/src/services/retention/__tests__/invalidLogRetention.test.ts
@@ -47,7 +47,7 @@ describe('sweepInvalidItemLogs', () => {
 
   it('returns deleted=0 / iterations=1 when the first batch is empty', async () => {
     setBatches([[]]);
-    const result = await sweepInvalidItemLogs({} as Env);
+    const result = await sweepInvalidItemLogs({ env: {} as Env });
     expect(result.deleted).toBe(0);
     expect(result.iterations).toBe(1);
     expect(result.capped).toBe(false);
@@ -58,7 +58,7 @@ describe('sweepInvalidItemLogs', () => {
     const fullBatch: FakeRow[] = Array.from({ length: 10_000 }, () => ({ id: 1 }));
     setBatches([fullBatch, fullBatch, [{ id: 1 }], []]);
 
-    const result = await sweepInvalidItemLogs({} as Env);
+    const result = await sweepInvalidItemLogs({ env: {} as Env });
 
     expect(result.deleted).toBe(20_001);
     expect(result.iterations).toBe(4);
@@ -69,7 +69,7 @@ describe('sweepInvalidItemLogs', () => {
     const fullBatch: FakeRow[] = Array.from({ length: 100 }, () => ({ id: 1 }));
     setBatches([fullBatch, fullBatch, fullBatch, fullBatch, fullBatch]);
 
-    const result = await sweepInvalidItemLogs({} as Env, { maxIterations: 3 });
+    const result = await sweepInvalidItemLogs({ env: {} as Env, options: { maxIterations: 3 } });
 
     expect(result.iterations).toBe(3);
     expect(result.capped).toBe(true);
@@ -78,13 +78,13 @@ describe('sweepInvalidItemLogs', () => {
 
   it('honors a custom retentionDays option', async () => {
     setBatches([[]]);
-    const result = await sweepInvalidItemLogs({} as Env, { retentionDays: 30 });
+    const result = await sweepInvalidItemLogs({ env: {} as Env, options: { retentionDays: 30 } });
     expect(result.retentionDays).toBe(30);
   });
 
   it('falls back to the default retentionDays when the option is zero or negative', async () => {
     setBatches([[]]);
-    const result = await sweepInvalidItemLogs({} as Env, { retentionDays: 0 });
+    const result = await sweepInvalidItemLogs({ env: {} as Env, options: { retentionDays: 0 } });
     expect(result.retentionDays).toBe(90);
   });
 });

--- a/packages/api/src/services/retention/invalidLogRetention.ts
+++ b/packages/api/src/services/retention/invalidLogRetention.ts
@@ -45,10 +45,13 @@ export type RetentionOptions = {
  * that on first execution, the function returns `capped: true` and the
  * remainder is swept on subsequent runs.
  */
-export async function sweepInvalidItemLogs(
-  env: Env,
-  options: RetentionOptions = {},
-): Promise<RetentionResult> {
+export async function sweepInvalidItemLogs({
+  env,
+  options = {},
+}: {
+  env: Env;
+  options?: RetentionOptions;
+}): Promise<RetentionResult> {
   const retentionDays =
     options.retentionDays !== undefined && options.retentionDays > 0
       ? options.retentionDays

--- a/packages/api/src/utils/__tests__/auth.test.ts
+++ b/packages/api/src/utils/__tests__/auth.test.ts
@@ -66,7 +66,7 @@ describe('auth utilities', () => {
 
   describe('timingSafeEqual', () => {
     it('rejects when the first value is longer than the second', () => {
-      expect(timingSafeEqual('test-api-key-extra', 'test-api-key')).toBe(false);
+      expect(timingSafeEqual({ a: 'test-api-key-extra', b: 'test-api-key' })).toBe(false);
     });
   });
 });

--- a/packages/api/src/utils/__tests__/embeddingHelper.test.ts
+++ b/packages/api/src/utils/__tests__/embeddingHelper.test.ts
@@ -285,7 +285,7 @@ describe('embeddingHelper', () => {
         name: 'Pants',
         variants: [{ attribute: 'Color', values: 'Black' as unknown as string[] }],
       };
-      const result = getEmbeddingText(item);
+      const result = getEmbeddingText({ item });
       expect(result).toContain('Color: Black');
     });
 
@@ -294,7 +294,7 @@ describe('embeddingHelper', () => {
       const existingItem = {
         variants: [{ attribute: 'Size', values: 'Large' as unknown as string[] }],
       };
-      const result = getEmbeddingText(item, existingItem);
+      const result = getEmbeddingText({ item, existingItem });
       expect(result).toContain('Size: Large');
     });
   });

--- a/packages/api/src/utils/__tests__/logger.test.ts
+++ b/packages/api/src/utils/__tests__/logger.test.ts
@@ -46,7 +46,7 @@ describe('logger', () => {
 
   describe('info', () => {
     it('emits a JSON line with level=INFO and event', () => {
-      logger.info('etl.test');
+      logger.info({ event: 'etl.test' });
       expect(logSpy).toHaveBeenCalledOnce();
       const line = parseLastLine(logSpy);
       expect(line.level).toBe('INFO');
@@ -55,7 +55,7 @@ describe('logger', () => {
     });
 
     it('merges ctx fields into the emitted line', () => {
-      logger.info('etl.test', { jobId: 'j1', count: 42 });
+      logger.info({ event: 'etl.test', ctx: { jobId: 'j1', count: 42 } });
       const line = parseLastLine(logSpy);
       expect(line.jobId).toBe('j1');
       expect(line.count).toBe(42);
@@ -65,7 +65,7 @@ describe('logger', () => {
       const ctx: Record<string, unknown> = {};
       ctx.self = ctx;
 
-      logger.info('etl.circular', ctx);
+      logger.info({ event: 'etl.circular', ctx: ctx });
 
       const line = parseLastLine(logSpy);
       expect(line).toMatchObject({
@@ -78,7 +78,7 @@ describe('logger', () => {
 
   describe('warn', () => {
     it('emits to console.warn with level=WARN', () => {
-      logger.warn('etl.fallback', { jobId: 'j2' });
+      logger.warn({ event: 'etl.fallback', ctx: { jobId: 'j2' } });
       expect(warnSpy).toHaveBeenCalledOnce();
       const line = parseLastLine(warnSpy);
       expect(line.level).toBe('WARN');
@@ -89,7 +89,7 @@ describe('logger', () => {
 
   describe('error', () => {
     it('emits to console.error with level=ERROR', () => {
-      logger.error('etl.failed', { jobId: 'j3' });
+      logger.error({ event: 'etl.failed', ctx: { jobId: 'j3' } });
       expect(errorSpy).toHaveBeenCalledOnce();
       const line = parseLastLine(errorSpy);
       expect(line.level).toBe('ERROR');
@@ -100,7 +100,7 @@ describe('logger', () => {
     it('unpacks an Error attached as ctx.err into errorName / errorMessage / errorStack', () => {
       const err = new Error('boom');
       err.name = 'BoomError';
-      logger.error('etl.failed', { jobId: 'j4', err });
+      logger.error({ event: 'etl.failed', ctx: { jobId: 'j4', err } });
       const line = parseLastLine(errorSpy);
       expect(line.errorName).toBe('BoomError');
       expect(line.errorMessage).toBe('boom');
@@ -110,14 +110,14 @@ describe('logger', () => {
     });
 
     it('coerces a non-Error err to a string errorMessage', () => {
-      logger.error('etl.failed', { err: 'plain string' });
+      logger.error({ event: 'etl.failed', ctx: { err: 'plain string' } });
       const line = parseLastLine(errorSpy);
       expect(line.errorMessage).toBe('plain string');
       expect(line.errorName).toBeUndefined();
     });
 
     it('omits err-related fields when no err is provided', () => {
-      logger.error('etl.failed', { jobId: 'j5' });
+      logger.error({ event: 'etl.failed', ctx: { jobId: 'j5' } });
       const line = parseLastLine(errorSpy);
       expect(line.errorName).toBeUndefined();
       expect(line.errorMessage).toBeUndefined();
@@ -129,11 +129,14 @@ describe('logger', () => {
     it('adds info breadcrumbs with primitive tags and complex extras', () => {
       sentry.isInitialized.mockReturnValue(true);
 
-      logger.info('etl.started', {
-        jobId: 'j1',
-        count: 42,
-        dryRun: true,
-        metadata: { source: 'test' },
+      logger.info({
+        event: 'etl.started',
+        ctx: {
+          jobId: 'j1',
+          count: 42,
+          dryRun: true,
+          metadata: { source: 'test' },
+        },
       });
 
       expect(sentry.addBreadcrumb).toHaveBeenCalledWith({
@@ -152,7 +155,7 @@ describe('logger', () => {
     it('adds warn breadcrumbs at warning level', () => {
       sentry.isInitialized.mockReturnValue(true);
 
-      logger.warn('etl.retry', { jobId: 'j2' });
+      logger.warn({ event: 'etl.retry', ctx: { jobId: 'j2' } });
 
       expect(sentry.addBreadcrumb).toHaveBeenCalledWith({
         category: 'etl.retry',
@@ -168,10 +171,13 @@ describe('logger', () => {
       sentry.isInitialized.mockReturnValue(true);
       const err = new Error('boom');
 
-      logger.error('etl.failed', {
-        err,
-        jobId: 'j3',
-        metadata: { source: 'test' },
+      logger.error({
+        event: 'etl.failed',
+        ctx: {
+          err,
+          jobId: 'j3',
+          metadata: { source: 'test' },
+        },
       });
 
       expect(sentry.captureException).toHaveBeenCalledWith(err, {
@@ -189,7 +195,7 @@ describe('logger', () => {
     it('captures error events without error objects as messages', () => {
       sentry.isInitialized.mockReturnValue(true);
 
-      logger.error('etl.failed', { jobId: 'j4' });
+      logger.error({ event: 'etl.failed', ctx: { jobId: 'j4' } });
 
       expect(sentry.captureMessage).toHaveBeenCalledWith('etl.failed', {
         level: 'error',
@@ -208,7 +214,7 @@ describe('logger', () => {
         throw new Error('sentry unavailable');
       });
 
-      expect(() => logger.info('etl.best-effort')).not.toThrow();
+      expect(() => logger.info({ event: 'etl.best-effort' })).not.toThrow();
       expect(logSpy).toHaveBeenCalledOnce();
     });
   });

--- a/packages/api/src/utils/__tests__/sentry.test.ts
+++ b/packages/api/src/utils/__tests__/sentry.test.ts
@@ -1,0 +1,101 @@
+// Unit tests for the Sentry API helpers.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const scope = vi.hoisted(() => ({
+  setTag: vi.fn(),
+  setExtra: vi.fn(),
+}));
+
+const sentry = vi.hoisted(() => ({
+  addBreadcrumb: vi.fn(),
+  captureException: vi.fn(),
+  captureMessage: vi.fn(),
+  setUser: vi.fn(),
+  withScope: vi.fn((cb: (s: typeof scope) => void) => cb(scope)),
+}));
+
+vi.mock('@sentry/cloudflare', () => sentry);
+
+import {
+  apiAddBreadcrumb,
+  captureApiException,
+  clearApiUser,
+  setApiUser,
+} from '@packrat/api/utils/sentry';
+
+describe('sentry helpers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('captureApiException', () => {
+    it('tags operation + user_id, applies tags/extra, and captures the error', () => {
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+      const error = new Error('boom');
+
+      captureApiException({
+        error,
+        operation: 'pack.create',
+        userId: 'u1',
+        tags: { feature: 'packs' },
+        extra: { packId: 'p1' },
+      });
+
+      expect(sentry.withScope).toHaveBeenCalledOnce();
+      expect(scope.setTag).toHaveBeenCalledWith('operation', 'pack.create');
+      expect(scope.setTag).toHaveBeenCalledWith('user_id', 'u1');
+      expect(scope.setTag).toHaveBeenCalledWith('feature', 'packs');
+      expect(scope.setExtra).toHaveBeenCalledWith('packId', 'p1');
+      expect(sentry.captureException).toHaveBeenCalledWith(error);
+      expect(errorSpy).toHaveBeenCalledWith('[sentry][pack.create]', error);
+
+      errorSpy.mockRestore();
+    });
+
+    it('omits user_id / tags / extra when they are not provided', () => {
+      vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+      captureApiException({ error: new Error('x'), operation: 'op' });
+
+      expect(scope.setTag).toHaveBeenCalledWith('operation', 'op');
+      expect(scope.setTag).not.toHaveBeenCalledWith('user_id', expect.anything());
+      expect(scope.setExtra).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('apiAddBreadcrumb', () => {
+    it('adds a default-type breadcrumb with the provided fields', () => {
+      apiAddBreadcrumb({
+        category: 'etl',
+        message: 'started',
+        level: 'info',
+        data: { jobId: 'j1' },
+      });
+
+      expect(sentry.addBreadcrumb).toHaveBeenCalledWith({
+        type: 'default',
+        category: 'etl',
+        message: 'started',
+        level: 'info',
+        data: { jobId: 'j1' },
+      });
+    });
+  });
+
+  describe('setApiUser / clearApiUser', () => {
+    it('maps role to username when setting the user', () => {
+      setApiUser({ id: 'u1', email: 'a@b.co', role: 'ADMIN' });
+      expect(sentry.setUser).toHaveBeenCalledWith({
+        id: 'u1',
+        email: 'a@b.co',
+        username: 'ADMIN',
+      });
+    });
+
+    it('clears the user context', () => {
+      clearApiUser();
+      expect(sentry.setUser).toHaveBeenCalledWith(null);
+    });
+  });
+});

--- a/packages/api/src/utils/json-utils.ts
+++ b/packages/api/src/utils/json-utils.ts
@@ -121,12 +121,12 @@ export function mapJsonRowToItem(obj: Record<string, unknown>): Partial<NewCatal
   const unitStr = isString(rawWeightUnit) ? rawWeightUnit : undefined;
 
   if (isNumber(rawWeight) && rawWeight > 0) {
-    const { weight, unit } = parseWeight(String(rawWeight), unitStr);
+    const { weight, unit } = parseWeight({ weightStr: String(rawWeight), unitStr });
     item.weight = weight ?? undefined;
     const parsedUnit = WeightUnitSchema.safeParse(unit);
     item.weightUnit = parsedUnit.success ? parsedUnit.data : undefined;
   } else if (isString(rawWeight) && parseFloat(rawWeight) > 0) {
-    const { weight, unit } = parseWeight(rawWeight, unitStr);
+    const { weight, unit } = parseWeight({ weightStr: rawWeight, unitStr });
     item.weight = weight ?? undefined;
     const parsedUnit = WeightUnitSchema.safeParse(unit);
     item.weightUnit = parsedUnit.success ? parsedUnit.data : undefined;
@@ -186,7 +186,7 @@ export function mapJsonRowToItem(obj: Record<string, unknown>): Partial<NewCatal
     const techs = toStringRecord(item.techs);
     const claimedWeight = techs['Claimed Weight'] ?? techs.weight;
     if (claimedWeight) {
-      const { weight, unit } = parseWeight(claimedWeight);
+      const { weight, unit } = parseWeight({ weightStr: claimedWeight });
       item.weight = weight ?? undefined;
       const parsedUnit = WeightUnitSchema.safeParse(unit);
       item.weightUnit = parsedUnit.success ? parsedUnit.data : undefined;

--- a/packages/api/src/utils/logger.ts
+++ b/packages/api/src/utils/logger.ts
@@ -115,13 +115,13 @@ function emit({ level, event, ctx }: EmitArgs): void {
 }
 
 export const logger = {
-  info(event: string, ctx?: LogContext): void {
+  info({ event, ctx }: { event: string; ctx?: LogContext }): void {
     emit({ level: 'INFO', event, ctx });
   },
-  warn(event: string, ctx?: LogContext): void {
+  warn({ event, ctx }: { event: string; ctx?: LogContext }): void {
     emit({ level: 'WARN', event, ctx });
   },
-  error(event: string, ctx?: LogContext): void {
+  error({ event, ctx }: { event: string; ctx?: LogContext }): void {
     emit({ level: 'ERROR', event, ctx });
   },
 };

--- a/packages/api/src/workflows/catalog-etl-workflow.ts
+++ b/packages/api/src/workflows/catalog-etl-workflow.ts
@@ -71,7 +71,13 @@ async function* streamToText(stream: ReadableStream<Uint8Array>) {
   }
 }
 
-async function fetchHeaderRow(r2: R2BucketService, objectKey: string): Promise<string> {
+async function fetchHeaderRow({
+  r2,
+  objectKey,
+}: {
+  r2: R2BucketService;
+  objectKey: string;
+}): Promise<string> {
   for (const length of HEADER_PEEK_SIZES) {
     const obj = await r2.get(objectKey, { range: { offset: 0, length } });
     if (!obj) throw new Error(`R2 header read returned null for ${objectKey}`);
@@ -217,7 +223,9 @@ export async function processChunk({
     }
   } else {
     // --- CSV path ---
-    const injectedHeader = isNonFirstChunk ? await fetchHeaderRow(r2, chunk.objectKey) : '';
+    const injectedHeader = isNonFirstChunk
+      ? await fetchHeaderRow({ r2, objectKey: chunk.objectKey })
+      : '';
 
     let fieldMap: Record<string, number> = {};
     let isHeaderProcessed = false;

--- a/packages/api/src/workflows/shared/chunkCsvForR2.ts
+++ b/packages/api/src/workflows/shared/chunkCsvForR2.ts
@@ -31,7 +31,10 @@ const DEFAULT_CHUNK_BYTES = 2 * 1024 * 1024; // 2 MiB — keeps each workflow st
 const DEFAULT_PEEK_BYTES = 64 * 1024; // 64 KiB
 
 export class ChunkBoundaryError extends Error {
-  constructor(objectKey: string, byteRange: { from: number; to: number }) {
+  constructor({
+    objectKey,
+    byteRange,
+  }: { objectKey: string; byteRange: { from: number; to: number } }) {
     super(
       `No newline found in ${byteRange.to - byteRange.from} bytes ending at ${byteRange.to} ` +
         `of ${objectKey} — row larger than the peek window or file is not line-oriented.`,
@@ -115,7 +118,7 @@ export async function chunkCsvForR2({
         const text = await obj.text();
         const lastNewlineIndex = text.lastIndexOf('\n');
         if (lastNewlineIndex === -1) {
-          throw new ChunkBoundaryError(objectKey, { from, to });
+          throw new ChunkBoundaryError({ objectKey, byteRange: { from, to } });
         }
         // TextEncoder gives byte length of the prefix — accurate for non-ASCII CSV
         // content where char index != byte offset (e.g. accented product names).

--- a/packages/mcp/src/__tests__/client.test.ts
+++ b/packages/mcp/src/__tests__/client.test.ts
@@ -80,7 +80,7 @@ describe('nowIso()', () => {
 describe('call()', () => {
   it('returns ok result when promise resolves with data', async () => {
     const mockPromise = Promise.resolve({ data: { id: 'pack-1' }, error: null, status: 200 });
-    const result = await call(mockPromise);
+    const result = await call({ promise: mockPromise });
     expect(result.isError).toBeUndefined();
     expect(result.content[0].text).toContain('"id": "pack-1"');
   });
@@ -91,27 +91,27 @@ describe('call()', () => {
       error: { status: 404, value: 'Not Found' },
       status: 404,
     });
-    const result = await call(mockPromise);
+    const result = await call({ promise: mockPromise });
     expect(result.isError).toBe(true);
     expect(result.content[0].text).toContain('404');
   });
 
   it('returns error result when data is null', async () => {
     const mockPromise = Promise.resolve({ data: null, error: null, status: 200 });
-    const result = await call(mockPromise);
+    const result = await call({ promise: mockPromise });
     expect(result.isError).toBe(true);
   });
 
   it('returns error result when promise rejects', async () => {
     const mockPromise = Promise.reject(new Error('network failure'));
-    const result = await call(mockPromise);
+    const result = await call({ promise: mockPromise });
     expect(result.isError).toBe(true);
     expect(result.content[0].text).toContain('network failure');
   });
 
   it('uses action from options in error messages', async () => {
     const mockPromise = Promise.reject(new Error('timeout'));
-    const result = await call(mockPromise, { action: 'fetch pack' });
+    const result = await call({ promise: mockPromise, action: 'fetch pack' });
     expect(result.content[0].text).toContain('fetch pack');
   });
 
@@ -121,7 +121,7 @@ describe('call()', () => {
       error: { status: 401, value: null },
       status: 401,
     });
-    const result = await call(mockPromise, { action: 'list packs' });
+    const result = await call({ promise: mockPromise, action: 'list packs' });
     expect(result.isError).toBe(true);
     expect(result.content[0].text.toLowerCase()).toContain('authentication');
   });
@@ -132,7 +132,7 @@ describe('call()', () => {
       error: { status: 401, value: null },
       status: 401,
     });
-    const result = await call(mockPromise, { action: 'list packs', requiresAdmin: true });
+    const result = await call({ promise: mockPromise, action: 'list packs', requiresAdmin: true });
     expect(result.isError).toBe(true);
     expect(result.content[0].text.toLowerCase()).toContain('admin');
   });
@@ -143,7 +143,7 @@ describe('call()', () => {
       error: { status: 403, value: null },
       status: 403,
     });
-    const result = await call(mockPromise, { action: 'delete pack' });
+    const result = await call({ promise: mockPromise, action: 'delete pack' });
     expect(result.isError).toBe(true);
     expect(result.content[0].text.toLowerCase()).toContain('forbidden');
   });
@@ -154,7 +154,11 @@ describe('call()', () => {
       error: { status: 404, value: null },
       status: 404,
     });
-    const result = await call(mockPromise, { action: 'get pack', resourceHint: 'pack p_123' });
+    const result = await call({
+      promise: mockPromise,
+      action: 'get pack',
+      resourceHint: 'pack p_123',
+    });
     expect(result.isError).toBe(true);
     expect(result.content[0].text).toContain('404');
   });
@@ -165,7 +169,7 @@ describe('call()', () => {
       error: { status: 409, value: null },
       status: 409,
     });
-    const result = await call(mockPromise, { action: 'create pack' });
+    const result = await call({ promise: mockPromise, action: 'create pack' });
     expect(result.isError).toBe(true);
     expect(result.content[0].text.toLowerCase()).toContain('conflict');
   });
@@ -176,7 +180,7 @@ describe('call()', () => {
       error: { status: 422, value: null },
       status: 422,
     });
-    const result = await call(mockPromise, { action: 'update pack' });
+    const result = await call({ promise: mockPromise, action: 'update pack' });
     expect(result.isError).toBe(true);
     expect(result.content[0].text.toLowerCase()).toContain('validation');
   });
@@ -187,7 +191,7 @@ describe('call()', () => {
       error: { status: 429, value: null },
       status: 429,
     });
-    const result = await call(mockPromise, { action: 'search' });
+    const result = await call({ promise: mockPromise, action: 'search' });
     expect(result.isError).toBe(true);
     expect(result.content[0].text.toLowerCase()).toContain('rate limit');
   });
@@ -198,7 +202,7 @@ describe('call()', () => {
       error: { status: 503, value: null },
       status: 503,
     });
-    const result = await call(mockPromise, { action: 'fetch data' });
+    const result = await call({ promise: mockPromise, action: 'fetch data' });
     expect(result.isError).toBe(true);
     expect(result.content[0].text).toContain('503');
   });
@@ -209,13 +213,13 @@ describe('call()', () => {
       error: { status: 400, value: { message: 'invalid input' } },
       status: 400,
     });
-    const result = await call(mockPromise);
+    const result = await call({ promise: mockPromise });
     expect(result.content[0].text).toContain('invalid input');
   });
 
   it('handles non-Error thrown exceptions', async () => {
     const mockPromise = Promise.reject('string error');
-    const result = await call(mockPromise);
+    const result = await call({ promise: mockPromise });
     expect(result.isError).toBe(true);
     expect(result.content[0].text).toContain('string error');
   });
@@ -226,7 +230,7 @@ describe('call()', () => {
       error: { status: 403, value: null },
       status: 403,
     });
-    const result = await call(mockPromise, { action: 'delete user', requiresAdmin: true });
+    const result = await call({ promise: mockPromise, action: 'delete user', requiresAdmin: true });
     expect(result.isError).toBe(true);
     expect(result.content[0].text.toLowerCase()).toContain('admin');
     expect(result.content[0].text.toLowerCase()).toContain('forbidden');
@@ -238,7 +242,7 @@ describe('call()', () => {
       error: { status: 400, value: { error: 'bad request detail' } },
       status: 400,
     });
-    const result = await call(mockPromise);
+    const result = await call({ promise: mockPromise });
     expect(result.content[0].text).toContain('bad request detail');
   });
 
@@ -248,7 +252,7 @@ describe('call()', () => {
       error: { status: 400, value: { code: 42, detail: 'some info' } },
       status: 400,
     });
-    const result = await call(mockPromise);
+    const result = await call({ promise: mockPromise });
     expect(result.content[0].text).toContain('42');
   });
 
@@ -258,7 +262,7 @@ describe('call()', () => {
       error: { status: 500, value: 12345 },
       status: 500,
     });
-    const result = await call(mockPromise);
+    const result = await call({ promise: mockPromise });
     expect(result.content[0].text).toContain('12345');
   });
 });

--- a/packages/overpass/src/client.test.ts
+++ b/packages/overpass/src/client.test.ts
@@ -6,7 +6,9 @@ let originalFetch: typeof globalThis.fetch;
 
 beforeEach(() => {
   originalFetch = globalThis.fetch;
-  globalThis.fetch = mockFetch as typeof globalThis.fetch;
+  // Test double: a vitest Mock has no structural overlap with `typeof fetch`,
+  // so the `unknown` bridge is the standard (and TS-suggested) cast here.
+  globalThis.fetch = mockFetch as unknown as typeof globalThis.fetch;
 });
 
 afterEach(() => {
@@ -46,7 +48,7 @@ describe('queryOverpass', () => {
   describe('HTTP request construction', () => {
     it('sends a POST to the default Overpass endpoint', async () => {
       mockFetch.mockResolvedValue(makeResponse(validResponse));
-      await queryOverpass('[out:json];relation(12345);out geom;');
+      await queryOverpass({ ql: '[out:json];relation(12345);out geom;' });
       expect(mockFetch).toHaveBeenCalledWith(
         'https://overpass-api.de/api/interpreter',
         expect.objectContaining({ method: 'POST' }),
@@ -55,14 +57,14 @@ describe('queryOverpass', () => {
 
     it('uses a custom endpoint when provided', async () => {
       mockFetch.mockResolvedValue(makeResponse(validResponse));
-      await queryOverpass('ql', { endpoint: 'https://custom.example.com/api' });
+      await queryOverpass({ ql: 'ql', config: { endpoint: 'https://custom.example.com/api' } });
       expect(mockFetch).toHaveBeenCalledWith('https://custom.example.com/api', expect.any(Object));
     });
 
     it('encodes the QL query as form-urlencoded body', async () => {
       mockFetch.mockResolvedValue(makeResponse(validResponse));
       const ql = '[out:json];relation(42);out geom;';
-      await queryOverpass(ql);
+      await queryOverpass({ ql });
       const firstCall = mockFetch.mock.calls.at(0) as [string, RequestInit] | undefined;
       const init = firstCall?.[1];
       expect(init?.body).toBe(`data=${encodeURIComponent(ql)}`);
@@ -70,7 +72,7 @@ describe('queryOverpass', () => {
 
     it('sets Content-Type to application/x-www-form-urlencoded', async () => {
       mockFetch.mockResolvedValue(makeResponse(validResponse));
-      await queryOverpass('ql');
+      await queryOverpass({ ql: 'ql' });
       const firstCall = mockFetch.mock.calls.at(0) as [string, RequestInit] | undefined;
       const headers = firstCall?.[1]?.headers as Record<string, string> | undefined;
       expect(headers?.['Content-Type']).toBe('application/x-www-form-urlencoded');
@@ -78,7 +80,7 @@ describe('queryOverpass', () => {
 
     it('sets a User-Agent header', async () => {
       mockFetch.mockResolvedValue(makeResponse(validResponse));
-      await queryOverpass('ql');
+      await queryOverpass({ ql: 'ql' });
       const firstCall = mockFetch.mock.calls.at(0) as [string, RequestInit] | undefined;
       const headers = firstCall?.[1]?.headers as Record<string, string> | undefined;
       expect(headers?.['User-Agent']).toBeDefined();
@@ -89,28 +91,28 @@ describe('queryOverpass', () => {
   describe('error handling', () => {
     it('throws when response status is not ok (429)', async () => {
       mockFetch.mockResolvedValue(makeResponse({}, 429));
-      await expect(queryOverpass('ql')).rejects.toThrow(
+      await expect(queryOverpass({ ql: 'ql' })).rejects.toThrow(
         'Overpass request failed: 429 Service Unavailable',
       );
     });
 
     it('throws when response status is not ok (500)', async () => {
       mockFetch.mockResolvedValue(makeResponse({}, 500));
-      await expect(queryOverpass('ql')).rejects.toThrow(
+      await expect(queryOverpass({ ql: 'ql' })).rejects.toThrow(
         'Overpass request failed: 500 Service Unavailable',
       );
     });
 
     it('throws when response JSON does not match expected schema', async () => {
       mockFetch.mockResolvedValue(makeResponse({ unexpected: 'data' }));
-      await expect(queryOverpass('ql')).rejects.toThrow(
+      await expect(queryOverpass({ ql: 'ql' })).rejects.toThrow(
         'Overpass response did not match expected schema',
       );
     });
 
     it('throws when response is missing elements field', async () => {
       mockFetch.mockResolvedValue(makeResponse({ version: 0.6 }));
-      await expect(queryOverpass('ql')).rejects.toThrow(
+      await expect(queryOverpass({ ql: 'ql' })).rejects.toThrow(
         'Overpass response did not match expected schema',
       );
     });
@@ -119,7 +121,7 @@ describe('queryOverpass', () => {
   describe('successful response', () => {
     it('returns the parsed response data', async () => {
       mockFetch.mockResolvedValue(makeResponse(validResponse));
-      const result = await queryOverpass('[out:json];relation(12345);out geom;');
+      const result = await queryOverpass({ ql: '[out:json];relation(12345);out geom;' });
       expect(result.elements).toHaveLength(1);
       const [firstElement] = result.elements;
       expect(firstElement?.id).toBe(12345);
@@ -127,7 +129,7 @@ describe('queryOverpass', () => {
 
     it('returns empty elements array for no results', async () => {
       mockFetch.mockResolvedValue(makeResponse({ ...validResponse, elements: [] }));
-      const result = await queryOverpass('ql');
+      const result = await queryOverpass({ ql: 'ql' });
       expect(result.elements).toHaveLength(0);
     });
   });

--- a/scripts/lint/no-owned-max-params.ts
+++ b/scripts/lint/no-owned-max-params.ts
@@ -28,7 +28,13 @@ const EXCLUDED_DIRS = new Set([
   'coverage',
 ]);
 
-const EXCLUDED_PATH_PARTS = ['/test/', '/__tests__/', '/mocks/', '/playwright/'];
+const EXCLUDED_PATH_PARTS = [
+  '/test/',
+  '/__tests__/',
+  '/__test-stubs__/',
+  '/mocks/',
+  '/playwright/',
+];
 const EXCLUDED_SUFFIXES = ['.test.ts', '.test.tsx', '.spec.ts', '.spec.tsx'];
 const EXCLUDED_FILES = new Set([
   // This service intentionally mirrors Cloudflare R2's positional API.
@@ -39,7 +45,7 @@ const EXCLUDED_FILES = new Set([
   'apps/guides/scripts/generate-og-images.ts',
   'apps/trails/scripts/generate-og-images.ts',
 ]);
-const FRAMEWORK_METHOD_NAMES = new Set(['fetch', 'queue', 'resolveRequest']);
+const FRAMEWORK_METHOD_NAMES = new Set(['fetch', 'queue', 'resolveRequest', 'scheduled']);
 const EXTERNAL_CALLBACK_NAMES = new Set([
   'fetcher',
   'keyExtractor',
@@ -178,6 +184,20 @@ function isFrameworkObjectMethod(node: ts.FunctionLikeDeclaration): boolean {
   return FRAMEWORK_METHOD_NAMES.has(name);
 }
 
+// Cloudflare WorkflowEntrypoint.run(event, step) is a framework-mandated
+// signature — exempt it, but narrowly: only `run` methods on a class that
+// extends WorkflowEntrypoint, never every method named `run`.
+function isWorkflowEntrypointRun(node: ts.FunctionLikeDeclaration): boolean {
+  if (!ts.isMethodDeclaration(node) || functionName(node) !== 'run') return false;
+  const cls = node.parent;
+  if (!ts.isClassLike(cls) || !cls.heritageClauses) return false;
+  return cls.heritageClauses.some(
+    (clause) =>
+      clause.token === ts.SyntaxKind.ExtendsKeyword &&
+      clause.types.some((type) => type.expression.getText().includes('WorkflowEntrypoint')),
+  );
+}
+
 function isExternalCallback(node: ts.FunctionLikeDeclaration): boolean {
   if (EXTERNAL_CALLBACK_NAMES.has(functionName(node).replace(/^['"]|['"]$/g, ''))) return true;
 
@@ -206,6 +226,7 @@ function shouldCheck(node: ts.FunctionLikeDeclaration): boolean {
   if (isExternalCallback(node)) return false;
   if (isAssertionPredicate(node)) return false;
   if (isFrameworkObjectMethod(node)) return false;
+  if (isWorkflowEntrypointRun(node)) return false;
   if (ts.isGetAccessor(node) || ts.isSetAccessor(node)) return false;
   return true;
 }

--- a/scripts/lint/no-owned-max-params.ts
+++ b/scripts/lint/no-owned-max-params.ts
@@ -194,7 +194,12 @@ function isWorkflowEntrypointRun(node: ts.FunctionLikeDeclaration): boolean {
   return cls.heritageClauses.some(
     (clause) =>
       clause.token === ts.SyntaxKind.ExtendsKeyword &&
-      clause.types.some((type) => type.expression.getText().includes('WorkflowEntrypoint')),
+      clause.types.some((type) => {
+        // Exact match (allowing a namespace qualifier like `cf.WorkflowEntrypoint`)
+        // so we don't accidentally exempt `NotWorkflowEntrypoint` / `WorkflowEntrypointStub`.
+        const name = type.expression.getText();
+        return name === 'WorkflowEntrypoint' || name.endsWith('.WorkflowEntrypoint');
+      }),
   );
 }
 


### PR DESCRIPTION
## What

`main` is currently **red** (Coverage api/mcp, Coverage Ratchet, checks) — independent of any feature branch. The single-object-args migration (PR #2422, "convert all owned functions to single object-param signatures" + "delete backward-compat shims") merged, but later changes left stale **positional call sites** that broke tests + tripped the `no-owned-max-params` checker. This completes it.

### api (Coverage api → green; 392 tests pass, was 7 failing)
- `json-utils.ts` `mapJsonRowToItem` called `parseWeight(str, unit)` → now `parseWeight({ weightStr, unitStr })` (3 sites; also the 3 baseline type errors).
- `embeddingHelper.test` / `auth.test` called `getEmbeddingText` / `timingSafeEqual` positionally → single-object.

### mcp (Coverage mcp → green; 63 tests pass, was 18 failing)
- `call()` is now `call({ promise, ...options })`; updated all 19 positional test call sites.

### checks / no-owned-max-params → green
- **Convert** owned functions to single-object (+ all call sites incl. tests): `logger.info/warn/error`, `sweepInvalidItemLogs`, `fetchHeaderRow`, `ChunkBoundaryError` ctor.
- **Exempt genuine framework signatures, narrowly:**
  - add `scheduled` to `FRAMEWORK_METHOD_NAMES` (Worker handler, like `fetch`/`queue`)
  - exempt `run` **only** on classes extending `WorkflowEntrypoint` (not every method named `run`)
  - exclude `/__test-stubs__/` (mirrors CF's positional API, same as the existing `/mocks/` exclusion)

## Verification (local)
- `bun test:api:unit` → 392 passed
- `bun test:mcp` → 63 passed
- `bun lint:custom` (the `checks` job) → all checks pass
- `bun run scripts/lint/no-owned-max-params.ts` → clean

## Notes
- Pure migration-completion + a narrow checker fix; no behavior change.
- Unblocks the stacked tsconfig PRs (#2527 + L3) once merged, but stands on its own as a main-greening fix.
- e2e iOS/Android excluded (device/simulator jobs).