### PR TITLE
📝 docs: Neon cost-profiling runbook + 2 follow-on brainstorms

### DIFF
--- a/docs/brainstorms/2026-06-01-embedding-regen-anomaly-requirements.md
+++ b/docs/brainstorms/2026-06-01-embedding-regen-anomaly-requirements.md
@@ -1,0 +1,104 @@
+# Catalog Embedding Regen Anomaly — Investigation Scope
+
+- **Date:** 2026-06-01
+- **Status:** Captured signal from PR #2544 verification work. No scope committed; awaiting investigation before sizing a fix.
+- **Related:** PR #2544 (Tier-1 cost projections), [docs/brainstorms/2026-06-01-neon-cost-reduction-requirements.md](./2026-06-01-neon-cost-reduction-requirements.md) (F4 finding in U2 doc review)
+
+## Problem
+
+While running `pg_stat_user_tables` to baseline catalog table activity ahead of PR #2544's U8 verification, the numbers surfaced an anomaly:
+
+| Metric | Value |
+|---|---|
+| `catalog_items` rows (from `product_sku` distinct count) | ~126,000 |
+| `n_tup_ins` (lifetime inserts) | 1,789,703 |
+| **`n_tup_upd` (lifetime updates)** | **5,556,406** |
+| Updates per row | **~44** |
+| `n_tup_del` (lifetime deletes) | 10 |
+
+44 updates per row over the table's lifetime is high enough to warrant a dedicated investigation. The most plausible explanation maps cleanly onto an existing code-review finding.
+
+## Hypothesis (most likely)
+
+**The embedding-regen diff loop in `upsertCatalogItems` has been a no-op since it shipped, causing every ETL upsert to regenerate the embedding regardless of whether the source text changed.**
+
+This is **F4** from the PR #2544 plan's doc-review pass (feasibility reviewer's catalogService.ts:378-409 finding):
+
+> The upsert at catalogService.ts:345-368 uses `excluded.<col>` for all non-special columns, so the returned row's `name` / `description` / `categories` / `brand` will equal the input's values after upsert — `inputItem[field] !== item[field]` will always be false, and the regen path is effectively dead code today.
+
+If true, then:
+
+1. Every ETL upsert (1.79M lifetime inserts via the ETL path, plus the upsert branch on existing-SKU writes) regenerates the embedding via OpenAI.
+2. Each regeneration is a write to `catalog_items` — counts in `n_tup_upd`.
+3. The OpenAI cost is also paid every time (not just Neon — the AI Gateway egress + the embedding API call).
+
+Two side effects compound:
+
+- **Compute waste:** every embedding write churns the HNSW index, dirties pages, increases checkpointer / WAL load. The Neon compute meter ticks for every one.
+- **Cost waste beyond Neon:** OpenAI text-embedding-3 calls are billed per token. 5.56M unneeded calls × N tokens per call adds up; would need actual rate math to size.
+- **Dead-tuple bloat:** 5.56M updates create 5.56M dead tuples that autovacuum has to reclaim. With pgvector + fat JSONB rows, each dead tuple is expensive to vacuum.
+
+PR #2544's U2 commit narrowed `.returning()` to project only the fields the diff loop reads — that exposed the bug at the type level (the projection forced the regen path to read input items instead of the returned rows, which masked the underlying issue). The narrowing is correct; the diff loop is still wrong.
+
+## Alternative explanations (less likely, worth ruling out)
+
+1. **Embedding backfill / migration runs** — the `handleEmbeddingsBatch` path issues an UPDATE per item. If backfill has run multiple times across the table's lifetime, that legitimately contributes to `n_tup_upd`. Estimated max: 126K × N backfill runs. If backfill has run ~40× lifetime, that alone explains the count without any bug. **Should check ETL job history / cron history to count backfill runs.**
+
+2. **Manual admin updates** — `routes/admin/index.ts` has a PUT path that updates catalog items. If a human or scraper has been editing items at scale, those count too. Likely a small contribution.
+
+3. **A re-ranking / score refresh job** — if anything writes computed scores back to catalog_items rows on a schedule, that's per-row updates. The schema doesn't show an obvious "score" column, but worth checking for cron / scheduled jobs touching the table.
+
+The investigation should distinguish these contributions rather than assume the F4 hypothesis is the whole story.
+
+## Goals
+
+- **Quantify each contributor to `n_tup_upd`.** ETL upsert regen vs. backfill runs vs. manual edits vs. anything else.
+- **If F4 is confirmed:** fix the diff to actually compare source text (not the post-upsert `excluded.col = input.col` values) so regen only fires on genuine changes.
+- **If backfill is the contributor:** decide whether the lifetime-update count is acceptable or whether backfill should track progress and skip already-embedded rows.
+- **Reduce embedding API cost** as a side effect if regen frequency drops.
+
+## Non-goals
+
+- Reworking the embedding pipeline architecture (queue cadence, model selection, dimension count). Those are separate concerns.
+- Pivot-table migration. That's already in flight as a separate follow-on; the regen path will move with it but the diff bug should be fixed first regardless of where embeddings live.
+- Cost-modeling the OpenAI savings precisely until investigation confirms the hypothesis.
+
+## Success criteria
+
+- A measured breakdown of what's driving the 5.56M updates (X% from ETL regen, Y% from backfill, Z% from manual)
+- If F4 is confirmed: a fix that drops regen calls to a measurably small fraction of upserts (target: regen only on actual source-text changes, which for a stable catalog should be < 1% of upserts after initial population)
+- Reduction in `n_tup_upd` growth rate post-fix
+- Reduction in OpenAI embedding API call count post-fix
+
+## Investigation plan
+
+1. **Read the regen path carefully** (`packages/api/src/services/catalogService.ts:378-409` post-PR-#2544). Confirm whether the input-vs-returned comparison is structurally a no-op as F4 claims.
+2. **Inspect ETL job history** for backfill runs. How many times has `catalogService.queueEmbeddingJobs()` been invoked? Each invocation does one UPDATE per item without an embedding.
+3. **Add structured logging or Sentry breadcrumbs** to the regen path so future ETL runs report "regenerated N of M embeddings, skipped K because unchanged." This makes the diagnosis observable rather than a one-shot SQL forensic.
+4. **Sample recent updates** via `SELECT id, updated_at, length(name) AS name_len FROM catalog_items ORDER BY updated_at DESC LIMIT 100` to spot patterns — bursts of identical-second updates suggest backfill; spread-out updates suggest per-write regen.
+5. **Check OpenAI bill / AI Gateway logs** for embedding call volume. If the call rate matches the upsert rate (rather than the change rate), that's hard confirmation of F4.
+
+## Scope boundaries
+
+**In scope (this investigation):**
+- Diagnosis of the 5.56M update count
+- Fix the regen diff if F4 is confirmed
+- Add observability so future regressions are visible
+
+**Deferred:**
+- Pivot table migration (separate plan)
+- Backfill workflow redesign (separate plan if needed)
+- Cost-modeling the savings (do this after measurement, not before)
+
+## Open questions
+
+1. **Is backfill scheduled** or only run manually? Affects how many lifetime invocations are plausible.
+2. **Has the OpenAI embedding model changed** during the table's lifetime? Model version changes would legitimately trigger full-table re-embedding.
+3. **Is the AI Gateway logging embedding calls** in a way we can count by timestamp? Would directly answer "how many regen calls actually happened."
+4. **Should regen be opt-out instead of opt-in?** I.e., default to NEVER regen on upsert unless the row explicitly requests it via a flag. Safer than fixing the diff if the diff has been wrong since shipping.
+
+## Handoff
+
+Recommended next step: assign a small `/ce-plan` to investigate (1-2 hours of code reading + SQL + AI Gateway log inspection). The plan's first unit is "confirm or refute F4 via observability + code re-read"; if confirmed, subsequent units are the fix + the bloat-cleanup VACUUM consideration.
+
+If F4 is confirmed and the AI Gateway logs show 5M+ embedding calls, this is likely a non-trivial OpenAI cost recovery in addition to the Neon side — worth prioritizing.

--- a/docs/brainstorms/2026-06-01-vector-search-hnsw-unused-requirements.md
+++ b/docs/brainstorms/2026-06-01-vector-search-hnsw-unused-requirements.md
@@ -20,6 +20,7 @@
 EXPLAIN comparison against the production database confirms the root cause is the query shape, not pgvector instrumentation:
 
 **Current shape** (Drizzle pattern, all 5 callsites):
+
 ```sql
 SELECT id, ..., 1 - (embedding <=> $1) AS similarity
 FROM catalog_items
@@ -27,9 +28,11 @@ WHERE 1 - (embedding <=> $1) > 0.1
 ORDER BY 1 - (embedding <=> $1) DESC
 LIMIT 10
 ```
+
 Planner picks **Seq Scan + Sort** (parallel workers). Total cost: **427,921**.
 
 **HNSW-eligible shape**:
+
 ```sql
 SELECT id, ..., 1 - (embedding <=> $1) AS similarity
 FROM catalog_items
@@ -37,6 +40,7 @@ WHERE embedding <=> $1 < 0.9            -- equivalent threshold, raw distance
 ORDER BY embedding <=> $1               -- raw distance ASC, HNSW recognises this
 LIMIT 10
 ```
+
 Planner picks **Index Scan using embedding_idx (HNSW)**. Total cost: **3,704**.
 
 **~115× cheaper.** Subtracting from 1 is opaque to the planner: it can't see through arithmetic on an indexed column, so the `ORDER BY` is treated as ordering by a computed expression rather than the operator that HNSW serves.

--- a/docs/brainstorms/2026-06-01-vector-search-hnsw-unused-requirements.md
+++ b/docs/brainstorms/2026-06-01-vector-search-hnsw-unused-requirements.md
@@ -1,0 +1,148 @@
+# Vector Search Bypassing HNSW Index — Hotfix Scope
+
+- **Date:** 2026-06-01
+- **Status:** Confirmed via EXPLAIN against prod (Neon MCP read-only). Hotfix straightforward; capturing scope before implementation so the change has a clear paper trail.
+- **Related:** PR #2544 (Tier-1 projections), [docs/runbooks/neon-cost-profiling.md](../runbooks/neon-cost-profiling.md)
+
+## Problem
+
+`pg_stat_user_indexes` shows the `embedding_idx` HNSW index on `catalog_items` (14 GB) has **0 lifetime scans** despite vector search being a shipped feature exposed via:
+
+- `/catalog/vector-search` REST endpoint (AI tool + mobile)
+- `catalogVectorSearch` AI tool definition
+- Pack generation (`PackService.generatePacks` → `batchVectorSearch`)
+- `/catalog/:id/similar` (similar items)
+- `/packs/:packId/items/:itemId/similar` (similar pack items)
+- `/packs/:packId/item-suggestions` (recommendations)
+
+`pg_stat_database.stats_reset` is null — stats have never been reset — so the zero is a lifetime measurement, not a windowed artifact.
+
+EXPLAIN comparison against the production database confirms the root cause is the query shape, not pgvector instrumentation:
+
+**Current shape** (Drizzle pattern, all 5 callsites):
+```sql
+SELECT id, ..., 1 - (embedding <=> $1) AS similarity
+FROM catalog_items
+WHERE 1 - (embedding <=> $1) > 0.1
+ORDER BY 1 - (embedding <=> $1) DESC
+LIMIT 10
+```
+Planner picks **Seq Scan + Sort** (parallel workers). Total cost: **427,921**.
+
+**HNSW-eligible shape**:
+```sql
+SELECT id, ..., 1 - (embedding <=> $1) AS similarity
+FROM catalog_items
+WHERE embedding <=> $1 < 0.9            -- equivalent threshold, raw distance
+ORDER BY embedding <=> $1               -- raw distance ASC, HNSW recognises this
+LIMIT 10
+```
+Planner picks **Index Scan using embedding_idx (HNSW)**. Total cost: **3,704**.
+
+**~115× cheaper.** Subtracting from 1 is opaque to the planner: it can't see through arithmetic on an indexed column, so the `ORDER BY` is treated as ordering by a computed expression rather than the operator that HNSW serves.
+
+Every vector search since the feature shipped has computed cosine distance for all ~1.79M catalog rows + sorted, instead of an HNSW top-k traversal. The 14 GB index has been paying storage + write-amplification cost for zero read benefit.
+
+## Hypothesis
+
+Drizzle's idiomatic "similarity-as-percentage" pattern wraps the distance for caller convenience. The wrapping is structurally incompatible with the planner's ability to recognise HNSW-eligible `ORDER BY`. The fix is to keep the wrapping for the **response payload** (callers want a similarity score, not a distance) but order by the **raw distance** in the SQL.
+
+## Goals
+
+- Restore HNSW for every catalog vector search → ~115× planner cost reduction per query
+- Reduce Neon compute spend proportional to vector-search call volume
+- Validate the fix via post-deploy EXPLAIN ANALYZE + `pg_stat_user_indexes.idx_scan` going up from 0
+- Preserve the existing `similarity` field in API response payloads (no consumer breakage)
+
+## Non-goals
+
+- Removing the HNSW index (it's about to start being useful)
+- Tuning HNSW `m` / `ef_construction` parameters (defer until the index is actually being used and we have post-fix latency data)
+- Pivot-table migration (deferred follow-on; the fix here works on the current schema)
+- Changing the similarity threshold semantics (translate `1 - dist > 0.1` to `dist < 0.9` mechanically)
+
+## Affected callsites
+
+All confirmed via grep `cosineDistance` in `packages/api/src/`:
+
+| File | Line | Function | Sort field today |
+|---|---|---|---|
+| `packages/api/src/services/catalogService.ts` | 304 | `vectorSearch` | `1 - (embedding <=> q)` DESC |
+| `packages/api/src/services/catalogService.ts` | 367 | `batchVectorSearch` | `1 - (embedding <=> q)` DESC |
+| `packages/api/src/routes/catalog/index.ts` | 455 | `/catalog/:id/similar` | `1 - (embedding <=> source.embedding)` DESC |
+| `packages/api/src/routes/packs/index.ts` | 474 | `/packs/:packId/item-suggestions` | `1 - (embedding <=> avg_embedding)` DESC |
+| `packages/api/src/routes/packs/index.ts` | 1038 | `/:packId/items/:itemId/similar` | `1 - (embedding <=> sourceItem.embedding)` DESC |
+
+All 5 share the same fix pattern.
+
+## Fix pattern
+
+```ts
+const distanceExpr = cosineDistance(catalogItems.embedding, embedding);     // raw distance, HNSW-eligible
+const similarity = sql<number>`1 - ${distanceExpr}`;                          // for SELECT only
+
+const items = await db
+  .select({
+    ...columnsToSelect,
+    similarity,                            // keep in response — callers expect this
+  })
+  .from(catalogItems)
+  .where(lt(distanceExpr, 0.9))           // equivalent to: 1 - distance > 0.1
+  .orderBy(distanceExpr)                  // ASC by default — closest distance = highest similarity
+  .limit(limit)
+  .offset(offset);
+```
+
+Key points:
+
+- **`distanceExpr` is a single Drizzle expression** that gets used in three places (SELECT, WHERE, ORDER BY) — Drizzle reuses the SQL fragment, planner sees the same operator each time
+- **No change to the `similarity` field in the response** — callers see `{ ..., similarity: 0.87 }` exactly as before
+- **`<=>` is the cosine-distance operator pgvector indexes on for `vector_cosine_ops`** (which is what `embedding_idx` uses per schema.ts:220 + 254)
+- **Threshold flips:** `1 - distance > 0.1` becomes `distance < 0.9` (mechanically equivalent)
+
+## Test plan
+
+For each callsite, an EXPLAIN ANALYZE in CI or a test asserting the plan contains `Index Scan using embedding_idx` would lock the fix in. Integration test option:
+
+```ts
+const explain = await db.execute(sql`EXPLAIN (FORMAT JSON) ${vectorSearchQuery}`);
+const plan = explain[0]['QUERY PLAN'][0].Plan;
+// Walk the plan tree for any Index Scan using embedding_idx
+expect(planUsesIndex(plan, 'embedding_idx')).toBe(true);
+```
+
+For batch vector search, similar — assert each sub-plan uses HNSW.
+
+Existing functional vector-search tests stay green (response shape unchanged); the new tests guard against regression to seq-scan via future query refactors.
+
+## Scope boundaries
+
+**In scope (this hotfix):**
+- Fix the 5 callsites
+- Add HNSW-plan assertion tests for at least the two service methods (`vectorSearch` + `batchVectorSearch`)
+- Update U1 vector-search characterization tests if they need to reflect new query shape (likely just response-shape tests, no change required)
+
+**Deferred to follow-on:**
+- Pack-items HNSW index — `pack_items_embedding_idx` (968 KB, also 0 scans). Same bug pattern in `/packs/:packId/items/:itemId/similar` callsite. The fix above covers it, but if pack_items vector search has other consumers, audit them too.
+- HNSW parameter tuning (`m`, `ef_construction`)
+- Index drop decision — the HNSW index becomes useful after this fix, so we keep it. If post-fix data shows vector search is genuinely low-volume, then revisit drop.
+
+## Open questions
+
+- **Does the `<=>` operator hand-rolled in raw SQL plan differently than Drizzle's `cosineDistance(...)` helper?** EXPLAIN should be identical (Drizzle emits the operator), but worth verifying once during implementation.
+- **Are there any callers of the affected services that depend on the `similarity` field being computed from distance via specifically `1 - distance` math?** Unlikely (consumers treat similarity as opaque score), but worth a brief grep.
+- **Does `cosineDistance` from Drizzle support being passed to `lt()` for the WHERE clause?** May need to use `sql\`${distanceExpr} < 0.9\`` directly. Resolves at implementation.
+
+## Verification (post-deploy)
+
+1. `pg_stat_user_indexes` on `embedding_idx` shows `idx_scan > 0` within minutes of first vector search hitting prod
+2. Neon Console Top Queries: catalogService.vectorSearch query drops from top rankings (was likely #1 by total time)
+3. `pg_stat_user_tables.seq_tup_read` on catalog_items grows more slowly (vector search no longer scanning the full table)
+4. Latency on `/catalog/vector-search`, `/catalog/:id/similar`, etc. drops measurably (HNSW is ~log-time vs. linear)
+5. Bill: noticeable compute hours reduction next cycle
+
+## Cost framing
+
+The Tier-1 PR (#2544) targeted egress + per-call hydration via projection. This hotfix targets the **planning cost per vector-search invocation**, which is orthogonal — even with perfect projection, the broken `ORDER BY` forced 1.79M cosine-distance computations per call.
+
+The two compound: with projection (#2544) AND HNSW (this hotfix), a vector search goes from `Seq Scan + cosine on 1.79M rows + ship N × 26KB` to `HNSW top-K + ship N × 4KB`. The whole hot path becomes cheap.

--- a/docs/brainstorms/2026-06-04-vector-search-total-count-cost-requirements.md
+++ b/docs/brainstorms/2026-06-04-vector-search-total-count-cost-requirements.md
@@ -1,0 +1,135 @@
+# Vector Search `totalCount` Bypasses HNSW — Investigation Scope
+
+- **Date:** 2026-06-04
+- **Status:** Captured signal from PR #2554 review (Copilot, low-confidence). Real concern, not a regression introduced by the HNSW fix. Investigation needed before deciding which option fits.
+- **Related:** PR #2554 (HNSW fix), [docs/brainstorms/2026-06-01-vector-search-hnsw-unused-requirements.md](./2026-06-01-vector-search-hnsw-unused-requirements.md), PR #2544 (Tier-1 projections)
+
+## Problem
+
+`CatalogService.vectorSearch` returns a `total` field alongside the paged items, computed via a second query:
+
+```ts
+this.db
+  .select({ totalCount: count() })
+  .from(catalogItems)
+  .where(vectorWhere);   // includes distance < 0.9 (post-HNSW-fix) or 1 - distance > 0.1 (pre-fix)
+```
+
+HNSW indexes only accelerate `ORDER BY <vector-op> LIMIT top-K` patterns. Counting matches under a distance threshold has to compute the distance for every row that passes other WHERE predicates — it doesn't use the index for the predicate evaluation. So this count query likely does a full filter scan over ~1.79M `catalog_items` rows, computing cosine distance for each, on every vector-search call.
+
+**This pre-dates PR #2554.** The pre-HNSW-fix code had the same query shape (`gt(similarity, 0.1)` instead of `lt(distance, 0.9)`). PR #2554's HNSW fix makes the SELECT path ~115× cheaper without making the count path worse — but the count remains the dominant cost on every call once the SELECT becomes cheap.
+
+## Hypothesis
+
+The `total` field is over-engineered for actual consumer needs:
+
+- **AI tool callers** (the catalogVectorSearch tool exposed to Vercel AI SDK) don't paginate — they take the top N and move on. Don't need `total`.
+- **Mobile search** likely paginates but with infinite-scroll patterns where `nextOffset` is sufficient; the user-visible "showing X of Y results" string is the only consumer of `total`.
+- **Web search** could go either way — depends on whether the search results page shows a result count.
+
+If most consumers don't need `total`, paying for a full-scan count on every call to satisfy the few that do is wasteful.
+
+## Options
+
+### A — Make `total` opt-in via query parameter
+
+```ts
+async vectorSearch({ q, opts = {}, includeTotal = false }: { ... }) {
+  const items = await /* top-K HNSW query */;
+  const total = includeTotal ? await /* count query */ : undefined;
+  return { items, total, /* ... */ };
+}
+```
+
+REST callers that need it pass `?includeTotal=1`. AI tool calls don't pass it; pay zero for the count. Default-off pushes consumers to think about whether they need it.
+
+**Pro:** simple, backward-compatible if `total` was already nullable, callers control cost
+**Con:** API contract change; mobile/web that already expected `total` need updating
+
+### B — Drop `total` entirely; use `nextOffset`-based pagination
+
+Already returned. Consumers paginate by checking whether `items.length === limit` (more results may exist) or `< limit` (last page).
+
+**Pro:** removes the cost line entirely; cleanest API
+**Con:** consumers lose "X of Y" UX; breaking API change
+
+### C — Approximate count via `pg_class.reltuples` + selectivity estimate
+
+```sql
+SELECT (SELECT reltuples FROM pg_class WHERE relname='catalog_items') * <estimated_selectivity_under_threshold>
+```
+
+No row scan, just metadata + a guess. For vector similarity, "rows under distance threshold T" maps roughly to a fraction of the embedding space, but the relationship is highly query-dependent. Hard to make reliable.
+
+**Pro:** instant, zero scan cost
+**Con:** estimate quality is shaky; consumers expecting accuracy will be confused
+
+### D — Drop the threshold filter from the count query; count = `LIMIT` or `count() <= LIMIT * 10`
+
+For pagination UX, knowing "are there at least 100 results" is often enough. Could count up to `limit * 10` and report "100+" or the exact number.
+
+```sql
+SELECT count(*) FROM (
+  SELECT 1 FROM catalog_items WHERE embedding IS NOT NULL ORDER BY embedding <=> $1 LIMIT 100
+) sub;
+```
+
+HNSW serves the inner query (top-100); count is over the small result set.
+
+**Pro:** HNSW-eligible, instant; supports "100+" UX
+**Con:** loses precision for high-result-count queries
+
+### E — Accept the cost (do nothing)
+
+Document the cost in a code comment; revisit if Neon bill or vector-search latency becomes a problem.
+
+**Pro:** zero work
+**Con:** the count query becomes the dominant cost on every vector search post-HNSW-fix; was previously hidden by the equally-expensive SELECT path
+
+## Goals
+
+- Quantify the count query's actual cost (EXPLAIN ANALYZE + Worker latency measurements post-HNSW-fix)
+- Identify all consumers of `total` across mobile + web + AI tool callers
+- Pick one of A-E based on cost-impact vs. consumer-impact trade-off
+
+## Non-goals
+
+- Reworking the entire vector search API surface
+- Tuning HNSW parameters (deferred to its own plan)
+- Pivot-table migration (deferred to its own plan)
+
+## Investigation plan
+
+1. **Wait for PR #2554 to merge** so the count query becomes the visible cost line (currently hidden by the equally-expensive SELECT)
+2. **EXPLAIN ANALYZE the count query** against prod after the HNSW fix lands. Real cost number, not estimate.
+3. **Grep consumer code** for `total` reads on vector search responses:
+   - `apps/expo/features/catalog/hooks/useVectorSearch.ts`
+   - AI tool consumers (`packages/api/src/utils/ai/tools.ts`)
+   - Any web app catalog search hooks
+4. **Spot-check what mobile renders** with `total` — is it a numeric badge? "X of Y" string? Or unused?
+5. **Decide A-E** based on findings
+
+## Open questions
+
+- Does mobile's catalog search actually display the total? If unused → Option B (drop it) is cheapest
+- Does the AI tool's `catalogVectorSearch` consumer use the `total` field in its prompt context? If unused → don't compute it on the AI-tool path even if REST keeps it
+- Is "100+" UX acceptable for any caller? → Option D becomes attractive
+
+## Verification (post-decision)
+
+- For options A/B/D: response shape change tracked + characterization tests updated
+- For option C: a comparison test that says "estimate is within 20% of true count over a sample of 50 queries" or similar tolerance
+- Worker-side latency measurement (Sentry breadcrumb) showing vectorSearch p50/p99 dropped post-decision
+
+## Scope boundaries
+
+**In scope (this investigation):**
+- Diagnose the count cost post-PR-#2554
+- Audit consumers of `total`
+- Pick + implement one option
+
+**Deferred (separate plans):**
+- HNSW parameter tuning
+- Pivot-table migration
+- The embedding-regen anomaly investigation
+- Broader vector-search API redesign

--- a/docs/runbooks/neon-cost-profiling.md
+++ b/docs/runbooks/neon-cost-profiling.md
@@ -1,0 +1,201 @@
+# Neon Cost Profiling
+
+Methodology and runnable SQL for diagnosing Neon Postgres cost spikes and verifying cost-reduction PRs. Anchored to the 2026-06-01 catalog-projection audit ([docs/brainstorms/2026-06-01-neon-cost-reduction-requirements.md](../brainstorms/2026-06-01-neon-cost-reduction-requirements.md)) but intended as a generic toolkit for future investigations.
+
+## When to use this
+
+- A cost-reduction PR shipped and you want to prove the projection / query / index change actually moved Neon's compute or egress
+- The bill jumped unexpectedly and you need to find which tables / queries are responsible
+- You're sizing the catalog (or any other heavy table) before designing a structural change like a pivot-table migration
+
+## What Neon meters, and how to see each
+
+| Cost line | Where it surfaces | Diagnostic angle |
+|---|---|---|
+| **Compute hours** | Neon Console → Monitoring → Compute trend | "How much time is at least one query in flight (or the compute holding idle past the 5-min cutoff)?" |
+| **Data transfer (egress)** | Neon Console → Monitoring → Data transfer | "How many bytes left Neon's network to my Worker / clients today?" |
+| **Storage** | Neon Console → Storage tab | Heap + TOAST + indexes per table |
+
+The Console gives you visual baselines without any SQL. For deeper attribution use the queries below.
+
+## Step 1 — Console-only baseline (no SQL)
+
+Before any code change, screenshot:
+
+1. **Monitoring → Compute** (last 7 days). Look for "always-on" plateaus vs. valleys with scale-to-zero.
+2. **Monitoring → Data transfer** (last 7 days). Spikes correlate with ingest jobs or hot-list traffic.
+3. **Monitoring → Top Queries**. Sort by **Total time** and by **Rows returned**, screenshot both. This data is from `pg_stat_statements` preloaded at the compute layer — readable in the Console without `CREATE EXTENSION` in your database.
+4. **Storage tab**. Per-table size + growth rate.
+
+Repeat 24-48 hours after deploy. The diffs are your before/after evidence without touching the schema.
+
+## Step 2 — Table-level read-load snapshot (no extension)
+
+Always-available via `pg_stat_user_tables`. Run before AND after a cost-reduction PR; save both outputs.
+
+```sql
+SELECT relname,
+       seq_scan,                                              -- # of full / range scans
+       seq_tup_read,                                          -- total rows fetched by seq scans (the big number to watch)
+       idx_scan,                                              -- # of index scans
+       idx_tup_fetch,                                         -- rows fetched via index
+       n_tup_ins, n_tup_upd, n_tup_del,                       -- mutation counts (good for spotting runaway updates)
+       pg_size_pretty(pg_relation_size(relid))   AS heap,
+       pg_size_pretty(pg_total_relation_size(relid)) AS total
+FROM pg_stat_user_tables
+WHERE relname IN ('catalog_items', 'pack_items', 'packs')     -- swap in tables you care about
+ORDER BY seq_tup_read DESC;
+```
+
+What the columns tell you:
+
+- `seq_tup_read` deltas — the projection wins land here. If U2-U6 cut catalog SELECTs in half, this drops in half.
+- `n_tup_upd` divided by row count — a "lifetime updates per row" sanity check. Anything above ~5 is suspicious and worth investigating (the catalog-projections audit surfaced ~44 updates/row, which traced back to a no-op embedding-regen diff loop).
+- `idx_scan` vs `seq_scan` ratio — on small tables (< ~1 MB) Postgres prefers seq scan and that's correct; on large tables a high seq_scan count usually means a missing or unused index.
+
+To reset and get a clean window (requires owner role):
+```sql
+SELECT pg_stat_reset_single_table_counters((SELECT relid FROM pg_stat_user_tables WHERE relname='catalog_items'));
+```
+
+## Step 3 — Per-row size distribution (no extension, sampled)
+
+`pg_column_size(table.*)` over the full table will time out on anything > a few thousand rows because each call has to detoast the large JSONB and vector columns. Use `TABLESAMPLE BERNOULLI` to sample 1-5% instead.
+
+**Per-column average sizes** (which JSONB column dominates the bytes):
+```sql
+SELECT
+  COUNT(*) AS sampled,
+  pg_size_pretty(AVG(pg_column_size(embedding))::bigint) AS avg_embedding,
+  pg_size_pretty(AVG(pg_column_size(reviews))::bigint)   AS avg_reviews,
+  pg_size_pretty(AVG(pg_column_size(qas))::bigint)       AS avg_qas,
+  pg_size_pretty(AVG(pg_column_size(faqs))::bigint)      AS avg_faqs,
+  pg_size_pretty(AVG(pg_column_size(techs))::bigint)     AS avg_techs,
+  pg_size_pretty(AVG(pg_column_size(variants))::bigint)  AS avg_variants,
+  pg_size_pretty(AVG(pg_column_size(images))::bigint)    AS avg_images
+FROM catalog_items TABLESAMPLE BERNOULLI (1);
+```
+
+**Distribution percentiles** (how skewed — i.e., is the bill driven by a long tail of fat rows or by every row equally?):
+```sql
+SELECT
+  COUNT(*) AS sampled,
+  pg_size_pretty(percentile_cont(0.5)  WITHIN GROUP (ORDER BY pg_column_size(c.*))::bigint) AS p50,
+  pg_size_pretty(percentile_cont(0.9)  WITHIN GROUP (ORDER BY pg_column_size(c.*))::bigint) AS p90,
+  pg_size_pretty(percentile_cont(0.99) WITHIN GROUP (ORDER BY pg_column_size(c.*))::bigint) AS p99,
+  pg_size_pretty(MAX(pg_column_size(c.*))::bigint) AS max_observed
+FROM catalog_items TABLESAMPLE BERNOULLI (1) c;
+```
+
+A wide p50→p99 gap means list endpoints that sort by rating / popularity / usage pull mostly the fat rows — projection wins are larger than the average-row math suggests.
+
+**TOAST vs main heap split** (instant — metadata only, no row scan):
+```sql
+SELECT
+  pg_size_pretty(pg_relation_size('catalog_items'))      AS heap_main,
+  pg_size_pretty(pg_relation_size(
+    (SELECT reltoastrelid FROM pg_class WHERE relname='catalog_items')
+  ))                                                      AS toast_storage,
+  pg_size_pretty(pg_indexes_size('catalog_items'))       AS indexes,
+  pg_size_pretty(pg_total_relation_size('catalog_items')) AS total;
+```
+
+High TOAST ratio (e.g., TOAST > main heap) means most rows have fat fields stored in out-of-line storage that get detoasted on access. Projection-discipline pays off the most for tables with this shape.
+
+## Step 4 — Per-query depth (optional, requires `pg_stat_statements`)
+
+`pg_stat_statements` is the canonical Postgres query profiler. **Neon preloads it at the compute layer** (which is how the Console's Top Queries panel works), but reading it from SQL needs the extension registered in your database:
+
+```sql
+CREATE EXTENSION IF NOT EXISTS pg_stat_statements;
+```
+
+**Conservative approach for production:** don't enable it on prod without testing first. Use Neon branching:
+
+```bash
+neon branches create --name test-pg-stat-statements --parent main
+```
+
+Then register the extension on the branch, confirm it behaves as expected, then decide whether to enable on main. Zero impact on prod traffic during validation.
+
+Once enabled, the high-value query:
+
+```sql
+SELECT query,
+       calls,
+       rows,
+       total_exec_time,
+       mean_exec_time,
+       shared_blks_read * 8192 AS bytes_read     -- pages × 8KB ≈ disk bytes
+FROM pg_stat_statements
+WHERE query ILIKE '%catalog_items%' OR query ILIKE '%pack_items%'
+ORDER BY total_exec_time DESC
+LIMIT 30;
+```
+
+`pg_stat_statements_reset()` (owner role required) clears the slate between before/after windows.
+
+## Step 5 — Worker-side response-byte logging
+
+DB-side measurement bounds what leaves Neon. Worker-side measurement bounds what reaches clients. Both matter for different cost lines (compute + Neon egress vs. Cloudflare bandwidth + LLM context cost).
+
+Cheapest pattern — Sentry breadcrumb on every Drizzle call site or response handler:
+
+```ts
+import { apiAddBreadcrumb } from '@packrat/api/utils/sentry';
+
+const rows = await catalogService.getCatalogItems({ limit });
+apiAddBreadcrumb({
+  category: 'db.egress',
+  message: 'catalog.list',
+  level: 'info',
+  data: {
+    rowCount: rows.items.length,
+    serializedBytes: JSON.stringify(rows).length,
+  },
+});
+```
+
+Searchable later by `category:db.egress` in Sentry. Surface a percentile chart of `serializedBytes` per endpoint and you have a permanent per-request egress monitor.
+
+For Worker → client specifically, wrap the response in a middleware that logs `response.headers.get('content-length')` (or computes from body length before returning) and ships to wrangler tail / Workers Logs.
+
+## How to verify a cost-reduction PR (the U8 pattern)
+
+The Tier-1 projections PR (2026-06-01) introduced this verification flow. Reuse it for future cost work:
+
+**Before merge** (capture baseline):
+
+1. Console screenshots: Compute trend (7d), Data transfer (7d), Top Queries (sorted by Total time AND by Rows returned).
+2. Save the Step 2 `pg_stat_user_tables` output to a file (`baseline-pre-merge.txt`).
+3. Run Step 3's three queries and save outputs.
+
+**Merge and deploy.** Wait 24-48 hours for the metrics to populate against realistic traffic.
+
+**After (verify):**
+
+4. Console screenshots again. Same panels, same time window.
+5. Re-run Step 2's pg_stat_user_tables query. Diff `seq_tup_read` and `n_tup_upd` against baseline.
+6. Re-run Step 3's queries. Sizes themselves shouldn't change (projection doesn't shrink stored rows), but you're confirming the table grew on schedule and TOAST ratio is sane.
+
+**What "good" looks like:**
+
+- `seq_tup_read` on the target table dropped proportional to the projection change
+- Top Queries panel: target queries dropped in rank, or disappeared entirely
+- Compute hours: visibly lower steady-state, especially during idle traffic windows
+- Data transfer: lower per-day total (factor in any non-cost-related traffic changes)
+- Bill: lower at next cycle close, controlling for ingest activity
+
+**What "investigate further" looks like:**
+
+- Compute hours stay continuously warm post-deploy → projection alone wasn't enough; next lever is API-traffic batching to enable scale-to-zero windows
+- Egress dropped but compute didn't → reads got cheaper but updates / inserts are still hot; investigate `n_tup_upd` growth
+- Some queries dropped in rank but new ones appeared → the lint (if you have one) is doing its job catching new patterns; or some path bypasses the projection rule
+
+## Related
+
+- Projection-discipline rules: see `CLAUDE.md` → Conventions → API → "DB query projection discipline" (once PR #2544 lands)
+- Lint enforcing the discipline: `scripts/lint/no-unprojected-fat-table-queries.ts`
+- Cost-bearing projection types: `packages/db/src/projections.ts`
+- Originating audit: `docs/brainstorms/2026-06-01-neon-cost-reduction-requirements.md`
+- Tier-1 PR: https://github.com/PackRat-AI/PackRat/pull/2544

--- a/docs/runbooks/neon-cost-profiling.md
+++ b/docs/runbooks/neon-cost-profiling.md
@@ -54,6 +54,7 @@ What the columns tell you:
 - `idx_scan` vs `seq_scan` ratio — on small tables (< ~1 MB) Postgres prefers seq scan and that's correct; on large tables a high seq_scan count usually means a missing or unused index.
 
 To reset and get a clean window (requires owner role):
+
 ```sql
 SELECT pg_stat_reset_single_table_counters((SELECT relid FROM pg_stat_user_tables WHERE relname='catalog_items'));
 ```
@@ -63,6 +64,7 @@ SELECT pg_stat_reset_single_table_counters((SELECT relid FROM pg_stat_user_table
 `pg_column_size(table.*)` over the full table will time out on anything > a few thousand rows because each call has to detoast the large JSONB and vector columns. Use `TABLESAMPLE BERNOULLI` to sample 1-5% instead.
 
 **Per-column average sizes** (which JSONB column dominates the bytes):
+
 ```sql
 SELECT
   COUNT(*) AS sampled,
@@ -77,6 +79,7 @@ FROM catalog_items TABLESAMPLE BERNOULLI (1);
 ```
 
 **Distribution percentiles** (how skewed — i.e., is the bill driven by a long tail of fat rows or by every row equally?):
+
 ```sql
 SELECT
   COUNT(*) AS sampled,
@@ -90,6 +93,7 @@ FROM catalog_items TABLESAMPLE BERNOULLI (1) c;
 A wide p50→p99 gap means list endpoints that sort by rating / popularity / usage pull mostly the fat rows — projection wins are larger than the average-row math suggests.
 
 **TOAST vs main heap split** (instant — metadata only, no row scan):
+
 ```sql
 SELECT
   pg_size_pretty(pg_relation_size('catalog_items'))      AS heap_main,
@@ -174,9 +178,9 @@ The Tier-1 projections PR (2026-06-01) introduced this verification flow. Reuse 
 
 **After (verify):**
 
-4. Console screenshots again. Same panels, same time window.
-5. Re-run Step 2's pg_stat_user_tables query. Diff `seq_tup_read` and `n_tup_upd` against baseline.
-6. Re-run Step 3's queries. Sizes themselves shouldn't change (projection doesn't shrink stored rows), but you're confirming the table grew on schedule and TOAST ratio is sane.
+1. Console screenshots again. Same panels, same time window.
+2. Re-run Step 2's pg_stat_user_tables query. Diff `seq_tup_read` and `n_tup_upd` against baseline.
+3. Re-run Step 3's queries. Sizes themselves shouldn't change (projection doesn't shrink stored rows), but you're confirming the table grew on schedule and TOAST ratio is sane.
 
 **What "good" looks like:**
 


### PR DESCRIPTION
## Summary

Three documentation artifacts from the cost-investigation work that turned up PR #2544 (Tier-1 projections) and the parallel HNSW hotfix PR. Each addresses a different concern; bundled together because they're all docs and they all cross-reference each other.

## Files

### 1. `docs/runbooks/neon-cost-profiling.md` (new)

Methodology for diagnosing Neon cost spikes and verifying cost-reduction PRs **without** enabling `pg_stat_statements` raw on prod. Five-step flow:

1. **Console-only baseline** (no SQL) — screenshot Monitoring → Compute, Data transfer, Top Queries
2. **Table-level read-load** via \`pg_stat_user_tables\` (no extension needed)
3. **Per-row size distribution** via \`TABLESAMPLE BERNOULLI\`-bounded \`pg_column_size\` (avoids the 30s HTTP query timeout from full-table detoasting)
4. **Per-query depth** via \`pg_stat_statements\` — with Neon-branching guidance for safe prod validation
5. **Worker-side response-byte logging** via Sentry breadcrumbs

Includes the U8-style before/after verification flow so the methodology persists past this immediate work.

### 2. \`docs/brainstorms/2026-06-01-embedding-regen-anomaly-requirements.md\` (new)

Signal captured during PR #2544 verification: \`catalog_items\` has **5.56M lifetime updates over ~1.79M rows**. Most-plausible hypothesis: the \`upsertCatalogItems\` regen-diff loop has been structurally a no-op since shipping (\`excluded.col = input.col\` after upsert), causing every ETL upsert to regenerate the embedding regardless of whether source text changed.

Captures hypothesis, alternative explanations to rule out, investigation plan, and likely OpenAI API cost recovery in addition to Neon waste.

### 3. \`docs/brainstorms/2026-06-01-vector-search-hnsw-unused-requirements.md\` (new)

The brainstorm behind the parallel HNSW hotfix PR. Full EXPLAIN evidence, root-cause analysis, fix pattern, test plan (CI assertion that vector search plans use \`embedding_idx\`), and scope boundaries. Lives separately from the hotfix itself so the rationale + verification methodology persist as a decision record.

## Why three artifacts in one PR

All three are documentation; none depend on each other for correctness. Bundling avoids three trivial PRs while keeping concerns crisp at the file level. None depend on PR #2544 landing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an investigation guide for catalog embedding regeneration anomalies, with hypotheses, success criteria, and a step-by-step diagnostic plan.
  * Added a vector-search index optimization doc describing a hotfix to restore index usage, query-shape recommendations, verification steps, and CI/EXPLAIN assertions.
  * Added an operational runbook for PostgreSQL cost profiling with diagnostics, sampling queries, verification checklists, and post-change validation steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->