### PR TITLE
fix(expo): add Sentry instrumentation across all error-handling paths

### DIFF
--- a/apps/expo/app/(app)/(tabs)/profile/index.tsx
+++ b/apps/expo/app/(app)/(tabs)/profile/index.tsx
@@ -14,6 +14,7 @@ import {
   Text,
 } from '@packrat/ui/nativewindui';
 import AsyncStorage from '@react-native-async-storage/async-storage';
+import * as Sentry from '@sentry/react-native';
 import { AndroidTabBarInsetFix } from 'expo-app/components/AndroidTabBarInsetFix';
 import { Icon } from 'expo-app/components/Icon';
 import { isLoadingAtom, suppressSignOutNavAtom } from 'expo-app/features/auth/atoms/authAtoms';
@@ -208,6 +209,9 @@ function ListHeaderComponent() {
           { text: t('permissions.openSettings'), onPress: () => Linking.openSettings() },
         ]);
       } else {
+        Sentry.captureException(err, {
+          tags: { feature: 'profile', action: 'handleAvatarPress' },
+        });
         Alert.alert(t('errors.somethingWentWrong'), t('errors.tryAgain'));
       }
     } finally {

--- a/apps/expo/features/ai-packs/hooks/useGeneratedPacks.ts
+++ b/apps/expo/features/ai-packs/hooks/useGeneratedPacks.ts
@@ -1,4 +1,5 @@
 import { use$ } from '@legendapp/state/react';
+import * as Sentry from '@sentry/react-native';
 import { useMutation } from '@tanstack/react-query';
 import type { Pack } from 'expo-app/features/packs';
 import { packsStore } from 'expo-app/features/packs/store';
@@ -8,7 +9,14 @@ import type { GenerationRequest } from '../types';
 
 const generatePacks = async (request: GenerationRequest): Promise<Pack[]> => {
   const { data, error } = await apiClient.packs['generate-packs'].post(request);
-  if (error) throw new Error(`Failed to generate packs: ${error.value}`);
+  if (error) {
+    const err = new Error(String(error.value ?? 'Failed to generate packs'));
+    Sentry.captureException(err, {
+      tags: { feature: 'ai-packs', action: 'generatePacks' },
+      extra: { apiError: error.value, httpStatus: error.status },
+    });
+    throw err;
+  }
   // safe-cast: treaty response shape matches Pack[] as validated by the API schema
   return (data ?? []) as unknown as Pack[];
 };

--- a/apps/expo/features/ai-packs/screens/AIPacksScreen.tsx
+++ b/apps/expo/features/ai-packs/screens/AIPacksScreen.tsx
@@ -6,6 +6,7 @@ import {
   LargeTitleHeader,
   Text,
 } from '@packrat/ui/nativewindui';
+import * as Sentry from '@sentry/react-native';
 import { useForm } from '@tanstack/react-form';
 import { Icon } from 'expo-app/components/Icon';
 import { TextInput } from 'expo-app/components/TextInput';
@@ -33,6 +34,12 @@ export function AIPacksScreen() {
     },
     onSubmit: async ({ value }) => {
       try {
+        Sentry.addBreadcrumb({
+          category: 'ai',
+          message: 'Generating AI packs',
+          level: 'info',
+          data: { count: value.count },
+        });
         const packs = await generatePacks(value);
         alertRef.current?.alert({
           title: t('ai.packsGenerated'),
@@ -49,6 +56,9 @@ export function AIPacksScreen() {
           ],
         });
       } catch (error) {
+        Sentry.captureException(error, {
+          tags: { feature: 'ai', action: 'generatePacks' },
+        });
         alertRef.current?.alert({
           title: t('common.error'),
           message: t('ai.failedToGenerate'),

--- a/apps/expo/features/ai/atoms/chatStorageAtoms.ts
+++ b/apps/expo/features/ai/atoms/chatStorageAtoms.ts
@@ -1,6 +1,7 @@
 import type { UIMessage } from '@ai-sdk/react';
 import { isObject, isString } from '@packrat/guards';
 import AsyncStorage from '@react-native-async-storage/async-storage';
+import * as Sentry from '@sentry/react-native';
 
 export type ChatContext = {
   itemId?: string;
@@ -74,6 +75,9 @@ export async function loadChatMessages(context: ChatContext): Promise<UIMessage[
     return parsed;
   } catch (error) {
     console.error('Failed to load chat messages:', error);
+    Sentry.captureException(error, {
+      tags: { feature: 'ai.chat', action: 'loadChatMessages' },
+    });
     return null;
   }
 }
@@ -94,6 +98,9 @@ export async function saveChatMessages({
     await AsyncStorage.setItem(key, JSON.stringify(messages));
   } catch (error) {
     console.error('Failed to save chat messages:', error);
+    Sentry.captureException(error, {
+      tags: { feature: 'ai.chat', action: 'saveChatMessages' },
+    });
   }
 }
 
@@ -106,5 +113,8 @@ export async function clearChatMessages(context: ChatContext): Promise<void> {
     await AsyncStorage.removeItem(key);
   } catch (error) {
     console.error('Failed to clear chat messages:', error);
+    Sentry.captureException(error, {
+      tags: { feature: 'ai.chat', action: 'clearChatMessages' },
+    });
   }
 }

--- a/apps/expo/features/ai/components/ChatBubble.tsx
+++ b/apps/expo/features/ai/components/ChatBubble.tsx
@@ -1,6 +1,7 @@
 import { BottomSheetScrollView } from '@gorhom/bottom-sheet';
 import { keyIn } from '@packrat/guards';
 import { Sheet, Text, useColorScheme, useSheetRef } from '@packrat/ui/nativewindui';
+import * as Sentry from '@sentry/react-native';
 import type { ToolUIPart, UIMessage } from 'ai';
 import * as Burnt from 'burnt';
 import { Icon } from 'expo-app/components/Icon';
@@ -64,6 +65,9 @@ export const ChatBubble = React.memo(function ChatBubble({
       });
     } catch (error) {
       console.error('Failed to copy text:', error);
+      Sentry.captureException(error, {
+        tags: { feature: 'ai.chat', action: 'copyText' },
+      });
       Burnt.toast({
         title: t('ai.failedToCopyText'),
         preset: 'error',

--- a/apps/expo/features/ai/components/GuidesRAGGenerativeUI.tsx
+++ b/apps/expo/features/ai/components/GuidesRAGGenerativeUI.tsx
@@ -1,4 +1,5 @@
 import { Text, useColorScheme } from '@packrat/ui/nativewindui';
+import * as Sentry from '@sentry/react-native';
 import { Icon } from 'expo-app/components/Icon';
 import { useTranslation } from 'expo-app/lib/hooks/useTranslation';
 import { useRef, useState } from 'react';
@@ -90,6 +91,10 @@ export function GuidesRAGGenerativeUI({ toolInvocation }: GuidesRAGGenerativeUIP
       await Linking.openURL(url);
     } catch (error) {
       console.error('Failed to open URL:', error);
+      Sentry.captureException(error, {
+        tags: { feature: 'ai.guidesRAG', action: 'openGuide' },
+        extra: { url },
+      });
     }
   };
 

--- a/apps/expo/features/ai/components/WebSearchGenerativeUI.tsx
+++ b/apps/expo/features/ai/components/WebSearchGenerativeUI.tsx
@@ -3,6 +3,7 @@ import Fontisto from '@expo/vector-icons/Fontisto';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { BottomSheetScrollView } from '@gorhom/bottom-sheet';
 import { Card, CardContent, Sheet, Text, useSheetRef } from '@packrat/ui/nativewindui';
+import * as Sentry from '@sentry/react-native';
 import { Icon } from 'expo-app/components/Icon';
 import { useColorScheme } from 'expo-app/lib/hooks/useColorScheme';
 import { useTranslation } from 'expo-app/lib/hooks/useTranslation';
@@ -60,6 +61,10 @@ export function WebSearchGenerativeUI({ toolInvocation }: WebSearchGenerativeUIP
       }
     } catch (error) {
       console.error('Error opening URL:', error);
+      Sentry.captureException(error, {
+        tags: { feature: 'ai.webSearch', action: 'openSource' },
+        extra: { url },
+      });
     }
   };
 

--- a/apps/expo/features/ai/hooks/useReportContent.ts
+++ b/apps/expo/features/ai/hooks/useReportContent.ts
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/react-native';
 import { useMutation } from '@tanstack/react-query';
 import { apiClient } from 'expo-app/lib/api/packrat';
 import type { ReportReason } from '../lib/reportReasons';
@@ -23,7 +24,14 @@ export const reportContent = async (
     ...rest,
     ...(userComment != null ? { userComment } : {}),
   });
-  if (error) throw new Error(`Failed to report content: ${error.value}`);
+  if (error) {
+    const err = new Error(String(error.value ?? 'Failed to report content'));
+    Sentry.captureException(err, {
+      tags: { feature: 'ai', action: 'reportContent' },
+      extra: { apiError: error.value, httpStatus: error.status },
+    });
+    throw err;
+  }
   // safe-cast: treaty response shape matches ReportContentResponse as validated by the API schema
   return data as unknown as ReportContentResponse;
 };

--- a/apps/expo/features/ai/hooks/useReportedContent.ts
+++ b/apps/expo/features/ai/hooks/useReportedContent.ts
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/react-native';
 import { useQuery } from '@tanstack/react-query';
 import { useUser } from 'expo-app/features/auth/hooks/useUser';
 import type { User } from 'expo-app/features/profile/types';
@@ -25,7 +26,14 @@ type ReportedContentCount = {
 
 export const getReportedContent = async (): Promise<ReportedContentResponse> => {
   const { data, error } = await apiClient.chat.reports.get();
-  if (error) throw new Error(`Failed to fetch reported content: ${error.value}`);
+  if (error) {
+    const err = new Error(String(error.value ?? 'Failed to fetch reported content'));
+    Sentry.captureException(err, {
+      tags: { feature: 'ai', action: 'getReportedContent' },
+      extra: { apiError: error.value, httpStatus: error.status },
+    });
+    throw err;
+  }
   // safe-cast: treaty response shape matches ReportedContentResponse as validated by the API schema
   return data as unknown as ReportedContentResponse;
 };

--- a/apps/expo/features/ai/hooks/useUpdateReportStatus.ts
+++ b/apps/expo/features/ai/hooks/useUpdateReportStatus.ts
@@ -17,7 +17,12 @@ export const updateReportStatus = async (
     const err = new Error(String(error.value ?? 'Failed to update report status'));
     Sentry.captureException(err, {
       tags: { feature: 'ai', action: 'updateReportStatus' },
-      extra: { id: payload.id, status: payload.status, apiError: error.value, httpStatus: error.status },
+      extra: {
+        id: payload.id,
+        status: payload.status,
+        apiError: error.value,
+        httpStatus: error.status,
+      },
     });
     throw err;
   }

--- a/apps/expo/features/ai/hooks/useUpdateReportStatus.ts
+++ b/apps/expo/features/ai/hooks/useUpdateReportStatus.ts
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/react-native';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { apiClient } from 'expo-app/lib/api/packrat';
 
@@ -12,7 +13,14 @@ export const updateReportStatus = async (
   const { data, error } = await apiClient.chat.reports({ id: payload.id }).patch({
     status: payload.status,
   });
-  if (error) throw new Error(`Failed to update report status: ${error.value}`);
+  if (error) {
+    const err = new Error(String(error.value ?? 'Failed to update report status'));
+    Sentry.captureException(err, {
+      tags: { feature: 'ai', action: 'updateReportStatus' },
+      extra: { id: payload.id, status: payload.status, apiError: error.value, httpStatus: error.status },
+    });
+    throw err;
+  }
   return data as unknown as { success: boolean };
 };
 

--- a/apps/expo/features/ai/lib/tools.ts
+++ b/apps/expo/features/ai/lib/tools.ts
@@ -83,6 +83,10 @@ export function createLocalTools(isAuthenticated = false) {
             })),
           };
         } catch (error) {
+          Sentry.captureException(error, {
+            tags: { feature: 'ai.tool', action: 'getPackDetails' },
+            extra: { packId },
+          });
           return {
             success: false,
             error: error instanceof Error ? error.message : 'Failed to get pack details',
@@ -105,6 +109,10 @@ export function createLocalTools(isAuthenticated = false) {
           }
           return { success: true, data: item };
         } catch (error) {
+          Sentry.captureException(error, {
+            tags: { feature: 'ai.tool', action: 'getPackItemDetails' },
+            extra: { itemId },
+          });
           return {
             success: false,
             error: error instanceof Error ? error.message : 'Failed to get item details',
@@ -140,8 +148,10 @@ export function createLocalTools(isAuthenticated = false) {
           const weatherData = await getWeatherData(first.id);
           return { success: true, data: formatWeatherData(weatherData) };
         } catch (error) {
-          console.log('getWeatherForLocation error', { error });
-
+          Sentry.captureException(error, {
+            tags: { feature: 'ai.tool', action: 'getWeatherForLocation' },
+            extra: { location },
+          });
           return {
             success: false,
             error: error instanceof Error ? error.message : 'Failed to get weather data',
@@ -166,6 +176,12 @@ export function createLocalTools(isAuthenticated = false) {
       }),
       execute: async ({ query, category, limit = 5, offset: _offset = 0 }) => {
         console.log('getCatalogItems called with', { query, category, limit, offset: _offset });
+        Sentry.addBreadcrumb({
+          category: 'ai.tool',
+          message: 'getCatalogItems called',
+          level: 'info',
+          data: { query, category, limit },
+        });
         const { data, error } = await apiClient.catalog.get({
           query: {
             page: 1,
@@ -175,6 +191,13 @@ export function createLocalTools(isAuthenticated = false) {
           },
         });
         if (error) {
+          Sentry.captureException(
+            new Error(String(error.value ?? 'Failed to retrieve catalog items')),
+            {
+              tags: { feature: 'ai.tool', action: 'getCatalogItems' },
+              extra: { query, category, limit, apiError: error.value, httpStatus: error.status },
+            },
+          );
           return { success: false, error: error.value ?? 'Failed to retrieve catalog items' };
         }
         const items = Array.isArray(data) ? data : ((data as { items?: unknown[] })?.items ?? []);
@@ -198,10 +221,23 @@ export function createLocalTools(isAuthenticated = false) {
         offset: z.number().min(0).optional().describe('Offset for pagination'),
       }),
       execute: async ({ query, limit = 5, offset = 0 }) => {
+        Sentry.addBreadcrumb({
+          category: 'ai.tool',
+          message: 'catalogVectorSearch called',
+          level: 'info',
+          data: { query, limit, offset },
+        });
         const { data, error } = await apiClient.catalog['vector-search'].get({
           query: { q: query, limit, offset },
         });
         if (error) {
+          Sentry.captureException(
+            new Error(String(error.value ?? 'Failed to perform vector search')),
+            {
+              tags: { feature: 'ai.tool', action: 'catalogVectorSearch' },
+              extra: { query, limit, offset, apiError: error.value, httpStatus: error.status },
+            },
+          );
           return { success: false, error: error.value ?? 'Failed to perform vector search' };
         }
         const items = Array.isArray(data) ? data : ((data as { items?: unknown[] })?.items ?? []);
@@ -225,10 +261,23 @@ export function createLocalTools(isAuthenticated = false) {
           .describe('Number of results to return (default 5)'),
       }),
       execute: async ({ query, limit = 5 }) => {
+        Sentry.addBreadcrumb({
+          category: 'ai.tool',
+          message: 'searchPackratOutdoorGuidesRAG called',
+          level: 'info',
+          data: { query, limit },
+        });
         const { data, error } = await apiClient.ai['rag-search'].get({
           query: { q: query, limit },
         });
         if (error) {
+          Sentry.captureException(
+            new Error(String(error.value ?? 'Failed to search outdoor guides')),
+            {
+              tags: { feature: 'ai.tool', action: 'searchPackratOutdoorGuidesRAG' },
+              extra: { query, limit, apiError: error.value, httpStatus: error.status },
+            },
+          );
           return { success: false, error: error.value ?? 'Failed to search outdoor guides' };
         }
         return { success: true, data };
@@ -248,10 +297,20 @@ export function createLocalTools(isAuthenticated = false) {
         query: z.string().describe('The search query - be specific and include relevant keywords'),
       }),
       execute: async ({ query }) => {
+        Sentry.addBreadcrumb({
+          category: 'ai.tool',
+          message: 'webSearchTool called',
+          level: 'info',
+          data: { query },
+        });
         const { data, error } = await apiClient.ai['web-search'].get({
           query: { q: query },
         });
         if (error) {
+          Sentry.captureException(new Error(String(error.value ?? 'Web search failed')), {
+            tags: { feature: 'ai.tool', action: 'webSearchTool' },
+            extra: { query, apiError: error.value, httpStatus: error.status },
+          });
           return { success: false, error: error.value ?? 'Search failed' };
         }
         return { success: true, data };
@@ -274,8 +333,18 @@ export function createLocalTools(isAuthenticated = false) {
           .describe('Maximum number of rows to return (default: 100, max: 1000)'),
       }),
       execute: async ({ query, limit = 100 }) => {
+        Sentry.addBreadcrumb({
+          category: 'ai.tool',
+          message: 'executeSql called',
+          level: 'info',
+          data: { limit },
+        });
         const { data, error } = await apiClient.ai['execute-sql'].post({ query, limit });
         if (error) {
+          Sentry.captureException(new Error(String(error.value ?? 'Failed to execute SQL query')), {
+            tags: { feature: 'ai.tool', action: 'executeSql' },
+            extra: { apiError: error.value, httpStatus: error.status },
+          });
           return { success: false, error: error.value ?? 'Failed to execute query' };
         }
         return data;
@@ -287,8 +356,20 @@ export function createLocalTools(isAuthenticated = false) {
         'Retrieve the database schema (table names and columns). Call this before executeSql if you are unsure which tables or columns exist.',
       inputSchema: z.object({}),
       execute: async () => {
+        Sentry.addBreadcrumb({
+          category: 'ai.tool',
+          message: 'getDatabaseSchema called',
+          level: 'info',
+        });
         const { data, error } = await apiClient.ai['db-schema'].get();
         if (error) {
+          Sentry.captureException(
+            new Error(String(error.value ?? 'Failed to retrieve database schema')),
+            {
+              tags: { feature: 'ai.tool', action: 'getDatabaseSchema' },
+              extra: { apiError: error.value, httpStatus: error.status },
+            },
+          );
           return { success: false, error: error.value ?? 'Failed to retrieve database schema' };
         }
         return { success: true, data };

--- a/apps/expo/features/auth/components/DeleteAccountButton.tsx
+++ b/apps/expo/features/auth/components/DeleteAccountButton.tsx
@@ -1,5 +1,6 @@
 import type { AlertMethods } from '@packrat/ui/nativewindui';
 import { ActivityIndicator, Alert, Button, Text } from '@packrat/ui/nativewindui';
+import * as Sentry from '@sentry/react-native';
 import { Icon } from 'expo-app/components/Icon';
 import { useAuth } from 'expo-app/features/auth/hooks/useAuth';
 import { useColorScheme } from 'expo-app/lib/hooks/useColorScheme';
@@ -42,7 +43,10 @@ export function DeleteAccountButton() {
                     try {
                       setIsDeleting(true);
                       await deleteAccount(); // handles redirect
-                    } catch (_error) {
+                    } catch (deleteError) {
+                      Sentry.captureException(deleteError, {
+                        tags: { feature: 'auth', action: 'deleteAccount' },
+                      });
                       setTimeout(() => {
                         alertRef.current?.alert({
                           title: t('common.error'),

--- a/apps/expo/features/catalog/hooks/useCatalogItemDetails.ts
+++ b/apps/expo/features/catalog/hooks/useCatalogItemDetails.ts
@@ -1,11 +1,19 @@
 import { CatalogItemSchema } from '@packrat/schemas/catalog';
+import * as Sentry from '@sentry/react-native';
 import { useQuery } from '@tanstack/react-query';
 import { apiClient } from 'expo-app/lib/api/packrat';
 import { useAuthenticatedQueryToolkit } from 'expo-app/lib/hooks/useAuthenticatedQueryToolkit';
 
 export const getCatalogItem = async (id: string) => {
   const { data, error } = await apiClient.catalog({ id }).get();
-  if (error) throw new Error(`Failed to fetch catalog item: ${error.value}`);
+  if (error) {
+    const err = new Error(String(error.value ?? 'Failed to fetch catalog item'));
+    Sentry.captureException(err, {
+      tags: { feature: 'catalog', action: 'getCatalogItem' },
+      extra: { id, apiError: error.value, httpStatus: error.status },
+    });
+    throw err;
+  }
   return CatalogItemSchema.parse(data);
 };
 

--- a/apps/expo/features/catalog/hooks/useCatalogItems.ts
+++ b/apps/expo/features/catalog/hooks/useCatalogItems.ts
@@ -1,4 +1,5 @@
 import { CatalogItemsResponseSchema } from '@packrat/schemas/catalog';
+import * as Sentry from '@sentry/react-native';
 import { useInfiniteQuery } from '@tanstack/react-query';
 import { apiClient } from 'expo-app/lib/api/packrat';
 
@@ -36,7 +37,14 @@ export const getCatalogItems = async ({
       ...(sort ? { sort } : {}),
     },
   });
-  if (error) throw new Error(`Failed to fetch catalog items: ${error.value}`);
+  if (error) {
+    const err = new Error(String(error.value ?? 'Failed to fetch catalog items'));
+    Sentry.captureException(err, {
+      tags: { feature: 'catalog', action: 'getCatalogItems' },
+      extra: { pageParam, query, category, apiError: error.value, httpStatus: error.status },
+    });
+    throw err;
+  }
   const parseResult = CatalogItemsResponseSchema.safeParse(data);
   if (parseResult.success) return parseResult.data;
   // Fallback: strict per-field validation failed (e.g., live DB has weightUnit values outside the

--- a/apps/expo/features/catalog/hooks/useCatalogItemsCategories.ts
+++ b/apps/expo/features/catalog/hooks/useCatalogItemsCategories.ts
@@ -1,5 +1,5 @@
-import { useQuery } from '@tanstack/react-query';
 import * as Sentry from '@sentry/react-native';
+import { useQuery } from '@tanstack/react-query';
 import { apiClient } from 'expo-app/lib/api/packrat';
 import { useAuthenticatedQueryToolkit } from 'expo-app/lib/hooks/useAuthenticatedQueryToolkit';
 

--- a/apps/expo/features/catalog/hooks/useCatalogItemsCategories.ts
+++ b/apps/expo/features/catalog/hooks/useCatalogItemsCategories.ts
@@ -1,4 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
+import * as Sentry from '@sentry/react-native';
 import { apiClient } from 'expo-app/lib/api/packrat';
 import { useAuthenticatedQueryToolkit } from 'expo-app/lib/hooks/useAuthenticatedQueryToolkit';
 
@@ -7,7 +8,14 @@ const getCategories = async (): Promise<string[]> => {
   // explicitly. Treaty also infers the response as `{}` when the route
   // returns a bare `string[]`, so cast through unknown.
   const { data, error } = await apiClient.catalog.categories.get({ query: { limit: 10 } });
-  if (error) throw new Error(`Failed to fetch catalog categories: ${error.value}`);
+  if (error) {
+    const err = new Error(String(error.value ?? 'Failed to fetch catalog categories'));
+    Sentry.captureException(err, {
+      tags: { feature: 'catalog', action: 'getCategories' },
+      extra: { apiError: error.value, httpStatus: error.status },
+    });
+    throw err;
+  }
   return (data as unknown as string[]) ?? [];
 };
 

--- a/apps/expo/features/catalog/hooks/useSimilarItems.ts
+++ b/apps/expo/features/catalog/hooks/useSimilarItems.ts
@@ -1,5 +1,5 @@
-import { useQuery } from '@tanstack/react-query';
 import * as Sentry from '@sentry/react-native';
+import { useQuery } from '@tanstack/react-query';
 import { apiClient } from 'expo-app/lib/api/packrat';
 import { useAuthenticatedQueryToolkit } from 'expo-app/lib/hooks/useAuthenticatedQueryToolkit';
 import type { CatalogItem } from '../types';

--- a/apps/expo/features/catalog/hooks/useSimilarItems.ts
+++ b/apps/expo/features/catalog/hooks/useSimilarItems.ts
@@ -1,4 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
+import * as Sentry from '@sentry/react-native';
 import { apiClient } from 'expo-app/lib/api/packrat';
 import { useAuthenticatedQueryToolkit } from 'expo-app/lib/hooks/useAuthenticatedQueryToolkit';
 import type { CatalogItem } from '../types';
@@ -31,7 +32,14 @@ export const getSimilarCatalogItems = async ({
       ...(params?.threshold !== undefined ? { threshold: String(params.threshold) } : {}),
     },
   });
-  if (error) throw new Error(`Failed to fetch similar catalog items: ${error.value}`);
+  if (error) {
+    const err = new Error(String(error.value ?? 'Failed to fetch similar catalog items'));
+    Sentry.captureException(err, {
+      tags: { feature: 'catalog', action: 'getSimilarCatalogItems' },
+      extra: { id, apiError: error.value, httpStatus: error.status },
+    });
+    throw err;
+  }
   // safe-cast: treaty response shape matches SimilarItemsResponse as validated by the API schema
   return data as unknown as SimilarItemsResponse;
 };
@@ -53,7 +61,14 @@ export const getSimilarPackItems = async ({
         ...(params?.threshold !== undefined ? { threshold: String(params.threshold) } : {}),
       },
     });
-  if (error) throw new Error(`Failed to fetch similar pack items: ${error.value}`);
+  if (error) {
+    const err = new Error(String(error.value ?? 'Failed to fetch similar pack items'));
+    Sentry.captureException(err, {
+      tags: { feature: 'catalog', action: 'getSimilarPackItems' },
+      extra: { packId, itemId, apiError: error.value, httpStatus: error.status },
+    });
+    throw err;
+  }
   return data;
 };
 

--- a/apps/expo/features/catalog/hooks/useVectorSearch.ts
+++ b/apps/expo/features/catalog/hooks/useVectorSearch.ts
@@ -1,4 +1,5 @@
 import { VectorSearchResponseSchema } from '@packrat/schemas/catalog';
+import * as Sentry from '@sentry/react-native';
 import { useQuery } from '@tanstack/react-query';
 import { apiClient } from 'expo-app/lib/api/packrat';
 import { useAuthenticatedQueryToolkit } from 'expo-app/lib/hooks/useAuthenticatedQueryToolkit';
@@ -13,7 +14,14 @@ const vectorSearchApi = async ({ query, limit }: { query: string; limit?: number
       offset: 0,
     },
   });
-  if (error) throw new Error(`Vector search API error: ${error.value}`);
+  if (error) {
+    const err = new Error(String(error.value ?? 'Vector search API error'));
+    Sentry.captureException(err, {
+      tags: { feature: 'catalog', action: 'vectorSearch' },
+      extra: { query, limit, apiError: error.value, httpStatus: error.status },
+    });
+    throw err;
+  }
   return VectorSearchResponseSchema.parse(data);
 };
 

--- a/apps/expo/features/catalog/lib/cacheCatalogItemImage.ts
+++ b/apps/expo/features/catalog/lib/cacheCatalogItemImage.ts
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/react-native';
 import ImageCacheManager from 'expo-app/lib/utils/ImageCacheManager';
 import { getImageExtension } from 'expo-app/lib/utils/imageUtils';
 import { nanoid } from 'nanoid';
@@ -14,6 +15,10 @@ export async function cacheCatalogItemImage(imageUrl?: string): Promise<string |
     return filename;
   } catch (err) {
     console.log('caching remote image failed', err);
+    Sentry.captureException(err, {
+      tags: { feature: 'catalog', action: 'cacheCatalogItemImage' },
+      extra: { imageUrl },
+    });
     return null;
   }
 }

--- a/apps/expo/features/feed/hooks/useAddComment.ts
+++ b/apps/expo/features/feed/hooks/useAddComment.ts
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/react-native';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { apiClient } from 'expo-app/lib/api/packrat';
 
@@ -16,7 +17,14 @@ export const useAddComment = () => {
         content,
         ...(parentCommentId !== undefined ? { parentCommentId } : {}),
       });
-      if (error) throw new Error(`Failed to add comment: ${error.value}`);
+      if (error) {
+        const err = new Error(String(error.value ?? 'Failed to add comment'));
+        Sentry.captureException(err, {
+          tags: { feature: 'feed', action: 'addComment' },
+          extra: { postId, parentCommentId, apiError: error.value, httpStatus: error.status },
+        });
+        throw err;
+      }
       return data;
     },
     onSuccess: (_data, variables) => {

--- a/apps/expo/features/feed/hooks/useCreatePost.ts
+++ b/apps/expo/features/feed/hooks/useCreatePost.ts
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/react-native';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { apiClient } from 'expo-app/lib/api/packrat';
 
@@ -12,7 +13,14 @@ export const useCreatePost = () => {
   return useMutation({
     mutationFn: async (input: CreatePostInput) => {
       const { data, error } = await apiClient.feed.post(input);
-      if (error) throw new Error(`Failed to create post: ${error.value}`);
+      if (error) {
+        const err = new Error(String(error.value ?? 'Failed to create post'));
+        Sentry.captureException(err, {
+          tags: { feature: 'feed', action: 'createPost' },
+          extra: { apiError: error.value, httpStatus: error.status },
+        });
+        throw err;
+      }
       return data;
     },
     onSuccess: () => {

--- a/apps/expo/features/feed/hooks/useDeleteComment.ts
+++ b/apps/expo/features/feed/hooks/useDeleteComment.ts
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/react-native';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { apiClient } from 'expo-app/lib/api/packrat';
 
@@ -10,7 +11,14 @@ export const useDeleteComment = () => {
         .feed({ postId: String(postId) })
         .comments({ commentId: String(commentId) })
         .delete();
-      if (error) throw new Error(`Failed to delete comment: ${error.value}`);
+      if (error) {
+        const err = new Error(String(error.value ?? 'Failed to delete comment'));
+        Sentry.captureException(err, {
+          tags: { feature: 'feed', action: 'deleteComment' },
+          extra: { postId, commentId, apiError: error.value, httpStatus: error.status },
+        });
+        throw err;
+      }
     },
     onSuccess: (_data, variables) => {
       queryClient.invalidateQueries({ queryKey: ['feed', variables.postId, 'comments'] });

--- a/apps/expo/features/feed/hooks/useDeletePost.ts
+++ b/apps/expo/features/feed/hooks/useDeletePost.ts
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/react-native';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { apiClient } from 'expo-app/lib/api/packrat';
 
@@ -7,7 +8,14 @@ export const useDeletePost = () => {
   return useMutation({
     mutationFn: async (postId: number) => {
       const { error } = await apiClient.feed({ postId: String(postId) }).delete();
-      if (error) throw new Error(`Failed to delete post: ${error.value}`);
+      if (error) {
+        const err = new Error(String(error.value ?? 'Failed to delete post'));
+        Sentry.captureException(err, {
+          tags: { feature: 'feed', action: 'deletePost' },
+          extra: { postId, apiError: error.value, httpStatus: error.status },
+        });
+        throw err;
+      }
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['feed'] });

--- a/apps/expo/features/feed/hooks/useFeed.ts
+++ b/apps/expo/features/feed/hooks/useFeed.ts
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/react-native';
 import { useInfiniteQuery } from '@tanstack/react-query';
 import { apiClient } from 'expo-app/lib/api/packrat';
 
@@ -8,7 +9,14 @@ export const useFeed = () => {
       const { data, error } = await apiClient.feed.get({
         query: { page: pageParam, limit: 20 },
       });
-      if (error) throw new Error(`Failed to fetch feed: ${error.value}`);
+      if (error) {
+        const err = new Error(String(error.value ?? 'Failed to fetch feed'));
+        Sentry.captureException(err, {
+          tags: { feature: 'feed', action: 'fetchFeed' },
+          extra: { page: pageParam, apiError: error.value, httpStatus: error.status },
+        });
+        throw err;
+      }
       return data;
     },
     getNextPageParam: (lastPage) => {

--- a/apps/expo/features/feed/hooks/usePostComments.ts
+++ b/apps/expo/features/feed/hooks/usePostComments.ts
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/react-native';
 import { useInfiniteQuery } from '@tanstack/react-query';
 import { apiClient } from 'expo-app/lib/api/packrat';
 
@@ -8,7 +9,14 @@ export const usePostComments = (postId: number) => {
       const { data, error } = await apiClient
         .feed({ postId: String(postId) })
         .comments.get({ query: { page: pageParam, limit: 20 } });
-      if (error) throw new Error(`Failed to fetch comments: ${error.value}`);
+      if (error) {
+        const err = new Error(String(error.value ?? 'Failed to fetch comments'));
+        Sentry.captureException(err, {
+          tags: { feature: 'feed', action: 'fetchPostComments' },
+          extra: { postId, page: pageParam, apiError: error.value, httpStatus: error.status },
+        });
+        throw err;
+      }
       return data;
     },
     getNextPageParam: (lastPage) => {

--- a/apps/expo/features/feed/hooks/useToggleCommentLike.ts
+++ b/apps/expo/features/feed/hooks/useToggleCommentLike.ts
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/react-native';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { apiClient } from 'expo-app/lib/api/packrat';
 
@@ -10,7 +11,14 @@ export const useToggleCommentLike = () => {
         .feed({ postId: String(postId) })
         .comments({ commentId: String(commentId) })
         .like.post();
-      if (error) throw new Error(`Failed to toggle comment like: ${error.value}`);
+      if (error) {
+        const err = new Error(String(error.value ?? 'Failed to toggle comment like'));
+        Sentry.captureException(err, {
+          tags: { feature: 'feed', action: 'toggleCommentLike' },
+          extra: { postId, commentId, apiError: error.value, httpStatus: error.status },
+        });
+        throw err;
+      }
       return data;
     },
     onSuccess: (_data, variables) => {

--- a/apps/expo/features/feed/hooks/useTogglePostLike.ts
+++ b/apps/expo/features/feed/hooks/useTogglePostLike.ts
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/react-native';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { apiClient } from 'expo-app/lib/api/packrat';
 
@@ -7,7 +8,14 @@ export const useTogglePostLike = () => {
   return useMutation({
     mutationFn: async (postId: number) => {
       const { data, error } = await apiClient.feed({ postId: String(postId) }).like.post();
-      if (error) throw new Error(`Failed to toggle post like: ${error.value}`);
+      if (error) {
+        const err = new Error(String(error.value ?? 'Failed to toggle post like'));
+        Sentry.captureException(err, {
+          tags: { feature: 'feed', action: 'togglePostLike' },
+          extra: { postId, apiError: error.value, httpStatus: error.status },
+        });
+        throw err;
+      }
       return data;
     },
     onSuccess: () => {

--- a/apps/expo/features/feed/screens/CreatePostScreen.tsx
+++ b/apps/expo/features/feed/screens/CreatePostScreen.tsx
@@ -1,4 +1,5 @@
 import { ActivityIndicator, Button, Text } from '@packrat/ui/nativewindui';
+import * as Sentry from '@sentry/react-native';
 import { Icon } from 'expo-app/components/Icon';
 import { TextInput } from 'expo-app/components/TextInput';
 import { uploadImage } from 'expo-app/features/packs/utils/uploadImage';
@@ -49,6 +50,9 @@ export const CreatePostScreen = ({ onSuccess }: { onSuccess?: () => void }) => {
       }
     } catch (err) {
       console.error('Error picking images:', err);
+      Sentry.captureException(err, {
+        tags: { feature: 'feed', action: 'pickImages' },
+      });
     }
   }, [t]);
 
@@ -75,6 +79,9 @@ export const CreatePostScreen = ({ onSuccess }: { onSuccess?: () => void }) => {
       }
     } catch (err) {
       console.error('Error taking photo:', err);
+      Sentry.captureException(err, {
+        tags: { feature: 'feed', action: 'takePhoto' },
+      });
     }
   }, [t]);
 
@@ -125,6 +132,10 @@ export const CreatePostScreen = ({ onSuccess }: { onSuccess?: () => void }) => {
       );
     } catch (err) {
       console.error('Upload error:', err);
+      Sentry.captureException(err, {
+        tags: { feature: 'feed', action: 'handleSubmit.upload' },
+        extra: { photoCount: photos.length },
+      });
       Alert.alert(t('common.error'), t('feed.uploadFailed'));
     } finally {
       setUploading(false);

--- a/apps/expo/features/feed/screens/CreatePostScreen.tsx
+++ b/apps/expo/features/feed/screens/CreatePostScreen.tsx
@@ -132,10 +132,6 @@ export const CreatePostScreen = ({ onSuccess }: { onSuccess?: () => void }) => {
       );
     } catch (err) {
       console.error('Upload error:', err);
-      Sentry.captureException(err, {
-        tags: { feature: 'feed', action: 'handleSubmit.upload' },
-        extra: { photoCount: photos.length },
-      });
       Alert.alert(t('common.error'), t('feed.uploadFailed'));
     } finally {
       setUploading(false);

--- a/apps/expo/features/guides/hooks/useGuideCategories.ts
+++ b/apps/expo/features/guides/hooks/useGuideCategories.ts
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/react-native';
 import { useQuery } from '@tanstack/react-query';
 import { apiClient } from 'expo-app/lib/api/packrat';
 import { useTranslation } from 'expo-app/lib/hooks/useTranslation';
@@ -9,7 +10,14 @@ export const useGuideCategories = () => {
     queryKey: ['guide-categories'],
     queryFn: async () => {
       const { data, error } = await apiClient.guides.categories.get();
-      if (error) throw new Error(`Failed to fetch guide categories: ${error.value}`);
+      if (error) {
+        const err = new Error(String(error.value ?? 'Failed to fetch guide categories'));
+        Sentry.captureException(err, {
+          tags: { feature: 'guides', action: 'fetchGuideCategories' },
+          extra: { apiError: error.value, httpStatus: error.status },
+        });
+        throw err;
+      }
 
       return [
         t('guides.all'),

--- a/apps/expo/features/guides/hooks/useGuideDetails.ts
+++ b/apps/expo/features/guides/hooks/useGuideDetails.ts
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/react-native';
 import { useQuery } from '@tanstack/react-query';
 import { apiClient } from 'expo-app/lib/api/packrat';
 
@@ -6,7 +7,14 @@ export const useGuideDetails = (id: string) => {
     queryKey: ['guide', id],
     queryFn: async () => {
       const { data, error } = await apiClient.guides({ id }).get();
-      if (error) throw new Error(`Failed to fetch guide: ${error.value}`);
+      if (error) {
+        const err = new Error(String(error.value ?? 'Failed to fetch guide'));
+        Sentry.captureException(err, {
+          tags: { feature: 'guides', action: 'fetchGuideDetails' },
+          extra: { id, apiError: error.value, httpStatus: error.status },
+        });
+        throw err;
+      }
       return data;
     },
     enabled: !!id,

--- a/apps/expo/features/guides/hooks/useGuides.ts
+++ b/apps/expo/features/guides/hooks/useGuides.ts
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/react-native';
 import { useInfiniteQuery } from '@tanstack/react-query';
 import { apiClient } from 'expo-app/lib/api/packrat';
 
@@ -26,7 +27,14 @@ export const useGuides = ({ category, sort }: UseGuidesParams = {}) => {
             : {}),
         },
       });
-      if (error) throw new Error(`Failed to fetch guides: ${error.value}`);
+      if (error) {
+        const err = new Error(String(error.value ?? 'Failed to fetch guides'));
+        Sentry.captureException(err, {
+          tags: { feature: 'guides', action: 'fetchGuides' },
+          extra: { page: pageParam, category, apiError: error.value, httpStatus: error.status },
+        });
+        throw err;
+      }
       return data;
     },
     getNextPageParam: (lastPage) => {

--- a/apps/expo/features/guides/hooks/useSearchGuides.ts
+++ b/apps/expo/features/guides/hooks/useSearchGuides.ts
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/react-native';
 import { useInfiniteQuery } from '@tanstack/react-query';
 import { apiClient } from 'expo-app/lib/api/packrat';
 
@@ -18,7 +19,14 @@ export const useSearchGuides = ({ query, category }: UseSearchGuidesParams) => {
           ...(category ? { category } : {}),
         },
       });
-      if (error) throw new Error(`Failed to search guides: ${error.value}`);
+      if (error) {
+        const err = new Error(String(error.value ?? 'Failed to search guides'));
+        Sentry.captureException(err, {
+          tags: { feature: 'guides', action: 'searchGuides' },
+          extra: { query, page: pageParam, category, apiError: error.value, httpStatus: error.status },
+        });
+        throw err;
+      }
       return data;
     },
     getNextPageParam: (lastPage) => {

--- a/apps/expo/features/guides/hooks/useSearchGuides.ts
+++ b/apps/expo/features/guides/hooks/useSearchGuides.ts
@@ -23,7 +23,13 @@ export const useSearchGuides = ({ query, category }: UseSearchGuidesParams) => {
         const err = new Error(String(error.value ?? 'Failed to search guides'));
         Sentry.captureException(err, {
           tags: { feature: 'guides', action: 'searchGuides' },
-          extra: { query, page: pageParam, category, apiError: error.value, httpStatus: error.status },
+          extra: {
+            query,
+            page: pageParam,
+            category,
+            apiError: error.value,
+            httpStatus: error.status,
+          },
         });
         throw err;
       }

--- a/apps/expo/features/pack-templates/hooks/useBulkAddCatalogItems.ts
+++ b/apps/expo/features/pack-templates/hooks/useBulkAddCatalogItems.ts
@@ -1,5 +1,6 @@
 import { fromZod } from '@packrat/guards';
 import { WeightUnitSchema } from '@packrat/schemas/constants';
+import * as Sentry from '@sentry/react-native';
 import { cacheCatalogItemImage } from 'expo-app/features/catalog/lib/cacheCatalogItemImage';
 import type { CatalogItemWithPackItemFields } from 'expo-app/features/catalog/types';
 import { useState } from 'react';
@@ -46,6 +47,10 @@ export function useBulkAddCatalogItems() {
       }
     } catch (error) {
       console.error('Error adding items to pack template:', error);
+      Sentry.captureException(error, {
+        tags: { feature: 'packTemplates', action: 'bulkAddCatalogItems' },
+        extra: { packTemplateId, itemCount: catalogItems.length },
+      });
       throw error;
     } finally {
       setIsLoading(false);

--- a/apps/expo/features/pack-templates/hooks/useGenerateTemplateFromOnlineContent.ts
+++ b/apps/expo/features/pack-templates/hooks/useGenerateTemplateFromOnlineContent.ts
@@ -1,4 +1,5 @@
 import { isObject } from '@packrat/guards';
+import * as Sentry from '@sentry/react-native';
 import { useMutation } from '@tanstack/react-query';
 import { apiClient } from 'expo-app/lib/api/packrat';
 import { obs } from 'expo-app/lib/store';
@@ -72,6 +73,15 @@ export function useGenerateTemplateFromOnlineContent() {
           importError.code = value.code;
           importError.existingTemplateId = value.existingTemplateId;
         }
+        Sentry.captureException(importError, {
+          tags: { feature: 'packTemplates', action: 'generateFromOnlineContent' },
+          extra: {
+            contentUrl: input.contentUrl,
+            apiError: value,
+            httpStatus: error.status,
+            errorCode: importError.code,
+          },
+        });
         throw importError;
       }
       // safe-cast: treaty response shape matches GeneratedTemplate as validated by the API schema

--- a/apps/expo/features/packs/hooks/useAllPacks.ts
+++ b/apps/expo/features/packs/hooks/useAllPacks.ts
@@ -1,10 +1,18 @@
+import * as Sentry from '@sentry/react-native';
 import { useQuery } from '@tanstack/react-query';
 import { apiClient } from 'expo-app/lib/api/packrat';
 import { useAuthenticatedQueryToolkit } from 'expo-app/lib/hooks/useAuthenticatedQueryToolkit';
 
 export const fetchAllPacks = async () => {
   const { data, error } = await apiClient.packs.get({ query: { includePublic: 0 } });
-  if (error) throw new Error(`Failed to fetch all packs: ${error.value}`);
+  if (error) {
+    const err = new Error(String(error.value ?? 'Failed to fetch all packs'));
+    Sentry.captureException(err, {
+      tags: { feature: 'packs', action: 'fetchAllPacks' },
+      extra: { apiError: error.value, httpStatus: error.status },
+    });
+    throw err;
+  }
   return data ?? [];
 };
 

--- a/apps/expo/features/packs/hooks/useBulkAddCatalogItems.ts
+++ b/apps/expo/features/packs/hooks/useBulkAddCatalogItems.ts
@@ -1,5 +1,6 @@
 import { fromZod } from '@packrat/guards';
 import { WeightUnitSchema } from '@packrat/schemas/constants';
+import * as Sentry from '@sentry/react-native';
 import { useState } from 'react';
 import { cacheCatalogItemImage } from '../../catalog/lib/cacheCatalogItemImage';
 import type { CatalogItemWithPackItemFields } from '../../catalog/types';
@@ -46,6 +47,10 @@ export function useBulkAddCatalogItems() {
       }
     } catch (error) {
       console.error('Error adding items to pack:', error);
+      Sentry.captureException(error, {
+        tags: { feature: 'packs', action: 'bulkAddCatalogItems' },
+        extra: { packId, itemCount: catalogItems.length },
+      });
       throw error;
     } finally {
       setIsLoading(false);

--- a/apps/expo/features/packs/hooks/useDuplicatePack.ts
+++ b/apps/expo/features/packs/hooks/useDuplicatePack.ts
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/react-native';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { apiClient } from 'expo-app/lib/api/packrat';
 import { useCallback } from 'react';
@@ -20,7 +21,14 @@ export function useDuplicatePack() {
         queryKey: ['pack', packId],
         queryFn: async () => {
           const { data, error } = await apiClient.packs({ packId }).get();
-          if (error) throw new Error(`Failed to fetch pack: ${error.value}`);
+          if (error) {
+            const err = new Error(String(error.value ?? 'Failed to fetch pack'));
+            Sentry.captureException(err, {
+              tags: { feature: 'packs', action: 'duplicatePack.fetchPack' },
+              extra: { packId, apiError: error.value, httpStatus: error.status },
+            });
+            throw err;
+          }
           // safe-cast: treaty response shape matches Pack as validated by the API schema
           return data as unknown as Pack;
         },

--- a/apps/expo/features/packs/hooks/useImageDetection.ts
+++ b/apps/expo/features/packs/hooks/useImageDetection.ts
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/react-native';
 import { useMutation } from '@tanstack/react-query';
 import type { CatalogItem } from 'expo-app/features/catalog/types';
 import { apiClient } from 'expo-app/lib/api/packrat';
@@ -37,7 +38,14 @@ export function useImageDetection() {
         image,
         matchLimit,
       });
-      if (error) throw new Error(`Failed to analyze image: ${error.value}`);
+      if (error) {
+        const err = new Error(String(error.value ?? 'Failed to analyze image'));
+        Sentry.captureException(err, {
+          tags: { feature: 'packs', action: 'analyzeImage' },
+          extra: { image, matchLimit, apiError: error.value, httpStatus: error.status },
+        });
+        throw err;
+      }
       // safe-cast: treaty response shape matches AnalyzeImageResponse as validated by the API schema
       return data as unknown as AnalyzeImageResponse;
     },

--- a/apps/expo/features/packs/hooks/useImageDetection.ts
+++ b/apps/expo/features/packs/hooks/useImageDetection.ts
@@ -42,7 +42,7 @@ export function useImageDetection() {
         const err = new Error(String(error.value ?? 'Failed to analyze image'));
         Sentry.captureException(err, {
           tags: { feature: 'packs', action: 'analyzeImage' },
-          extra: { image, matchLimit, apiError: error.value, httpStatus: error.status },
+          extra: { matchLimit, apiError: error.value, httpStatus: error.status },
         });
         throw err;
       }

--- a/apps/expo/features/packs/hooks/useImagePicker.ts
+++ b/apps/expo/features/packs/hooks/useImagePicker.ts
@@ -1,4 +1,5 @@
 import { assertDefined } from '@packrat/guards';
+import * as Sentry from '@sentry/react-native';
 import ImageCacheManager from 'expo-app/lib/utils/ImageCacheManager';
 import * as ImagePicker from 'expo-image-picker';
 import { nanoid } from 'nanoid';
@@ -46,6 +47,9 @@ export function useImagePicker(selectedImageInit?: SelectedImage) {
       }
     } catch (err) {
       console.error('Error picking image:', err);
+      Sentry.captureException(err, {
+        tags: { feature: 'imagePicker', action: 'pickImage' },
+      });
       throw err;
     }
   };
@@ -77,6 +81,9 @@ export function useImagePicker(selectedImageInit?: SelectedImage) {
       }
     } catch (err) {
       console.error('Error taking photo:', err);
+      Sentry.captureException(err, {
+        tags: { feature: 'imagePicker', action: 'takePhoto' },
+      });
       throw err;
     }
   };
@@ -100,6 +107,9 @@ export function useImagePicker(selectedImageInit?: SelectedImage) {
       return fileName;
     } catch (err) {
       console.error('Error saving image locally:', err);
+      Sentry.captureException(err, {
+        tags: { feature: 'imagePicker', action: 'permanentlyPersistImageLocally' },
+      });
       return null;
     }
   };

--- a/apps/expo/features/packs/hooks/usePackDetailsFromApi.ts
+++ b/apps/expo/features/packs/hooks/usePackDetailsFromApi.ts
@@ -1,11 +1,19 @@
 import { PackWithWeightsSchema } from '@packrat/schemas/packs';
+import * as Sentry from '@sentry/react-native';
 import { useQuery } from '@tanstack/react-query';
 import { apiClient } from 'expo-app/lib/api/packrat';
 import { useAuthenticatedQueryToolkit } from 'expo-app/lib/hooks/useAuthenticatedQueryToolkit';
 
 const fetchPackById = async (id: string) => {
   const { data, error } = await apiClient.packs({ packId: id }).get();
-  if (error) throw new Error(`Failed to fetch pack: ${error.value}`);
+  if (error) {
+    const err = new Error(String(error.value ?? 'Failed to fetch pack'));
+    Sentry.captureException(err, {
+      tags: { feature: 'packs', action: 'fetchPackById' },
+      extra: { packId: id, apiError: error.value, httpStatus: error.status },
+    });
+    throw err;
+  }
   return PackWithWeightsSchema.parse(data);
 };
 

--- a/apps/expo/features/packs/hooks/usePackGapAnalysis.ts
+++ b/apps/expo/features/packs/hooks/usePackGapAnalysis.ts
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/react-native';
 import { useMutation } from '@tanstack/react-query';
 import { apiClient } from 'expo-app/lib/api/packrat';
 
@@ -30,7 +31,14 @@ export const analyzePackGaps = async ({
   context?: GapAnalysisRequest;
 }): Promise<GapAnalysisResponse> => {
   const { data, error } = await apiClient.packs({ packId })['gap-analysis'].post(context ?? {});
-  if (error) throw new Error(`Failed to analyze pack gaps: ${error.value}`);
+  if (error) {
+    const err = new Error(String(error.value ?? 'Failed to analyze pack gaps'));
+    Sentry.captureException(err, {
+      tags: { feature: 'packs', action: 'analyzePackGaps' },
+      extra: { packId, apiError: error.value, httpStatus: error.status },
+    });
+    throw err;
+  }
   // safe-cast: treaty response shape matches GapAnalysisResponse as validated by the API schema
   return data as unknown as GapAnalysisResponse;
 };

--- a/apps/expo/features/packs/hooks/usePackItemDetailsFromApi.ts
+++ b/apps/expo/features/packs/hooks/usePackItemDetailsFromApi.ts
@@ -1,4 +1,5 @@
 import { PackItemSchema } from '@packrat/schemas/packs';
+import * as Sentry from '@sentry/react-native';
 import { useQuery } from '@tanstack/react-query';
 import { apiClient } from 'expo-app/lib/api/packrat';
 import { useAuthenticatedQueryToolkit } from 'expo-app/lib/hooks/useAuthenticatedQueryToolkit';
@@ -6,7 +7,14 @@ import type { PackItem } from '../types';
 
 export async function fetchPackItemById(id: string) {
   const { data, error } = await apiClient.packs.items({ itemId: id }).get();
-  if (error) throw new Error(`Failed to fetch pack item: ${error.value}`);
+  if (error) {
+    const err = new Error(String(error.value ?? 'Failed to fetch pack item'));
+    Sentry.captureException(err, {
+      tags: { feature: 'packs', action: 'fetchPackItemById' },
+      extra: { itemId: id, apiError: error.value, httpStatus: error.status },
+    });
+    throw err;
+  }
   // safe-cast: Zod parse validates the shape; TypeScript types diverge from Zod-inferred type
   return PackItemSchema.parse(data) as unknown as PackItem;
 }

--- a/apps/expo/features/packs/hooks/useSeasonSuggestions.ts
+++ b/apps/expo/features/packs/hooks/useSeasonSuggestions.ts
@@ -27,7 +27,12 @@ const generateSeasonSuggestions = async (
     const err = new Error(String(error.value ?? 'Failed to generate season suggestions'));
     Sentry.captureException(err, {
       tags: { feature: 'packs', action: 'generateSeasonSuggestions' },
-      extra: { location: data.location, date: data.date, apiError: error.value, httpStatus: error.status },
+      extra: {
+        location: data.location,
+        date: data.date,
+        apiError: error.value,
+        httpStatus: error.status,
+      },
     });
     throw err;
   }

--- a/apps/expo/features/packs/hooks/useSeasonSuggestions.ts
+++ b/apps/expo/features/packs/hooks/useSeasonSuggestions.ts
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/react-native';
 import { useMutation } from '@tanstack/react-query';
 import { apiClient } from 'expo-app/lib/api/packrat';
 import type { PackInput, PackItemInput } from '../types';
@@ -22,7 +23,14 @@ const generateSeasonSuggestions = async (
   data: SeasonSuggestionsRequest,
 ): Promise<SeasonSuggestionsResponse> => {
   const { data: result, error } = await apiClient['season-suggestions'].post(data);
-  if (error) throw new Error(`Failed to generate season suggestions: ${error.value}`);
+  if (error) {
+    const err = new Error(String(error.value ?? 'Failed to generate season suggestions'));
+    Sentry.captureException(err, {
+      tags: { feature: 'packs', action: 'generateSeasonSuggestions' },
+      extra: { location: data.location, date: data.date, apiError: error.value, httpStatus: error.status },
+    });
+    throw err;
+  }
   // safe-cast: treaty response shape matches SeasonSuggestionsResponse as validated by the API schema
   return result as unknown as SeasonSuggestionsResponse;
 };

--- a/apps/expo/features/packs/screens/CreatePackItemForm.tsx
+++ b/apps/expo/features/packs/screens/CreatePackItemForm.tsx
@@ -2,6 +2,7 @@ import { useActionSheet } from '@expo/react-native-action-sheet';
 import type { WeightUnit } from '@packrat/constants';
 import { safeIndexOf } from '@packrat/guards';
 import { Form, FormItem, FormSection, SegmentedControl, TextField } from '@packrat/ui/nativewindui';
+import * as Sentry from '@sentry/react-native';
 import { useForm } from '@tanstack/react-form';
 import { Icon } from 'expo-app/components/Icon';
 import { useColorScheme } from 'expo-app/lib/hooks/useColorScheme';
@@ -140,6 +141,10 @@ export const CreatePackItemForm = ({
         }
       } catch (err) {
         console.error('Error submitting form:', err);
+        Sentry.captureException(err, {
+          tags: { feature: 'packs', action: 'createPackItem' },
+          extra: { packId, isEditing },
+        });
         Alert.alert('Error', 'Failed to save item. Please try again.');
       }
     },
@@ -178,6 +183,9 @@ export const CreatePackItemForm = ({
           }
         } catch (err) {
           console.error('Error handling image:', err);
+          Sentry.captureException(err, {
+            tags: { feature: 'packs', action: 'handleAddImage' },
+          });
           Alert.alert('Error', 'Failed to process image. Please try again.');
         }
       },

--- a/apps/expo/features/packs/utils/uploadImage.ts
+++ b/apps/expo/features/packs/utils/uploadImage.ts
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/react-native';
 import { userStore } from 'expo-app/features/auth/store';
 import { apiClient } from 'expo-app/lib/api/packrat';
 import * as FileSystem from 'expo-file-system/legacy';
@@ -20,6 +21,12 @@ export const uploadImage = async ({
     const fileExtension = fileName.split('.').pop()?.toLowerCase() || 'jpg';
     const type = `image/${fileExtension === 'jpg' ? 'jpeg' : fileExtension}`;
     const remoteFileName = `${userId}-${fileName}`;
+    Sentry.addBreadcrumb({
+      category: 'upload',
+      message: 'Starting image upload',
+      level: 'info',
+      data: { fileName, type },
+    });
     const { url: presignedUrl } = await getPresignedUrl({
       fileName: remoteFileName,
       contentType: type,
@@ -39,6 +46,10 @@ export const uploadImage = async ({
     return remoteFileName;
   } catch (err) {
     console.error('Error uploading image:', err);
+    Sentry.captureException(err, {
+      tags: { feature: 'upload', action: 'uploadImage' },
+      extra: { fileName },
+    });
     throw err;
   }
 };
@@ -53,6 +64,13 @@ const getPresignedUrl = async ({
   const { data, error } = await apiClient.upload.presigned.get({
     query: { fileName, contentType },
   });
-  if (error || !data) throw new Error(`Failed to get upload URL: ${error?.value}`);
+  if (error || !data) {
+    const err = new Error(`Failed to get upload URL: ${String(error?.value ?? 'no data')}`);
+    Sentry.captureException(err, {
+      tags: { feature: 'upload', action: 'getPresignedUrl' },
+      extra: { fileName, contentType, apiError: error?.value, httpStatus: error?.status },
+    });
+    throw err;
+  }
   return data;
 };

--- a/apps/expo/features/packs/utils/uploadImage.web.ts
+++ b/apps/expo/features/packs/utils/uploadImage.web.ts
@@ -4,6 +4,8 @@
  * The caller obtains a presigned URL from the API (same as the native flow)
  * but the binary upload uses fetch instead of expo-file-system.
  */
+
+import * as Sentry from '@sentry/react-native';
 import { userStore } from 'expo-app/features/auth/store';
 import { apiClient } from 'expo-app/lib/api/packrat';
 
@@ -24,6 +26,12 @@ export const uploadImage = async ({
     const type = `image/${fileExtension === 'jpg' ? 'jpeg' : fileExtension}`;
     const remoteFileName = `${userStore.id.peek()}-${fileName}`;
 
+    Sentry.addBreadcrumb({
+      category: 'upload',
+      message: 'Starting image upload (web)',
+      level: 'info',
+      data: { fileName, type },
+    });
     const { url: presignedUrl } = await getPresignedUrl({
       fileName: remoteFileName,
       contentType: type,
@@ -45,6 +53,10 @@ export const uploadImage = async ({
     return remoteFileName;
   } catch (err) {
     console.error('Error uploading image:', err);
+    Sentry.captureException(err, {
+      tags: { feature: 'upload', action: 'uploadImage.web' },
+      extra: { fileName },
+    });
     throw err;
   }
 };
@@ -59,7 +71,14 @@ const getPresignedUrl = async ({
   const { data, error } = await apiClient.upload.presigned.get({
     query: { fileName, contentType },
   });
-  if (error || !data) throw new Error(`Failed to get upload URL: ${error?.value}`);
+  if (error || !data) {
+    const err = new Error(`Failed to get upload URL: ${String(error?.value ?? 'no data')}`);
+    Sentry.captureException(err, {
+      tags: { feature: 'upload', action: 'getPresignedUrl.web' },
+      extra: { fileName, contentType, apiError: error?.value, httpStatus: error?.status },
+    });
+    throw err;
+  }
   return data;
 };
 

--- a/apps/expo/features/profile/hooks/useUpdateProfile.ts
+++ b/apps/expo/features/profile/hooks/useUpdateProfile.ts
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/react-native';
 import { userStore } from 'expo-app/features/auth/store';
 import { apiClient } from 'expo-app/lib/api/packrat';
 import { useState } from 'react';
@@ -17,8 +18,18 @@ export function useUpdateProfile() {
     setIsLoading(true);
     setError(null);
     try {
+      Sentry.addBreadcrumb({
+        category: 'profile',
+        message: 'Updating user profile',
+        level: 'info',
+      });
       const { data, error: apiError } = await apiClient.user.profile.put(payload);
       if (apiError) {
+        const err = new Error(String(apiError.value ?? 'Update failed'));
+        Sentry.captureException(err, {
+          tags: { feature: 'profile', action: 'updateProfile' },
+          extra: { apiError: apiError.value, httpStatus: apiError.status },
+        });
         setError(String(apiError.value ?? 'Update failed'));
         return false;
       }
@@ -28,6 +39,9 @@ export function useUpdateProfile() {
       }
       return true;
     } catch (err) {
+      Sentry.captureException(err, {
+        tags: { feature: 'profile', action: 'updateProfile' },
+      });
       setError(err instanceof Error ? err.message : 'Update failed');
       return false;
     } finally {

--- a/apps/expo/features/trail-conditions/components/SubmitConditionReportForm.tsx
+++ b/apps/expo/features/trail-conditions/components/SubmitConditionReportForm.tsx
@@ -1,4 +1,5 @@
 import { Text } from '@packrat/ui/nativewindui';
+import * as Sentry from '@sentry/react-native';
 import { TextInput } from 'expo-app/components/TextInput';
 import { useTranslation } from 'expo-app/lib/hooks/useTranslation';
 import { useState } from 'react';
@@ -56,6 +57,12 @@ export function SubmitConditionReportForm({
       return;
     }
     try {
+      Sentry.addBreadcrumb({
+        category: 'trailConditions',
+        message: 'Submitting trail condition report',
+        level: 'info',
+        data: { trailName: trailName.trim() },
+      });
       await submitReport({
         trailName: trailName.trim(),
         trailRegion: trailRegion.trim() || null,
@@ -71,6 +78,10 @@ export function SubmitConditionReportForm({
       Alert.alert(t('common.success'), t('trailConditions.reportSubmitted'));
       onSuccess?.();
     } catch (err) {
+      Sentry.captureException(err, {
+        tags: { feature: 'trailConditions', action: 'submitReport' },
+        extra: { trailName: trailName.trim() },
+      });
       const message = err instanceof Error ? err.message : String(err);
       Alert.alert(t('common.error'), message);
     }

--- a/apps/expo/features/trail-conditions/hooks/useSubmitTrailConditionReport.ts
+++ b/apps/expo/features/trail-conditions/hooks/useSubmitTrailConditionReport.ts
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/react-native';
 import { useQueryClient } from '@tanstack/react-query';
 import { obs } from 'expo-app/lib/store';
 import { nanoid } from 'nanoid';
@@ -162,6 +163,10 @@ export function useSubmitTrailConditionReport(): SubmitResult {
         return id;
       } catch (err) {
         const asError = err instanceof Error ? err : new Error(String(err));
+        Sentry.captureException(asError, {
+          tags: { feature: 'trailConditions', action: 'submitReport.syncDrain' },
+          extra: { reportId: id },
+        });
         if (mountedRef.current && !signal.cancelled) {
           setError(asError);
           setIsPending(false);

--- a/apps/expo/features/trail-conditions/hooks/useTrailConditionReports.ts
+++ b/apps/expo/features/trail-conditions/hooks/useTrailConditionReports.ts
@@ -1,5 +1,6 @@
 import { useSelector } from '@legendapp/state/react';
 import AsyncStorage from '@react-native-async-storage/async-storage';
+import * as Sentry from '@sentry/react-native';
 import { useQuery } from '@tanstack/react-query';
 import { userStore } from 'expo-app/features/auth/store/user';
 import { apiClient } from 'expo-app/lib/api/packrat';
@@ -58,7 +59,12 @@ export const fetchTrailConditionReports = async (
   });
   if (error) {
     console.error('Failed to fetch trail condition reports:', error.value);
-    throw new Error(`Failed to fetch trail condition reports: ${error.value}`);
+    const err = new Error(`Failed to fetch trail condition reports: ${String(error.value)}`);
+    Sentry.captureException(err, {
+      tags: { feature: 'trailConditions', action: 'fetchReports' },
+      extra: { trailName, apiError: error.value, httpStatus: error.status },
+    });
+    throw err;
   }
   // safe-cast: treaty response shape matches TrailConditionReport[] as validated by the API schema
   return (data ?? []) as unknown as TrailConditionReport[];

--- a/apps/expo/features/trips/components/TripForm.tsx
+++ b/apps/expo/features/trips/components/TripForm.tsx
@@ -1,6 +1,7 @@
 import { assertDefined, isString } from '@packrat/guards';
 import { Form, FormItem, FormSection, TextField } from '@packrat/ui/nativewindui';
 import DateTimePicker from '@react-native-community/datetimepicker';
+import * as Sentry from '@sentry/react-native';
 import { useForm } from '@tanstack/react-form';
 import * as Burnt from 'burnt';
 import { Icon } from 'expo-app/components/Icon';
@@ -121,12 +122,23 @@ export const TripForm = ({ trip }: { trip?: Trip }) => {
       };
       try {
         if (isEditingExistingTrip) {
+          Sentry.addBreadcrumb({
+            category: 'trips',
+            message: 'Updating trip',
+            level: 'info',
+            data: { tripId: trip?.id },
+          });
           await updateTrip({ ...trip, ...submitData });
           Burnt.toast({
             title: t('trips.tripUpdatedSuccess'),
             preset: 'done',
           });
         } else {
+          Sentry.addBreadcrumb({
+            category: 'trips',
+            message: 'Creating trip',
+            level: 'info',
+          });
           await createTrip(submitData);
           Burnt.toast({
             title: t('trips.tripCreatedSuccess'),
@@ -135,6 +147,10 @@ export const TripForm = ({ trip }: { trip?: Trip }) => {
         }
         router.back();
       } catch (_e) {
+        Sentry.captureException(_e, {
+          tags: { feature: 'trips', action: isEditingExistingTrip ? 'updateTrip' : 'createTrip' },
+          extra: { tripId: trip?.id },
+        });
         Burnt.toast({
           title: t('errors.tryAgain'),
           preset: 'error',

--- a/apps/expo/features/trips/hooks/useAllTrips.ts
+++ b/apps/expo/features/trips/hooks/useAllTrips.ts
@@ -1,9 +1,17 @@
+import * as Sentry from '@sentry/react-native';
 import { useQuery } from '@tanstack/react-query';
 import { apiClient } from 'expo-app/lib/api/packrat';
 import { useAuthenticatedQueryToolkit } from 'expo-app/lib/hooks/useAuthenticatedQueryToolkit';
 export const fetchAllTrips = async () => {
   const { data, error } = await apiClient.trips.get();
-  if (error) throw new Error(`Failed to fetch trips: ${error.value}`);
+  if (error) {
+    const err = new Error(String(error.value ?? 'Failed to fetch trips'));
+    Sentry.captureException(err, {
+      tags: { feature: 'trips', action: 'fetchAllTrips' },
+      extra: { apiError: error.value, httpStatus: error.status },
+    });
+    throw err;
+  }
   return data ?? [];
 };
 

--- a/apps/expo/features/trips/hooks/useDeleteTrip.ts
+++ b/apps/expo/features/trips/hooks/useDeleteTrip.ts
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/react-native';
 import { tripsStore } from 'expo-app/features/trips/store/trips';
 import { apiClient } from 'expo-app/lib/api/packrat';
 import { obs } from 'expo-app/lib/store';
@@ -11,7 +12,15 @@ export function useDeleteTrip() {
       tripObs.deleted.set(true);
     }
     // Hard-delete on the server so the list GET won't return the trip on any subsequent reload
-    await apiClient.trips({ tripId: id }).delete();
+    const { error } = await apiClient.trips({ tripId: id }).delete();
+    if (error) {
+      const err = new Error(String(error.value ?? 'Failed to delete trip'));
+      Sentry.captureException(err, {
+        tags: { feature: 'trips', action: 'deleteTrip' },
+        extra: { tripId: id, apiError: error.value, httpStatus: error.status },
+      });
+      throw err;
+    }
   }, []);
 
   return deleteTrip;

--- a/apps/expo/features/trips/screens/TripWeatherDetailsScreen.tsx
+++ b/apps/expo/features/trips/screens/TripWeatherDetailsScreen.tsx
@@ -62,10 +62,6 @@ export default function TripWeatherDetailsScreen() {
       setGradientColors(getWeatherBackgroundColors({ code: weatherCode, isNight }));
     } catch (e) {
       console.error(e);
-      Sentry.captureException(e, {
-        tags: { feature: 'trips', action: 'fetchWeather' },
-        extra: { latitude, longitude },
-      });
       setError('Failed to load weather');
     } finally {
       setLoading(false);

--- a/apps/expo/features/trips/screens/TripWeatherDetailsScreen.tsx
+++ b/apps/expo/features/trips/screens/TripWeatherDetailsScreen.tsx
@@ -1,4 +1,5 @@
 import type { WeatherAPIForecastResponse } from '@packrat/schemas/weather';
+import * as Sentry from '@sentry/react-native';
 import { Icon } from 'expo-app/components/Icon';
 import { WeatherForecast } from 'expo-app/features/weather/components/WeatherForecast';
 import {
@@ -43,6 +44,12 @@ export default function TripWeatherDetailsScreen() {
       setLoading(true);
       setError(null);
 
+      Sentry.addBreadcrumb({
+        category: 'trips',
+        message: 'Fetching trip weather',
+        level: 'info',
+        data: { latitude, longitude },
+      });
       const locations = await searchLocationsByCoordinates({ latitude, longitude });
       const first = locations[0];
       if (!first) throw new Error('No location found for these coordinates');
@@ -55,6 +62,10 @@ export default function TripWeatherDetailsScreen() {
       setGradientColors(getWeatherBackgroundColors({ code: weatherCode, isNight }));
     } catch (e) {
       console.error(e);
+      Sentry.captureException(e, {
+        tags: { feature: 'trips', action: 'fetchWeather' },
+        extra: { latitude, longitude },
+      });
       setError('Failed to load weather');
     } finally {
       setLoading(false);

--- a/apps/expo/features/weather/hooks/useLocationRefresh.ts
+++ b/apps/expo/features/weather/hooks/useLocationRefresh.ts
@@ -1,4 +1,3 @@
-import * as Sentry from '@sentry/react-native';
 import { formatWeatherData, getWeatherData } from 'expo-app/features/weather/lib/weatherService';
 import { useState } from 'react';
 import type { WeatherLocation } from '../types';
@@ -30,10 +29,6 @@ export function useLocationRefresh() {
       return false;
     } catch (err) {
       console.error('Error refreshing location:', err);
-      Sentry.captureException(err, {
-        tags: { feature: 'weather', action: 'refreshLocation' },
-        extra: { locationId },
-      });
       return false;
     } finally {
       setIsRefreshing(false);
@@ -64,10 +59,6 @@ export function useLocationRefresh() {
           }
         } catch (error) {
           console.error(`Error updating weather for ${location.name}:`, error);
-          Sentry.captureException(error, {
-            tags: { feature: 'weather', action: 'refreshAllLocations' },
-            extra: { locationId: location.id, locationName: location.name },
-          });
         }
       }
     } finally {

--- a/apps/expo/features/weather/hooks/useLocationRefresh.ts
+++ b/apps/expo/features/weather/hooks/useLocationRefresh.ts
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/react-native';
 import { formatWeatherData, getWeatherData } from 'expo-app/features/weather/lib/weatherService';
 import { useState } from 'react';
 import type { WeatherLocation } from '../types';
@@ -29,6 +30,10 @@ export function useLocationRefresh() {
       return false;
     } catch (err) {
       console.error('Error refreshing location:', err);
+      Sentry.captureException(err, {
+        tags: { feature: 'weather', action: 'refreshLocation' },
+        extra: { locationId },
+      });
       return false;
     } finally {
       setIsRefreshing(false);
@@ -59,6 +64,10 @@ export function useLocationRefresh() {
           }
         } catch (error) {
           console.error(`Error updating weather for ${location.name}:`, error);
+          Sentry.captureException(error, {
+            tags: { feature: 'weather', action: 'refreshAllLocations' },
+            extra: { locationId: location.id, locationName: location.name },
+          });
         }
       }
     } finally {

--- a/apps/expo/features/weather/hooks/useLocationSearch.ts
+++ b/apps/expo/features/weather/hooks/useLocationSearch.ts
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/react-native';
 import {
   formatWeatherData,
   getWeatherData,
@@ -28,6 +29,10 @@ export function useLocationSearch() {
       setResults(searchResults);
     } catch (err) {
       console.error('Error searching locations:', err);
+      Sentry.captureException(err, {
+        tags: { feature: 'weather', action: 'search' },
+        extra: { query },
+      });
       setError('Failed to search locations. Please try again.');
     } finally {
       setIsLoading(false);
@@ -54,6 +59,10 @@ export function useLocationSearch() {
       }
     } catch (err) {
       console.error('Error searching locations by coordinates:', err);
+      Sentry.captureException(err, {
+        tags: { feature: 'weather', action: 'searchByCoordinates' },
+        extra: { latitude, longitude },
+      });
       setError('Failed to find locations near you. Please try again or search manually.');
     } finally {
       setIsLoading(false);
@@ -82,6 +91,10 @@ export function useLocationSearch() {
       }
     } catch (err) {
       console.error('Error adding location:', err);
+      Sentry.captureException(err, {
+        tags: { feature: 'weather', action: 'addSearchResult' },
+        extra: { locationId: result.id, locationName: result.name },
+      });
       setError('Failed to add location. Please try again.');
       return false;
     } finally {

--- a/apps/expo/features/weather/hooks/useLocationSearch.ts
+++ b/apps/expo/features/weather/hooks/useLocationSearch.ts
@@ -1,4 +1,3 @@
-import * as Sentry from '@sentry/react-native';
 import {
   formatWeatherData,
   getWeatherData,
@@ -29,10 +28,6 @@ export function useLocationSearch() {
       setResults(searchResults);
     } catch (err) {
       console.error('Error searching locations:', err);
-      Sentry.captureException(err, {
-        tags: { feature: 'weather', action: 'search' },
-        extra: { query },
-      });
       setError('Failed to search locations. Please try again.');
     } finally {
       setIsLoading(false);
@@ -59,10 +54,6 @@ export function useLocationSearch() {
       }
     } catch (err) {
       console.error('Error searching locations by coordinates:', err);
-      Sentry.captureException(err, {
-        tags: { feature: 'weather', action: 'searchByCoordinates' },
-        extra: { latitude, longitude },
-      });
       setError('Failed to find locations near you. Please try again or search manually.');
     } finally {
       setIsLoading(false);
@@ -91,10 +82,6 @@ export function useLocationSearch() {
       }
     } catch (err) {
       console.error('Error adding location:', err);
-      Sentry.captureException(err, {
-        tags: { feature: 'weather', action: 'addSearchResult' },
-        extra: { locationId: result.id, locationName: result.name },
-      });
       setError('Failed to add location. Please try again.');
       return false;
     } finally {

--- a/apps/expo/features/weather/lib/weatherService.ts
+++ b/apps/expo/features/weather/lib/weatherService.ts
@@ -12,14 +12,21 @@ import { getWeatherIconName as getIconNameFromCode } from './weatherIcons';
  * Search for locations by name
  */
 export async function searchLocations(query: string) {
+  Sentry.addBreadcrumb({
+    category: 'weather',
+    message: 'Searching locations',
+    level: 'info',
+    data: { query },
+  });
   const { data, error } = await apiClient.weather.search.get({ query: { q: query } });
 
   if (error) {
     console.error('Error searching locations:', error.value);
-    const err = new Error('Failed to search locations');
+    const err = new Error(String(error.value ?? 'Failed to search locations'));
     Sentry.captureException(err, {
       contexts: { weather: { query, apiError: error.value } },
       tags: { weather_operation: 'searchLocations' },
+      extra: { httpStatus: error.status },
     });
     throw err;
   }
@@ -36,15 +43,22 @@ export async function searchLocationsByCoordinates({
   latitude: number;
   longitude: number;
 }) {
+  Sentry.addBreadcrumb({
+    category: 'weather',
+    message: 'Searching locations by coordinates',
+    level: 'info',
+    data: { latitude, longitude },
+  });
   const { data, error } = await apiClient.weather['search-by-coordinates'].get({
     query: { lat: latitude.toFixed(6), lon: longitude.toFixed(6) },
   });
   if (error) {
     console.error('Error searching locations by coordinates:', error.value);
-    const err = new Error('Failed to find locations near you');
+    const err = new Error(String(error.value ?? 'Failed to find locations near you'));
     Sentry.captureException(err, {
       contexts: { weather: { latitude, longitude, apiError: error.value } },
       tags: { weather_operation: 'searchLocationsByCoordinates' },
+      extra: { httpStatus: error.status },
     });
     throw err;
   }
@@ -55,13 +69,20 @@ export async function searchLocationsByCoordinates({
  * Get detailed weather data for a location
  */
 export async function getWeatherData(id: number) {
+  Sentry.addBreadcrumb({
+    category: 'weather',
+    message: 'Fetching weather forecast',
+    level: 'info',
+    data: { locationId: id },
+  });
   const { data, error } = await apiClient.weather.forecast.get({ query: { id: String(id) } });
   if (error) {
     console.error('Error getting weather data:', error.value);
-    const err = new Error('Failed to get weather data');
+    const err = new Error(String(error.value ?? 'Failed to get weather data'));
     Sentry.captureException(err, {
       contexts: { weather: { locationId: id, apiError: error.value } },
       tags: { weather_operation: 'getWeatherData' },
+      extra: { httpStatus: error.status },
     });
     throw err;
   }

--- a/apps/expo/features/weather/screens/LocationSearchScreen.tsx
+++ b/apps/expo/features/weather/screens/LocationSearchScreen.tsx
@@ -1,5 +1,6 @@
 import { Text } from '@packrat/ui/nativewindui';
 import AsyncStorage from '@react-native-async-storage/async-storage';
+import * as Sentry from '@sentry/react-native';
 import { Icon } from 'expo-app/components/Icon';
 import { SearchInput } from 'expo-app/components/SearchInput';
 import { cn } from 'expo-app/lib/cn';
@@ -58,6 +59,9 @@ export default function LocationSearchScreen() {
         }
       } catch (err) {
         console.error('Error loading recent searches:', err);
+        Sentry.captureException(err, {
+          tags: { feature: 'weather', action: 'loadRecentSearches' },
+        });
       }
     };
 
@@ -86,6 +90,10 @@ export default function LocationSearchScreen() {
       await AsyncStorage.setItem(RECENT_SEARCHES_KEY, JSON.stringify(updatedSearches));
     } catch (err) {
       console.error('Error saving recent search:', err);
+      Sentry.captureException(err, {
+        tags: { feature: 'weather', action: 'saveToRecentSearches' },
+        extra: { searchTerm },
+      });
     }
   };
 
@@ -135,6 +143,10 @@ export default function LocationSearchScreen() {
       }
     } catch (err) {
       console.error('Error adding location:', err);
+      Sentry.captureException(err, {
+        tags: { feature: 'weather', action: 'handleAddLocation' },
+        extra: { locationId: location.id, locationName: location.name },
+      });
       Alert.alert(t('common.error'), t('weather.unexpectedError'));
     } finally {
       setIsAdding(false);

--- a/apps/expo/features/wildlife/hooks/useWildlifeIdentification.ts
+++ b/apps/expo/features/wildlife/hooks/useWildlifeIdentification.ts
@@ -1,4 +1,5 @@
 import { isObject, zodGuard } from '@packrat/guards';
+import * as Sentry from '@sentry/react-native';
 import { useMutation } from '@tanstack/react-query';
 import type { SelectedImage } from 'expo-app/features/packs/hooks/useImagePicker';
 import { uploadImage } from 'expo-app/features/packs/utils';
@@ -18,10 +19,18 @@ async function identifyOnline(selectedImage: SelectedImage): Promise<Identificat
   }
   const { data, error } = await apiClient.wildlife.identify.post({ image });
   if (error) {
-    const wrapped = new Error(`Wildlife identification failed: ${error.value}`) as Error & {
+    const wrapped = new Error(`Wildlife identification failed: ${String(error.value)}`) as Error & {
       isApiError?: boolean;
     };
     wrapped.isApiError = true;
+    Sentry.captureException(wrapped, {
+      tags: { feature: 'wildlife', action: 'identify' },
+      extra: {
+        apiError: error.value,
+        httpStatus: error.status,
+        imageFileName: selectedImage.fileName,
+      },
+    });
     throw wrapped;
   }
   if (!isIdentifyResponse(data))

--- a/apps/expo/features/wildlife/screens/IdentificationScreen.tsx
+++ b/apps/expo/features/wildlife/screens/IdentificationScreen.tsx
@@ -1,5 +1,6 @@
 import { useActionSheet } from '@expo/react-native-action-sheet';
 import { ActivityIndicator, Button, Text } from '@packrat/ui/nativewindui';
+import * as Sentry from '@sentry/react-native';
 import { appAlert } from 'expo-app/app/_layout';
 import { Icon } from 'expo-app/components/Icon';
 import { TextInput } from 'expo-app/components/TextInput';
@@ -60,6 +61,9 @@ export function IdentificationScreen() {
           }
         } catch (err) {
           console.error('Error selecting image:', err);
+          Sentry.captureException(err, {
+            tags: { feature: 'wildlife', action: 'handleSelectImage' },
+          });
           appAlert.current?.alert({
             title: t('common.error'),
             message: t('wildlife.failedToSelectImage'),

--- a/bun.lock
+++ b/bun.lock
@@ -22,7 +22,7 @@
     },
     "apps/admin": {
       "name": "packrat-admin-app",
-      "version": "2.0.26",
+      "version": "2.0.27",
       "dependencies": {
         "@elysiajs/eden": "catalog:",
         "@packrat/api-client": "workspace:*",
@@ -71,7 +71,7 @@
     },
     "apps/expo": {
       "name": "packrat-expo-app",
-      "version": "2.0.26",
+      "version": "2.0.27",
       "dependencies": {
         "@ai-sdk/react": "^3.0.170",
         "@better-auth/expo": "^1.6.9",
@@ -210,7 +210,7 @@
     },
     "apps/guides": {
       "name": "packrat-guides-app",
-      "version": "2.0.26",
+      "version": "2.0.27",
       "dependencies": {
         "@ai-sdk/openai": "catalog:",
         "@elysiajs/eden": "catalog:",
@@ -299,7 +299,7 @@
     },
     "apps/landing": {
       "name": "packrat-landing-app",
-      "version": "2.0.26",
+      "version": "2.0.27",
       "dependencies": {
         "@emotion/is-prop-valid": "^1.3.1",
         "@hookform/resolvers": "catalog:",
@@ -369,7 +369,7 @@
     },
     "apps/trails": {
       "name": "packrat-trails-app",
-      "version": "2.0.26",
+      "version": "2.0.27",
       "dependencies": {
         "@packrat/api-client": "workspace:*",
         "@packrat/app": "workspace:*",
@@ -442,7 +442,7 @@
     },
     "packages/analytics": {
       "name": "@packrat/analytics",
-      "version": "2.0.26",
+      "version": "2.0.27",
       "dependencies": {
         "@duckdb/node-api": "catalog:",
         "@packrat/env": "workspace:*",
@@ -459,7 +459,7 @@
     },
     "packages/api": {
       "name": "@packrat/api",
-      "version": "2.0.26",
+      "version": "2.0.27",
       "dependencies": {
         "@ai-sdk/google": "^3.0.64",
         "@ai-sdk/openai": "catalog:",
@@ -480,7 +480,7 @@
         "@packrat/schemas": "workspace:*",
         "@packrat/types": "workspace:*",
         "@packrat/units": "workspace:*",
-        "@sentry/cloudflare": "^10.0.0",
+        "@sentry/cloudflare": "^10.37.0",
         "@sinclair/typebox": "^0.34.15",
         "@types/nodemailer": "^6.4.17",
         "ai": "catalog:",
@@ -523,7 +523,7 @@
     },
     "packages/api-client": {
       "name": "@packrat/api-client",
-      "version": "2.0.26",
+      "version": "2.0.27",
       "dependencies": {
         "@elysiajs/eden": "catalog:",
         "@packrat/guards": "workspace:*",
@@ -541,7 +541,7 @@
     },
     "packages/app": {
       "name": "@packrat/app",
-      "version": "2.0.26",
+      "version": "2.0.27",
       "dependencies": {
         "@packrat/api-client": "workspace:*",
         "@packrat/schemas": "workspace:*",
@@ -562,11 +562,11 @@
     },
     "packages/checks": {
       "name": "@packrat/checks",
-      "version": "2.0.26",
+      "version": "2.0.27",
     },
     "packages/cli": {
       "name": "@packrat/cli",
-      "version": "2.0.26",
+      "version": "2.0.27",
       "bin": {
         "packrat": "./src/index.ts",
       },
@@ -590,21 +590,21 @@
     },
     "packages/config": {
       "name": "@packrat/config",
-      "version": "2.0.26",
+      "version": "2.0.27",
       "dependencies": {
         "@packrat/guards": "workspace:*",
       },
     },
     "packages/constants": {
       "name": "@packrat/constants",
-      "version": "0.0.0",
+      "version": "2.0.27",
       "devDependencies": {
         "typescript": "catalog:",
       },
     },
     "packages/db": {
       "name": "@packrat/db",
-      "version": "0.0.0",
+      "version": "2.0.27",
       "dependencies": {
         "@packrat/constants": "workspace:*",
         "drizzle-orm": "catalog:",
@@ -616,14 +616,14 @@
     },
     "packages/env": {
       "name": "@packrat/env",
-      "version": "2.0.26",
+      "version": "2.0.27",
       "dependencies": {
         "zod": "catalog:",
       },
     },
     "packages/guards": {
       "name": "@packrat/guards",
-      "version": "2.0.26",
+      "version": "2.0.27",
       "dependencies": {
         "radash": "catalog:",
         "ts-extras": "catalog:",
@@ -632,7 +632,7 @@
     },
     "packages/mcp": {
       "name": "@packrat/mcp",
-      "version": "2.0.26",
+      "version": "2.0.27",
       "dependencies": {
         "@cloudflare/workers-oauth-provider": "^0.4.0",
         "@modelcontextprotocol/sdk": "^1.11.0",
@@ -652,7 +652,7 @@
     },
     "packages/osm-db": {
       "name": "@packrat/osm-db",
-      "version": "2.0.26",
+      "version": "2.0.27",
       "dependencies": {
         "@neondatabase/serverless": "catalog:",
         "drizzle-orm": "catalog:",
@@ -666,7 +666,7 @@
     },
     "packages/osm-import": {
       "name": "@packrat/osm-import",
-      "version": "2.0.26",
+      "version": "2.0.27",
       "dependencies": {
         "@packrat/env": "workspace:*",
         "pg": "catalog:",
@@ -674,7 +674,7 @@
     },
     "packages/overpass": {
       "name": "@packrat/overpass",
-      "version": "2.0.26",
+      "version": "2.0.27",
       "dependencies": {
         "@packrat/guards": "workspace:*",
         "zod": "catalog:",
@@ -686,7 +686,7 @@
     },
     "packages/schemas": {
       "name": "@packrat/schemas",
-      "version": "0.0.0",
+      "version": "2.0.27",
       "dependencies": {
         "@packrat/constants": "workspace:*",
         "@packrat/db": "workspace:*",
@@ -699,7 +699,7 @@
     },
     "packages/types": {
       "name": "@packrat/types",
-      "version": "0.0.0",
+      "version": "2.0.27",
       "dependencies": {
         "@packrat/constants": "workspace:*",
         "@packrat/schemas": "workspace:*",
@@ -714,14 +714,14 @@
     },
     "packages/ui": {
       "name": "@packrat/ui",
-      "version": "2.0.26",
+      "version": "2.0.27",
       "dependencies": {
         "@packrat-ai/nativewindui": "2.0.3-2",
       },
     },
     "packages/units": {
       "name": "@packrat/units",
-      "version": "2.0.26",
+      "version": "2.0.27",
       "dependencies": {
         "@packrat/constants": "workspace:*",
         "@packrat/guards": "workspace:*",
@@ -733,7 +733,7 @@
     },
     "packages/web-ui": {
       "name": "@packrat/web-ui",
-      "version": "2.0.26",
+      "version": "2.0.27",
       "dependencies": {
         "@packrat/guards": "workspace:*",
         "@radix-ui/react-accordion": "catalog:",


### PR DESCRIPTION
## Summary

Audit of the Expo app revealed 46+ catch blocks missing `captureException`, 14+ error conditionals missing capture, 30+ async ops missing `addBreadcrumb`, and 7 violations where the original error was wrapped in a new `Error()` before Sentry (losing the original stack).

This PR addresses every gap found, including a follow-up deep audit that uncovered additional uninstrumented hooks across catalog, feed, packs, guides, trips, and AI features.

---

## Changes

### Violation Fixes (incorrect error wrapping)
- **weatherService.ts**: replaced `new Error('hardcoded message')` with `new Error(String(error.value ?? 'fallback'))` for `searchLocations`, `searchLocationsByCoordinates`, `getWeatherData` — preserves actual API error text and adds `httpStatus` to `extra`

### Duplicate Capture Removal
- Removed redundant `captureException` calls from callers of `weatherService` (`useLocationSearch.ts`, `useLocationRefresh.ts`, `TripWeatherDetailsScreen.tsx`) and `uploadImage` (`CreatePostScreen.tsx`) where the service boundary already captures before rethrowing.

### Breadcrumbs Added
Added `Sentry.addBreadcrumb()` before significant async operations in: weatherService.ts (3), uploadImage.ts, uploadImage.web.ts, TripForm.tsx, SubmitConditionReportForm.tsx, AIPacksScreen.tsx, useUpdateProfile.ts, TripWeatherDetailsScreen.tsx

### `captureException` in Catch Blocks
- **Weather**: useLocationSearch.ts, useLocationRefresh.ts, LocationSearchScreen.tsx
- **Upload/Image**: uploadImage.ts, uploadImage.web.ts, useImagePicker.ts
- **Trips/Packs/Feed/Profile**: TripForm.tsx, CreatePostScreen.tsx, AIPacksScreen.tsx, useUpdateProfile.ts, profile/index.tsx, TripWeatherDetailsScreen.tsx, useBulkAddCatalogItems.ts, CreatePackItemForm.tsx (onSubmit + handleAddImage)
- **Trail conditions**: SubmitConditionReportForm.tsx, useSubmitTrailConditionReport.ts
- **Wildlife**: IdentificationScreen.tsx
- **AI**: chatStorageAtoms.ts (3 catches), ChatBubble.tsx, WebSearchGenerativeUI.tsx, GuidesRAGGenerativeUI.tsx
- **Catalog**: cacheCatalogItemImage.ts

### `captureException` in `if (error)` API Error Branches
- **tools.ts**: getCatalogItems, catalogVectorSearch, searchPackratOutdoorGuidesRAG, webSearchTool, executeSql, getDatabaseSchema (6 branches)
- useTrailConditionReports.ts, useWildlifeIdentification.ts, useUpdateProfile.ts, useGenerateTemplateFromOnlineContent.ts

### Additional Instrumentation (deep audit follow-up)
Previously uninstrumented hooks now fully covered:
- **Catalog**: useCatalogItemDetails, useCatalogItems, useCatalogItemsCategories, useSimilarItems, useVectorSearch
- **Feed**: useAddComment, useCreatePost, useDeleteComment, useDeletePost, useFeed, usePostComments, useToggleCommentLike, useTogglePostLike
- **Packs**: useAllPacks, useDuplicatePack, usePackDetailsFromApi, usePackItemDetailsFromApi, usePackGapAnalysis, useSeasonSuggestions, useImageDetection, useBulkAddCatalogItems
- **Guides**: useGuideCategories, useGuideDetails, useGuides, useSearchGuides
- **Trips**: useAllTrips, useDeleteTrip (also added missing API error check — delete was silently ignoring server failures)
- **AI**: useGeneratedPacks, useReportContent, useReportedContent, useUpdateReportStatus
- **Auth**: DeleteAccountButton

---

## Pattern Applied

**Treaty API error** (`error` is `{ value, status }`, not a JS Error):
```ts
const err = new Error(String(error.value ?? 'fallback'));
Sentry.captureException(err, {
  tags: { feature: 'x', action: 'y' },
  extra: { apiError: error.value, httpStatus: error.status },
});
throw err;
```

**Catch blocks** (original Error preserved):
```ts
} catch (error) {
  Sentry.captureException(error, {
    tags: { feature: 'x', action: 'y' },
  });
  throw error; // or handle
}
```

**Special cases**:
- `profile/index.tsx` skips Sentry for permission-denied errors (user choice, not an app error).
- `useImageDetection.ts` omits the image string from Sentry `extra` to avoid large payloads and potential privacy exposure.
- `onError` callbacks are not instrumented where the underlying function already captures at the API boundary, preventing double-reporting.