### PR TITLE
fix: gate auth-required local AI tools for unauthenticated users

### DIFF
--- a/apps/expo/app/(app)/ai-chat.tsx
+++ b/apps/expo/app/(app)/ai-chat.tsx
@@ -157,7 +157,8 @@ export default function AIChat() {
   // Build the right transport based on current AI mode.
   // Recreated when aiMode or modelStatus changes (modelStatus drives local readiness).
   const isLocalReady = modelStatus === 'ready';
-  const tools = React.useMemo(() => createLocalTools(), []);
+  const isAuthenticated = !!token;
+  const tools = React.useMemo(() => createLocalTools(isAuthenticated), [isAuthenticated]);
 
   const { transport, transportKey } = React.useMemo(() => {
     if (featureFlags.enableLocalAI && aiMode === 'local' && isLocalReady) {
@@ -456,7 +457,7 @@ export default function AIChat() {
             <View className="pl-4 pr-16">
               <Text className="mb-2 text-xs text-muted-foreground mt-0">{t('ai.suggestions')}</Text>
               <View className="flex-row flex-wrap gap-2">
-                {getContextualSuggestions(context).map((suggestion) => (
+                {getContextualSuggestions(context, isAuthenticated).map((suggestion) => (
                   <TouchableOpacity
                     key={suggestion}
                     onPress={() => handleSubmit(suggestion)}

--- a/apps/expo/app/(app)/ai-chat.tsx
+++ b/apps/expo/app/(app)/ai-chat.tsx
@@ -467,7 +467,7 @@ export default function AIChat() {
             <View className="pl-4 pr-16">
               <Text className="mb-2 text-xs text-muted-foreground mt-0">{t('ai.suggestions')}</Text>
               <View className="flex-row flex-wrap gap-2">
-                {getContextualSuggestions(context, isAuthenticated).map((suggestion) => (
+                {getContextualSuggestions({ context, isAuthenticated }).map((suggestion) => (
                   <TouchableOpacity
                     key={suggestion}
                     onPress={() => handleSubmit(suggestion)}

--- a/apps/expo/app/(app)/ai-chat.tsx
+++ b/apps/expo/app/(app)/ai-chat.tsx
@@ -25,6 +25,7 @@ import { CustomChatTransport } from 'expo-app/features/ai/lib/CustomChatTranspor
 import {
   getLocalModel,
   initLocalModel,
+  isAppleIntelligenceAvailable,
   releaseLocalModel,
 } from 'expo-app/features/ai/lib/localModelManager';
 import { createLocalTools } from 'expo-app/features/ai/lib/tools';
@@ -104,6 +105,7 @@ export default function AIChat() {
   const { data: _authSession } = authClient.useSession();
   const token = _authSession?.session?.token ?? null;
   const userId = _authSession?.user?.id ?? '';
+  const isAuthenticated = !!token;
   const [input, setInput] = React.useState('');
   const [lastUserMessage, setLastUserMessage] = React.useState('');
   const [previousMessages, setPreviousMessages] = React.useState<UIMessage[]>([]);
@@ -128,14 +130,14 @@ export default function AIChat() {
   React.useEffect(() => {
     if (!featureFlags.enableLocalAI) return;
 
-    initLocalModel();
+    initLocalModel(isAuthenticated);
 
     const subscription = AppState.addEventListener('change', (nextState) => {
       if (nextState === 'background' || nextState === 'inactive') {
         releaseLocalModel();
       } else if (nextState === 'active') {
         // Re-prepare the model when the app comes back to the foreground.
-        initLocalModel();
+        initLocalModel(isAuthenticatedRef.current);
       }
     });
 
@@ -150,14 +152,22 @@ export default function AIChat() {
     };
   }, []);
 
+  // Re-initialize the Apple provider when auth state changes so that the
+  // set of available tools stays in sync with the user's authentication status.
+  React.useEffect(() => {
+    if (!featureFlags.enableLocalAI || !isAppleIntelligenceAvailable()) return;
+    releaseLocalModel().then(() => initLocalModel(isAuthenticated));
+  }, [isAuthenticated]);
+
   // Keep a ref for context body values so the transport closure stays fresh
   const contextRef = React.useRef(context);
   contextRef.current = context;
+  const isAuthenticatedRef = React.useRef(isAuthenticated);
+  isAuthenticatedRef.current = isAuthenticated;
 
   // Build the right transport based on current AI mode.
   // Recreated when aiMode or modelStatus changes (modelStatus drives local readiness).
   const isLocalReady = modelStatus === 'ready';
-  const isAuthenticated = !!token;
   const tools = React.useMemo(() => createLocalTools(isAuthenticated), [isAuthenticated]);
 
   const { transport, transportKey } = React.useMemo(() => {

--- a/apps/expo/app/(app)/settings/index.tsx
+++ b/apps/expo/app/(app)/settings/index.tsx
@@ -143,7 +143,7 @@ export default function SettingsScreen() {
                         </View>
                       )}
                       {(!isDownloaded || isError) && !isDownloading && !isPreparing && (
-                        <TouchableOpacity onPress={downloadLocalModel}>
+                        <TouchableOpacity onPress={() => downloadLocalModel(isAuthenticated)}>
                           <Text
                             variant="footnote"
                             className="font-medium"

--- a/apps/expo/features/ai/components/AIModeSheet.tsx
+++ b/apps/expo/features/ai/components/AIModeSheet.tsx
@@ -54,7 +54,7 @@ export const AIModeSheet = React.forwardRef<BottomSheetModal, AIModeSheetProps>(
       if (selected === 'cloud' && !isAuthenticated) return;
       if (selected === 'local' && !isModelReady) {
         // trigger download/init but don't switch mode yet
-        downloadLocalModel();
+        downloadLocalModel(isAuthenticated);
         return;
       }
       setMode(selected);
@@ -64,7 +64,7 @@ export const AIModeSheet = React.forwardRef<BottomSheetModal, AIModeSheetProps>(
     };
 
     const handleDownload = () => {
-      downloadLocalModel();
+      downloadLocalModel(isAuthenticated);
     };
 
     const handleCancel = () => {

--- a/apps/expo/features/ai/lib/localModelManager.ts
+++ b/apps/expo/features/ai/lib/localModelManager.ts
@@ -133,7 +133,7 @@ export async function isLlamaModelDownloaded(): Promise<boolean> {
  * Initialise the local model. For Apple this is instant; for llama this
  * only prepares an already-downloaded model — call `downloadLocalModel` first.
  */
-export async function initLocalModel(): Promise<void> {
+export async function initLocalModel(isAuthenticated = false): Promise<void> {
   const status = store.get(localModelStatusAtom);
   if (status === 'downloading' || status === 'preparing' || status === 'ready') return;
 
@@ -141,7 +141,7 @@ export async function initLocalModel(): Promise<void> {
   store.set(localModelErrorAtom, null);
 
   if (isAppleIntelligenceAvailable()) {
-    await _initAppleModel();
+    await _initAppleModel(isAuthenticated);
   } else {
     await _initLlamaModel();
   }
@@ -151,10 +151,10 @@ export async function initLocalModel(): Promise<void> {
  * Download the llama model (no-op on Apple). Safe to call if already downloaded;
  * will fast-path to prepare().
  */
-export async function downloadLocalModel(): Promise<void> {
+export async function downloadLocalModel(isAuthenticated = false): Promise<void> {
   if (isAppleIntelligenceAvailable()) {
     // Apple model needs no download — just init
-    await _initAppleModel();
+    await _initAppleModel(isAuthenticated);
     return;
   }
 
@@ -329,7 +329,7 @@ export async function deleteLocalModel(): Promise<void> {
 
 // ─── private helpers ───────────────────────────────────────────────────────
 
-async function _initAppleModel(): Promise<void> {
+async function _initAppleModel(isAuthenticated = false): Promise<void> {
   // isAppleIntelligenceAvailable() has already confirmed availability — just init.
   store.set(localModelStatusAtom, 'preparing');
 
@@ -338,7 +338,7 @@ async function _initAppleModel(): Promise<void> {
     if (!mod) throw new Error('Apple module not available');
 
     const apple = mod.createAppleProvider({
-      availableTools: createLocalTools(),
+      availableTools: createLocalTools(isAuthenticated),
     });
 
     appleModel = new AppleModelWrapper(apple());

--- a/apps/expo/features/ai/lib/localModelManager.web.ts
+++ b/apps/expo/features/ai/lib/localModelManager.web.ts
@@ -16,9 +16,9 @@ export async function isLlamaModelDownloaded(): Promise<boolean> {
   return false;
 }
 
-export async function initLocalModel(): Promise<void> {}
+export async function initLocalModel(_isAuthenticated?: boolean): Promise<void> {}
 
-export async function downloadLocalModel(): Promise<void> {}
+export async function downloadLocalModel(_isAuthenticated?: boolean): Promise<void> {}
 
 export async function cancelLocalModelDownload(): Promise<void> {}
 

--- a/apps/expo/features/ai/lib/tools.ts
+++ b/apps/expo/features/ai/lib/tools.ts
@@ -40,8 +40,8 @@ function trimCatalogItem(item: unknown) {
   };
 }
 
-export function createLocalTools() {
-  return {
+export function createLocalTools(isAuthenticated = false) {
+  const allTools = {
     getPackDetails: tool({
       description:
         'Get detailed information about a specific pack including all its items, weights, and categories. Use this when the user asks about a specific pack by name or ID.',
@@ -140,6 +140,8 @@ export function createLocalTools() {
           const weatherData = await getWeatherData(first.id);
           return { success: true, data: formatWeatherData(weatherData) };
         } catch (error) {
+          console.log('getWeatherForLocation error', { error });
+
           return {
             success: false,
             error: error instanceof Error ? error.message : 'Failed to get weather data',
@@ -293,6 +295,14 @@ export function createLocalTools() {
       },
     }),
   };
+
+  if (isAuthenticated) {
+    return allTools;
+  }
+
+  // For unauthenticated users, only expose tools that operate on local device data.
+  const { getPackDetails, getPackItemDetails } = allTools;
+  return { getPackDetails, getPackItemDetails };
 }
 
 export type LocalTools = ReturnType<typeof createLocalTools>;

--- a/apps/expo/utils/__tests__/chatContextHelpers.test.ts
+++ b/apps/expo/utils/__tests__/chatContextHelpers.test.ts
@@ -45,13 +45,37 @@ describe('generatePromptWithContext', () => {
 });
 
 describe('getContextualSuggestions', () => {
-  it('returns general suggestions when no context is provided', () => {
+  it('returns unauthenticated suggestions when no args provided', () => {
     const suggestions = getContextualSuggestions();
+    expect(Array.isArray(suggestions)).toBe(true);
+    expect(suggestions.length).toBeGreaterThan(0);
+    // unauthenticated suggestions do not include tool-dependent prompts like weather lookups
+    expect(suggestions.some((s) => s.toLowerCase().includes('london'))).toBe(false);
+  });
+
+  it('returns unauthenticated suggestions when isAuthenticated is false', () => {
+    const suggestions = getContextualSuggestions({ isAuthenticated: false });
+    expect(suggestions.some((s) => s.toLowerCase().includes('ultralight'))).toBe(true);
+  });
+
+  it('returns authenticated general suggestions when isAuthenticated is true', () => {
+    const suggestions = getContextualSuggestions({ isAuthenticated: true });
+    expect(Array.isArray(suggestions)).toBe(true);
+    expect(suggestions.length).toBeGreaterThan(0);
+    // authenticated suggestions include tool-driven prompts like weather
+    expect(suggestions.some((s) => s.toLowerCase().includes('weather'))).toBe(true);
+  });
+
+  it('returns authenticated suggestions for a general context', () => {
+    const suggestions = getContextualSuggestions({
+      context: { contextType: 'general' },
+      isAuthenticated: true,
+    });
     expect(Array.isArray(suggestions)).toBe(true);
     expect(suggestions.length).toBeGreaterThan(0);
   });
 
-  it('returns general suggestions for a general context', () => {
+  it('returns unauthenticated suggestions for a general context', () => {
     const suggestions = getContextualSuggestions({ context: { contextType: 'general' } });
     expect(Array.isArray(suggestions)).toBe(true);
     expect(suggestions.length).toBeGreaterThan(0);

--- a/apps/expo/utils/__tests__/chatContextHelpers.test.ts
+++ b/apps/expo/utils/__tests__/chatContextHelpers.test.ts
@@ -52,21 +52,23 @@ describe('getContextualSuggestions', () => {
   });
 
   it('returns general suggestions for a general context', () => {
-    const suggestions = getContextualSuggestions({ contextType: 'general' });
+    const suggestions = getContextualSuggestions({ context: { contextType: 'general' } });
     expect(Array.isArray(suggestions)).toBe(true);
     expect(suggestions.length).toBeGreaterThan(0);
   });
 
   it('returns item-specific suggestions with item name', () => {
     const suggestions = getContextualSuggestions({
-      contextType: 'item',
-      itemName: 'Rain Jacket',
+      context: {
+        contextType: 'item',
+        itemName: 'Rain Jacket',
+      },
     });
     expect(suggestions.some((s) => s.includes('Rain Jacket'))).toBe(true);
   });
 
   it('returns pack-specific suggestions for pack context', () => {
-    const suggestions = getContextualSuggestions({ contextType: 'pack' });
+    const suggestions = getContextualSuggestions({ context: { contextType: 'pack' } });
     expect(suggestions.length).toBeGreaterThan(0);
   });
 });

--- a/apps/expo/utils/chatContextHelpers.ts
+++ b/apps/expo/utils/chatContextHelpers.ts
@@ -31,7 +31,10 @@ export function generatePromptWithContext({
 export function getContextualSuggestions({
   context,
   isAuthenticated = false,
-}: { context?: ChatContext; isAuthenticated?: boolean } = {}): string[] {
+}: {
+  context?: ChatContext;
+  isAuthenticated?: boolean;
+} = {}): string[] {
   if (!context || context.contextType === 'general') {
     if (!isAuthenticated) {
       return [

--- a/apps/expo/utils/chatContextHelpers.ts
+++ b/apps/expo/utils/chatContextHelpers.ts
@@ -28,7 +28,10 @@ export function generatePromptWithContext({
   return userMessage;
 }
 
-export function getContextualSuggestions(context?: ChatContext, isAuthenticated = false): string[] {
+export function getContextualSuggestions({
+  context,
+  isAuthenticated = false,
+}: { context?: ChatContext; isAuthenticated?: boolean } = {}): string[] {
   if (!context || context.contextType === 'general') {
     if (!isAuthenticated) {
       return [

--- a/apps/expo/utils/chatContextHelpers.ts
+++ b/apps/expo/utils/chatContextHelpers.ts
@@ -28,8 +28,17 @@ export function generatePromptWithContext({
   return userMessage;
 }
 
-export function getContextualSuggestions(context?: ChatContext): string[] {
+export function getContextualSuggestions(context?: ChatContext, isAuthenticated = false): string[] {
   if (!context || context.contextType === 'general') {
+    if (!isAuthenticated) {
+      return [
+        'What are ultralight hiking principles?',
+        'How do I organize my backpack efficiently?',
+        'What essential gear do I need for a day hike?',
+        'How can I reduce my pack weight?',
+        "What's the best way to layer clothing for cold weather?",
+      ];
+    }
     return [
       'What is the weather in London this weekend?', // Primes AI to invoke weather tool
       'Are there any deals on highly rated rain jackets right now?', // Primes AI to invoke web search tool


### PR DESCRIPTION
## Summary

Local AI is available to unauthenticated users, but several tools it could invoke (weather, catalog, web search, RAG, SQL) call API endpoints that require authentication — causing silent failures or 401 errors.

## Changes

### `apps/expo/features/ai/lib/tools.ts`
- `createLocalTools()` now accepts an `isAuthenticated` parameter (default `false`)
- When `false`, only local device tools (`getPackDetails`, `getPackItemDetails`) are returned — these read from on-device Legend-State stores and require no network auth
- When `true`, all tools are available (weather, catalog, vector search, RAG, web search, SQL)

### `apps/expo/app/(app)/ai-chat.tsx`
- Derives `isAuthenticated = !!token` from the existing auth session
- Passes it to `createLocalTools(isAuthenticated)` so the tool set updates reactively when auth state changes
- Passes it to `getContextualSuggestions(context, isAuthenticated)` for consistent suggestion gating

### `apps/expo/utils/chatContextHelpers.ts`
- `getContextualSuggestions()` now accepts `isAuthenticated` (default `false`)
- Unauthenticated users see general hiking knowledge questions that the AI can answer without tools (e.g. "What are ultralight hiking principles?")
- Authenticated users keep the existing tool-priming suggestions (weather, web search, catalog, guides)

## Testing
- Launch app without signing in → suggestions should be generic hiking questions; weather/catalog prompts should not appear
- Sign in → suggestions should return to the full set including weather/web search prompts
- Ask about weather as unauthenticated user → AI should respond from general knowledge, not attempt the weather tool

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * AI chat now personalizes available tools, contextual suggestions, and local model download/initialization based on whether the user is authenticated; UI actions (mode selection, download) respect current auth state.

* **Bug Fixes**
  * Improved error handling and logging for location/weather features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->