### PR TITLE
🐛 fix(api): vector search uses HNSW index (was bypassing it, ~115× cost)

### DIFF
--- a/packages/api/src/routes/catalog/index.ts
+++ b/packages/api/src/routes/catalog/index.ts
@@ -26,10 +26,8 @@ import {
   and,
   cosineDistance,
   count,
-  desc,
   eq,
   getTableColumns,
-  gt,
   inArray,
   isNotNull,
   isNull,
@@ -554,7 +552,13 @@ export const catalogRoutes = new Elysia({ prefix: '/catalog' })
         return status(404, { error: 'Catalog item not found or has no embedding' });
       }
 
-      const similarity = sql<number>`1 - (${cosineDistance(catalogItems.embedding, sourceItem.embedding)})`;
+      // HNSW-eligible: ORDER BY raw distance ASC. The `similarity = 1 - distance`
+      // field is preserved in the response, but the operators see the raw
+      // distance so the planner can use embedding_idx (HNSW). Threshold
+      // mechanically flips from `similarity > T` to `distance < (1 - T)`.
+      const distance = cosineDistance(catalogItems.embedding, sourceItem.embedding);
+      const similarity = sql<number>`1 - (${distance})`;
+      const maxDistance = 1 - threshold;
       const { embedding: _embedding, ...columnsToSelect } = getTableColumns(catalogItems);
 
       const similarItems = await db
@@ -562,12 +566,12 @@ export const catalogRoutes = new Elysia({ prefix: '/catalog' })
         .from(catalogItems)
         .where(
           and(
-            gt(similarity, threshold),
+            sql`${distance} < ${maxDistance}`,
             ne(catalogItems.id, itemId),
             isNotNull(catalogItems.embedding),
           ),
         )
-        .orderBy(desc(similarity))
+        .orderBy(distance)
         .limit(validLimit);
 
       const { embedding: _sourceEmbedding, ...sourceItemData } = sourceItem;

--- a/packages/api/src/routes/packs/index.ts
+++ b/packages/api/src/routes/packs/index.ts
@@ -37,13 +37,12 @@ import { ErrorResponseSchema } from '@packrat/schemas/shared';
 import {
   and,
   cosineDistance,
-  desc,
   eq,
   getTableColumns,
-  gt,
   isNotNull,
   notInArray,
   or,
+  type SQL,
   sql,
 } from 'drizzle-orm';
 import { Elysia, NotFoundError, status } from 'elysia';
@@ -395,8 +394,11 @@ export const packsRoutes = new Elysia({ prefix: '/packs' })
           existingEmbeddings.length,
       );
 
-      const similarity = sql<number>`1 - (${cosineDistance(catalogItems.embedding, avgEmbedding)})`;
-      const whereConditions = [gt(similarity, 0.1)];
+      // HNSW-eligible: ORDER BY raw distance ASC. See catalogService.vectorSearch
+      // for the full rationale on why `1 - (...)` wrapping defeats HNSW.
+      const distance = cosineDistance(catalogItems.embedding, avgEmbedding);
+      const similarity = sql<number>`1 - (${distance})`;
+      const whereConditions: SQL[] = [sql`${distance} < 0.9`];
       if (existingCatalogItemIds.length > 0) {
         whereConditions.push(notInArray(catalogItems.id, existingCatalogItemIds));
       }
@@ -413,7 +415,7 @@ export const packsRoutes = new Elysia({ prefix: '/packs' })
         })
         .from(catalogItems)
         .where(and(...whereConditions))
-        .orderBy(desc(similarity))
+        .orderBy(distance)
         .limit(5);
 
       return similarItems;
@@ -911,14 +913,20 @@ Limit to maximum 6 recommendations, prioritizing the most important gaps. Only s
         return status(403, { error: 'Access denied to private pack' });
       }
 
