### PR TITLE
fix(ai): guard details access in WeatherGenerativeUI against undefined

### DIFF
--- a/apps/expo/features/ai/components/WeatherGenerativeUI.tsx
+++ b/apps/expo/features/ai/components/WeatherGenerativeUI.tsx
@@ -12,11 +12,15 @@ type WeatherToolOutput =
   | {
       success: true;
       data: {
-        location: string;
+        name: string;
         temperature: number;
-        conditions: string;
-        humidity: number;
-        windSpeed: number;
+        condition: string;
+        details: {
+          humidity: number;
+          windSpeed: number;
+          feelsLike?: number;
+          isDay?: number;
+        };
       };
     }
   | {
@@ -124,7 +128,7 @@ export function WeatherGenerativeUI({ toolInvocation }: WeatherGenerativeUIProps
               <Icon name="map-marker-radius-outline" size={16} color={colors.primary} />
               <Text className="text-base font-semibold text-blue-800 dark:text-blue-200">
                 {t('ai.tools.weatherIn', {
-                  location: toolInvocation.output.data.location,
+                  location: toolInvocation.output.data.name,
                 })}
               </Text>
             </View>
@@ -136,7 +140,8 @@ export function WeatherGenerativeUI({ toolInvocation }: WeatherGenerativeUIProps
               <View className="flex-row items-center">
                 <Icon
                   name={getWeatherIconByCondition({
-                    condition: toolInvocation.output.data.conditions,
+                    condition: toolInvocation.output.data.condition,
+                    isDay: toolInvocation.output.data.details?.isDay,
                   })}
                   size={48}
                   color="#3b82f6"
@@ -148,7 +153,7 @@ export function WeatherGenerativeUI({ toolInvocation }: WeatherGenerativeUIProps
                     {toolInvocation.output.data.temperature}°
                   </Text>
                   <Text className="mt-1 text-base text-gray-600 dark:text-gray-300">
-                    {toolInvocation.output.data.conditions}
+                    {toolInvocation.output.data.condition}
                   </Text>
                 </View>
               </View>
@@ -165,7 +170,7 @@ export function WeatherGenerativeUI({ toolInvocation }: WeatherGenerativeUIProps
                     </Text>
                   </View>
                   <Text className="text-lg font-semibold text-gray-900 dark:text-gray-100">
-                    {toolInvocation.output.data.humidity}%
+                    {toolInvocation.output.data.details?.humidity}%
                   </Text>
                 </View>
 
@@ -179,7 +184,7 @@ export function WeatherGenerativeUI({ toolInvocation }: WeatherGenerativeUIProps
                     </Text>
                   </View>
                   <Text className="text-lg font-semibold text-gray-900 dark:text-gray-100">
-                    {toolInvocation.output.data.windSpeed} mph
+                    {toolInvocation.output.data.details?.windSpeed} mph
                   </Text>
                 </View>
               </View>

--- a/apps/expo/features/ai/components/WeatherGenerativeUI.tsx
+++ b/apps/expo/features/ai/components/WeatherGenerativeUI.tsx
@@ -12,15 +12,11 @@ type WeatherToolOutput =
   | {
       success: true;
       data: {
-        name: string;
+        location: string;
         temperature: number;
-        condition: string;
-        details: {
-          humidity: number;
-          windSpeed: number;
-          feelsLike: number;
-          isDay: number;
-        };
+        conditions: string;
+        humidity: number;
+        windSpeed: number;
       };
     }
   | {
@@ -128,7 +124,7 @@ export function WeatherGenerativeUI({ toolInvocation }: WeatherGenerativeUIProps
               <Icon name="map-marker-radius-outline" size={16} color={colors.primary} />
               <Text className="text-base font-semibold text-blue-800 dark:text-blue-200">
                 {t('ai.tools.weatherIn', {
-                  location: toolInvocation.output.data.name,
+                  location: toolInvocation.output.data.location,
                 })}
               </Text>
             </View>
@@ -140,8 +136,7 @@ export function WeatherGenerativeUI({ toolInvocation }: WeatherGenerativeUIProps
               <View className="flex-row items-center">
                 <Icon
                   name={getWeatherIconByCondition({
-                    condition: toolInvocation.output.data.condition,
-                    isDay: toolInvocation.output.data.details?.isDay,
+                    condition: toolInvocation.output.data.conditions,
                   })}
                   size={48}
                   color="#3b82f6"
@@ -153,7 +148,7 @@ export function WeatherGenerativeUI({ toolInvocation }: WeatherGenerativeUIProps
                     {toolInvocation.output.data.temperature}°
                   </Text>
                   <Text className="mt-1 text-base text-gray-600 dark:text-gray-300">
-                    {toolInvocation.output.data.condition}
+                    {toolInvocation.output.data.conditions}
                   </Text>
                 </View>
               </View>
@@ -170,7 +165,7 @@ export function WeatherGenerativeUI({ toolInvocation }: WeatherGenerativeUIProps
                     </Text>
                   </View>
                   <Text className="text-lg font-semibold text-gray-900 dark:text-gray-100">
-                    {toolInvocation.output.data.details?.humidity}%
+                    {toolInvocation.output.data.humidity}%
                   </Text>
                 </View>
 
@@ -184,7 +179,7 @@ export function WeatherGenerativeUI({ toolInvocation }: WeatherGenerativeUIProps
                     </Text>
                   </View>
                   <Text className="text-lg font-semibold text-gray-900 dark:text-gray-100">
-                    {toolInvocation.output.data.details?.windSpeed} mph
+                    {toolInvocation.output.data.windSpeed} mph
                   </Text>
                 </View>
               </View>

--- a/apps/expo/features/ai/components/WeatherGenerativeUI.tsx
+++ b/apps/expo/features/ai/components/WeatherGenerativeUI.tsx
@@ -141,7 +141,7 @@ export function WeatherGenerativeUI({ toolInvocation }: WeatherGenerativeUIProps
                 <Icon
                   name={getWeatherIconByCondition({
                     condition: toolInvocation.output.data.condition,
-                    isDay: toolInvocation.output.data.details.isDay,
+                    isDay: toolInvocation.output.data.details?.isDay,
                   })}
                   size={48}
                   color="#3b82f6"
@@ -170,7 +170,7 @@ export function WeatherGenerativeUI({ toolInvocation }: WeatherGenerativeUIProps
                     </Text>
                   </View>
                   <Text className="text-lg font-semibold text-gray-900 dark:text-gray-100">
-                    {toolInvocation.output.data.details.humidity}%
+                    {toolInvocation.output.data.details?.humidity}%
                   </Text>
                 </View>
 
@@ -184,7 +184,7 @@ export function WeatherGenerativeUI({ toolInvocation }: WeatherGenerativeUIProps
                     </Text>
                   </View>
                   <Text className="text-lg font-semibold text-gray-900 dark:text-gray-100">
-                    {toolInvocation.output.data.details.windSpeed} mph
+                    {toolInvocation.output.data.details?.windSpeed} mph
                   </Text>
                 </View>
               </View>

--- a/apps/expo/features/ai/components/WeatherGenerativeUI.tsx
+++ b/apps/expo/features/ai/components/WeatherGenerativeUI.tsx
@@ -128,7 +128,7 @@ export function WeatherGenerativeUI({ toolInvocation }: WeatherGenerativeUIProps
               <Icon name="map-marker-radius-outline" size={16} color={colors.primary} />
               <Text className="text-base font-semibold text-blue-800 dark:text-blue-200">
                 {t('ai.tools.weatherIn', {
-                  location: toolInvocation.output.data.name,
+                  location: toolInvocation.output.data.name || toolInvocation.input.location,
                 })}
               </Text>
             </View>
@@ -140,7 +140,7 @@ export function WeatherGenerativeUI({ toolInvocation }: WeatherGenerativeUIProps
               <View className="flex-row items-center">
                 <Icon
                   name={getWeatherIconByCondition({
-                    condition: toolInvocation.output.data.condition,
+                    condition: toolInvocation.output.data.condition || '',
                     isDay: toolInvocation.output.data.details?.isDay,
                   })}
                   size={48}
@@ -153,7 +153,7 @@ export function WeatherGenerativeUI({ toolInvocation }: WeatherGenerativeUIProps
                     {toolInvocation.output.data.temperature}°
                   </Text>
                   <Text className="mt-1 text-base text-gray-600 dark:text-gray-300">
-                    {toolInvocation.output.data.condition}
+                    {toolInvocation.output.data.condition || '—'}
                   </Text>
                 </View>
               </View>
@@ -170,7 +170,7 @@ export function WeatherGenerativeUI({ toolInvocation }: WeatherGenerativeUIProps
                     </Text>
                   </View>
                   <Text className="text-lg font-semibold text-gray-900 dark:text-gray-100">
-                    {toolInvocation.output.data.details?.humidity}%
+                    {toolInvocation.output.data.details?.humidity ?? '—'}%
                   </Text>
                 </View>
 
@@ -184,7 +184,7 @@ export function WeatherGenerativeUI({ toolInvocation }: WeatherGenerativeUIProps
                     </Text>
                   </View>
                   <Text className="text-lg font-semibold text-gray-900 dark:text-gray-100">
-                    {toolInvocation.output.data.details?.windSpeed} mph
+                    {toolInvocation.output.data.details?.windSpeed ?? '—'} mph
                   </Text>
                 </View>
               </View>

--- a/apps/expo/features/weather/lib/weatherIcons.ts
+++ b/apps/expo/features/weather/lib/weatherIcons.ts
@@ -96,6 +96,7 @@ export function getWeatherIconByCondition({
   condition: string;
   isDay?: number;
 }): MaterialIconName {
+  if (!condition) return isDay ? 'weather-sunny' : 'weather-night';
   const conditionLower = condition.toLowerCase();
 
   // Clear, sunny

--- a/packages/api/src/utils/ai/tools.ts
+++ b/packages/api/src/utils/ai/tools.ts
@@ -35,7 +35,19 @@ export function createTools(userId: string) {
       execute: async ({ location }) => {
         try {
           const weatherData = await weatherService.getWeatherForLocation(location);
-          return { success: true, data: { ...weatherData } };
+          console.log('getWeatherForLocation tool success', { location, weatherData });
+          return {
+            success: true,
+            data: {
+              name: weatherData.location,
+              temperature: weatherData.temperature,
+              condition: weatherData.conditions,
+              details: {
+                humidity: weatherData.humidity,
+                windSpeed: weatherData.windSpeed,
+              },
+            },
+          };
         } catch (error) {
           console.error('getWeatherForLocation tool error', error);
           return {

--- a/packages/api/src/utils/ai/tools.ts
+++ b/packages/api/src/utils/ai/tools.ts
@@ -35,7 +35,6 @@ export function createTools(userId: string) {
       execute: async ({ location }) => {
         try {
           const weatherData = await weatherService.getWeatherForLocation(location);
-          console.log('getWeatherForLocation tool success', { location, weatherData });
           return {
             success: true,
             data: {


### PR DESCRIPTION
## Problem

`WeatherGenerativeUI` crashed with **"Cannot read property 'isDay' of undefined"** when `toolInvocation.output.data.details` was absent from the API response (e.g. partial/unexpected payloads).

Three fields were accessed unsafely:
- `details.isDay` — passed to `getWeatherIconByCondition`
- `details.humidity` — rendered in the weather card
- `details.windSpeed` — rendered in the weather card

## Fix

Added optional chaining (`?.`) on all three accesses so the component renders gracefully when `details` is undefined, matching the existing default behaviour in `getWeatherIconByCondition` (`isDay` defaults to `1`).