### PR TITLE
fix(schemas): handle legacy pack category values with .catch(null)

### DIFF
--- a/packages/schemas/src/packs.ts
+++ b/packages/schemas/src/packs.ts
@@ -29,7 +29,7 @@ export const PackSchema = z.object({
   userId: z.string(),
   name: z.string(),
   description: z.string().nullable(),
-  category: z.enum(PACK_CATEGORIES).nullable(),
+  category: z.enum(PACK_CATEGORIES).nullable().catch(null),
   isPublic: z.boolean(),
   image: z.string().nullable(),
   tags: z.array(z.string()).nullable(),


### PR DESCRIPTION
## Problem

The `GET /api/packs` endpoint was returning 500 errors for users whose packs had legacy `category` values in the database (e.g. `"Outdoor Adventure"`, `"Water Adventure"`, `"Cultural Adventure"`) that predate the current strict enum definition.

Sentry error:
```
invalid_enum_value: Expected 'hiking' | 'backpacking' | 'camping' | 'climbing' | 'winter' | 'desert' | 'custom' | 'water sports' | 'skiing', received 'Outdoor Adventure'
```

## Fix

Added `.catch(null)` to the `category` field in `PackSchema` so any unrecognised DB value gracefully falls back to `null` rather than throwing a Zod validation error.

```ts
// before
category: z.enum(PACK_CATEGORIES).nullable(),

// after
category: z.enum(PACK_CATEGORIES).nullable().catch(null),
```

The TypeScript type is unchanged — `category` remains `PackCategory | null`.

## Root cause

Legacy data in the DB from an earlier era when the category enum had different display-name values. These rows never got migrated when the enum was tightened to lowercase identifiers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of invalid pack categories—they now default to null instead of causing validation errors, allowing packs with invalid categories to process gracefully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->