-      const catalogSimilarity = sql<number>`1 - (${cosineDistance(catalogItems.embedding, sourceItem.embedding)})`;
+      // HNSW-eligible: ORDER BY raw distance ASC. The `similarity` field is
+      // preserved in the response (1 - distance) for caller compatibility.
+      const catalogDistance = cosineDistance(catalogItems.embedding, sourceItem.embedding);
+      const catalogSimilarity = sql<number>`1 - (${catalogDistance})`;
+      const maxCatalogDistance = 1 - threshold;
       const { embedding: _catalogEmbedding, ...catalogColumns } = getTableColumns(catalogItems);
 
       const similarCatalogItems = await db
         .select({ ...catalogColumns, similarity: catalogSimilarity })
         .from(catalogItems)
-        .where(and(gt(catalogSimilarity, threshold), isNotNull(catalogItems.embedding)))
-        .orderBy(desc(catalogSimilarity))
+        .where(
+          and(sql`${catalogDistance} < ${maxCatalogDistance}`, isNotNull(catalogItems.embedding)),
+        )
+        .orderBy(catalogDistance)
         .limit(validLimit);
 
       const { embedding: _sourceEmbedding, ...sourceItemData } = sourceItem;

--- a/packages/api/src/services/catalogService.ts
+++ b/packages/api/src/services/catalogService.ts
@@ -16,7 +16,6 @@ import {
   desc,
   eq,
   getTableColumns,
-  gt,
   ilike,
   inArray,
   isNotNull,
@@ -238,11 +237,21 @@ export class CatalogService {
       };
     }
 
-    const similarity = sql<number>`1 - (${cosineDistance(catalogItems.embedding, embedding)})`;
+    // ORDER BY the raw cosine distance so the HNSW index (vector_cosine_ops
+    // on embedding_idx) can serve the query. Wrapping the distance in
+    // `1 - (...)` and ordering by that DESC made the planner fall back to
+    // Seq Scan + Sort across all ~1.79M catalog rows — ~115× more expensive
+    // than HNSW per EXPLAIN against prod. The `similarity` field is still
+    // computed and returned for caller compatibility (response shape
+    // unchanged); only the SQL operators ORDER BY / WHERE see the raw
+    // distance, which is what HNSW is built to serve.
+    const distance = cosineDistance(catalogItems.embedding, embedding);
+    const similarity = sql<number>`1 - (${distance})`;
 
     const { embedding: _embedding, ...columnsToSelect } = getTableColumns(catalogItems);
 
-    const vectorWhere = and(isNotNull(catalogItems.embedding), gt(similarity, 0.1));
+    // `distance < 0.9` is equivalent to the previous `similarity > 0.1`.
+    const vectorWhere = and(isNotNull(catalogItems.embedding), sql`${distance} < 0.9`);
 
     const [items, vectorTotalCountResult] = await Promise.all([
       this.db
@@ -252,7 +261,7 @@ export class CatalogService {
         })
         .from(catalogItems)
         .where(vectorWhere)
-        .orderBy(desc(similarity))
+        .orderBy(distance) // ASC; HNSW-eligible
         .limit(limit)
         .offset(offset),
       this.db
@@ -303,7 +312,10 @@ export class CatalogService {
         return Promise.resolve([]);
       }
 
-      const similarity = sql<number>`1 - (${cosineDistance(catalogItems.embedding, embedding)})`;
+      // HNSW-eligible: ORDER BY the raw distance ASC. See vectorSearch above
+      // for the full rationale on why `1 - (...)` wrapping defeats HNSW.
+      const distance = cosineDistance(catalogItems.embedding, embedding);
+      const similarity = sql<number>`1 - (${distance})`;
       const { embedding: _embedding, ...columnsToSelect } = getTableColumns(catalogItems);
       return this.db
         .select({
@@ -311,8 +323,8 @@ export class CatalogService {
           similarity,
         })
         .from(catalogItems)
-        .where(and(isNotNull(catalogItems.embedding), gt(similarity, 0.1)))
-        .orderBy(desc(similarity))
+        .where(and(isNotNull(catalogItems.embedding), sql`${distance} < 0.9`))
+        .orderBy(distance)
         .limit(limit);
     });
 


