### PR TITLE
fix(expo): profile picture disappears after closing the app

### DIFF
--- a/apps/expo/features/auth/hooks/useAuthActions.ts
+++ b/apps/expo/features/auth/hooks/useAuthActions.ts
@@ -44,7 +44,7 @@ function mapToUser(raw: Record<string, unknown>): User {
     lastName: spaceIdx >= 0 ? name.slice(spaceIdx + 1) : '',
     role: asString(raw.role) ?? 'USER',
     emailVerified: asBoolean(raw.emailVerified) ?? null,
-    avatarUrl: asString(raw.image) ?? null,
+    avatarUrl: asString(raw.avatarUrl) ?? asString(raw.image) ?? null,
     createdAt: asString(raw.createdAt) ?? null,
     updatedAt: asString(raw.updatedAt) ?? null,
     preferredWeightUnit: (raw.preferredWeightUnit as User['preferredWeightUnit']) ?? 'g',

--- a/apps/expo/features/auth/hooks/useAuthInit.ts
+++ b/apps/expo/features/auth/hooks/useAuthInit.ts
@@ -1,4 +1,5 @@
 import { when } from '@legendapp/state';
+import { WEIGHT_UNITS } from '@packrat/constants';
 import { clientEnvs } from '@packrat/env/expo-client';
 import { asBoolean, asString } from '@packrat/guards';
 import AsyncStorage from '@react-native-async-storage/async-storage';
@@ -42,10 +43,13 @@ function applySessionUser(sessionUser: Record<string, unknown>) {
     id: asString(sessionUser.id) ?? '',
     email: asString(sessionUser.email) ?? '',
     firstName:
-      asString(sessionUser.firstName) ?? name.split(' ')[0] ?? existingUser?.firstName ?? '',
+      asString(sessionUser.firstName) ??
+      (name.split(' ')[0] || undefined) ??
+      existingUser?.firstName ??
+      '',
     lastName:
       asString(sessionUser.lastName) ??
-      name.split(' ').slice(1).join(' ') ??
+      (name.split(' ').slice(1).join(' ') || undefined) ??
       existingUser?.lastName ??
       '',
     role: asString(sessionUser.role) ?? existingUser?.role ?? 'USER',
@@ -58,7 +62,9 @@ function applySessionUser(sessionUser: Record<string, unknown>) {
     createdAt: asString(sessionUser.createdAt) ?? existingUser?.createdAt ?? null,
     updatedAt: asString(sessionUser.updatedAt) ?? existingUser?.updatedAt ?? null,
     preferredWeightUnit:
-      (sessionUser.preferredWeightUnit as import('@packrat/constants').WeightUnit | undefined) ??
+      (WEIGHT_UNITS.includes(sessionUser.preferredWeightUnit as never)
+        ? (sessionUser.preferredWeightUnit as import('@packrat/constants').WeightUnit)
+        : undefined) ??
       existingUser?.preferredWeightUnit ??
       'g',
   });

--- a/apps/expo/features/auth/hooks/useAuthInit.ts
+++ b/apps/expo/features/auth/hooks/useAuthInit.ts
@@ -32,17 +32,35 @@ function applySessionUser(sessionUser: Record<string, unknown>) {
   // Keep Sentry user identity in sync with the session.
   Sentry.setUser({ id: userId, email, username: name });
 
+  // Better Auth's getSession() may not return additionalFields (e.g. avatarUrl,
+  // firstName, lastName) if the session was created before those fields were
+  // added or if the client doesn't request them. Preserve existing persisted
+  // values for those fields rather than overwriting with null.
+  const existingUser = userStore.get();
+
   userStore.set({
     id: asString(sessionUser.id) ?? '',
     email: asString(sessionUser.email) ?? '',
-    firstName: name.split(' ')[0] ?? '',
-    lastName: name.split(' ').slice(1).join(' ') ?? '',
-    role: asString(sessionUser.role) ?? 'USER',
+    firstName:
+      asString(sessionUser.firstName) ?? name.split(' ')[0] ?? existingUser?.firstName ?? '',
+    lastName:
+      asString(sessionUser.lastName) ??
+      name.split(' ').slice(1).join(' ') ??
+      existingUser?.lastName ??
+      '',
+    role: asString(sessionUser.role) ?? existingUser?.role ?? 'USER',
     emailVerified: asBoolean(sessionUser.emailVerified) ?? null,
-    avatarUrl: asString(sessionUser.avatarUrl) ?? asString(sessionUser.image) ?? null,
-    createdAt: asString(sessionUser.createdAt) ?? null,
-    updatedAt: asString(sessionUser.updatedAt) ?? null,
-    preferredWeightUnit: 'g',
+    avatarUrl:
+      asString(sessionUser.avatarUrl) ??
+      asString(sessionUser.image) ??
+      existingUser?.avatarUrl ??
+      null,
+    createdAt: asString(sessionUser.createdAt) ?? existingUser?.createdAt ?? null,
+    updatedAt: asString(sessionUser.updatedAt) ?? existingUser?.updatedAt ?? null,
+    preferredWeightUnit:
+      (sessionUser.preferredWeightUnit as import('@packrat/constants').WeightUnit | undefined) ??
+      existingUser?.preferredWeightUnit ??
+      'g',
   });
 }
 

--- a/apps/expo/features/auth/hooks/useAuthInit.ts
+++ b/apps/expo/features/auth/hooks/useAuthInit.ts
@@ -39,7 +39,7 @@ function applySessionUser(sessionUser: Record<string, unknown>) {
     lastName: name.split(' ').slice(1).join(' ') ?? '',
     role: asString(sessionUser.role) ?? 'USER',
     emailVerified: asBoolean(sessionUser.emailVerified) ?? null,
-    avatarUrl: asString(sessionUser.image) ?? null,
+    avatarUrl: asString(sessionUser.avatarUrl) ?? asString(sessionUser.image) ?? null,
     createdAt: asString(sessionUser.createdAt) ?? null,
     updatedAt: asString(sessionUser.updatedAt) ?? null,
     preferredWeightUnit: 'g',


### PR DESCRIPTION
## Problem

Profile pictures uploaded by users would disappear every time the app was closed and reopened.

## Root Cause

Two functions that map the Better Auth session user to the local `User` type were reading the wrong field:

- `applySessionUser` in `useAuthInit.ts` (runs on every app start during background session refresh)
- `mapToUser` in `useAuthActions.ts` (runs after sign-in / OAuth flows)

Both were doing:
```ts
avatarUrl: asString(sessionUser.image) ?? null,
```

PackRat stores avatars as R2 keys in `avatarUrl` — a Better Auth `additionalField` mapped to the `avatar_url` column. The Better Auth built-in `image` field is always `null` for email/password users. So on every app restart, the background `getSession()` call overwrote the persisted `avatarUrl` with `null`.

## Fix

Prefer the `avatarUrl` additionalField (populated by Better Auth from the DB) and fall back to `image` for OAuth providers that set the built-in field:

```ts
avatarUrl: asString(sessionUser.avatarUrl) ?? asString(sessionUser.image) ?? null,
```

## Files Changed

- `apps/expo/features/auth/hooks/useAuthInit.ts` — `applySessionUser`
- `apps/expo/features/auth/hooks/useAuthActions.ts` — `mapToUser`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved avatar URL handling with better fallback logic. User profile images now display more reliably across the entire application. When primary image sources are unavailable, the system now properly falls back to alternative sources, ensuring consistent avatar display throughout the app and providing a seamless user profile experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->