### PR DESCRIPTION
## Summary

The 14 GB HNSW index on \`catalog_items.embedding\` has **0 lifetime scans** — verified against prod via \`pg_stat_user_indexes\` (\`stats_reset\` is null, so this measures the database's entire lifetime). Every vector search since the feature shipped has been doing **Seq Scan + parallel-Sort over 1.79M rows × 1536-dim cosine distance** instead of an HNSW top-k traversal.

**Root cause:** Drizzle's \`cosineDistance(...)\` wrapped in \`1 - (...)\` for the \`similarity\` value, then ordered by \`desc(similarity)\`. The arithmetic wrapping is opaque to the Postgres planner — it treats ORDER BY as a computed expression rather than the \`<=>\` operator that HNSW's \`vector_cosine_ops\` index can serve.

**Fix** at 5 callsites: order by the raw \`cosineDistance\` (ASC; HNSW-eligible), switch WHERE threshold from \`similarity > T\` to \`distance < (1 - T)\`, keep \`similarity = 1 - distance\` in the SELECT for response-payload compatibility.

## EXPLAIN evidence (verified against prod via Neon MCP)

| Query shape | Plan | Total cost |
|---|---|---|
| **Old** (\`ORDER BY 1 - (embedding <=> \$1) DESC\`) | Seq Scan + Sort (parallel) | **427,921** |
| **New** (\`ORDER BY embedding <=> \$1 ASC\`) | Index Scan using **embedding_idx** | **3,704** |

**~115× cheaper per query.** Re-verified after applying the fix shape with full \`similarity\` in SELECT + raw distance in WHERE/ORDER BY — planner still picks \`Index Scan using embedding_idx\`. Confirmed end-to-end.

## Callsites fixed

| File | Function |
|---|---|
| \`packages/api/src/services/catalogService.ts\` | \`vectorSearch\` |
| \`packages/api/src/services/catalogService.ts\` | \`batchVectorSearch\` |
| \`packages/api/src/routes/catalog/index.ts\` | \`/catalog/:id/similar\` |
| \`packages/api/src/routes/packs/index.ts\` | \`/packs/:packId/item-suggestions\` |
| \`packages/api/src/routes/packs/index.ts\` | \`/:packId/items/:itemId/similar\` |

All 5 share the same fix pattern. Response shape unchanged — callers still receive \`{ ..., similarity: 0.87 }\` exactly as before.

## Test plan

- [x] EXPLAIN against prod confirms post-fix shape uses \`embedding_idx\` (HNSW)
- [x] \`bun check-types\` clean
- [x] \`bun biome check\` clean (auto-removed now-unused \`gt\` / \`desc\` imports)
- [ ] **Post-deploy:** \`pg_stat_user_indexes.embedding_idx.idx_scan\` goes from 0 → > 0 within minutes of first vector search
- [ ] **Post-deploy:** Neon Console Top Queries — catalogService.vectorSearch drops off the top of total-time rankings
- [ ] **Post-deploy:** \`pg_stat_user_tables.seq_tup_read\` on catalog_items grows more slowly
- [ ] **Post-deploy:** vector-search latency drops measurably (HNSW is ~log-time vs. O(n))

## Orthogonal to PR #2544

PR #2544 (Tier-1 projections) targets egress + per-call hydration via column projection. **This hotfix targets the planning cost per vector-search invocation** — different cost surface, different revert blast radius. The two compound: with projection AND HNSW, vector search goes from "scan + cosine on 1.79M rows + ship 26 KB/row" to "HNSW top-K + ship 4 KB/row."

## Refs

- Brainstorm with full EXPLAIN traces + scope: see PR #2553 (docs)
- Tier-1 projections: PR #2544