### PR TITLE
fix: add back button to Gear Inventory screen

### DIFF
--- a/apps/expo/app/(app)/gear-inventory.tsx
+++ b/apps/expo/app/(app)/gear-inventory.tsx
@@ -1,5 +1,5 @@
 import { assertDefined } from '@packrat/guards';
-import { Text } from '@packrat/ui/nativewindui';
+import { LargeTitleHeader, Text } from '@packrat/ui/nativewindui';
 import { PackItemCard } from 'expo-app/features/packs/components/PackItemCard';
 import { useUserPackItems } from 'expo-app/features/packs/hooks/useUserPackItems';
 import type { PackItem } from 'expo-app/features/packs/types';
@@ -64,12 +64,8 @@ export default function GearInventoryScreen() {
   const itemsByCategory = groupByCategory(items);
 
   return (
-    <SafeAreaView className="flex-1" edges={['top', 'bottom']}>
-      <View className="px-4 pb-2 pt-4">
-        <Text variant="title1" className="font-bold">
-          {t('packs.gearInventory')}
-        </Text>
-      </View>
+    <SafeAreaView className="flex-1" edges={['bottom']}>
+      <LargeTitleHeader title={t('packs.gearInventory')} />
       <ScrollView className="flex-1 px-4">
         <View className="flex-row items-center justify-between p-4">
           <Text variant="subhead" className="text-muted-foreground">


### PR DESCRIPTION
## Summary

Fixes #2548 — back button was missing from the Gear Inventory screen on iOS.

## Root Cause

The Gear Inventory screen used a custom `View` for its header (title only), unlike other screens in the app that use `LargeTitleHeader` from `@packrat/ui/nativewindui`. `LargeTitleHeader` automatically wires up the native back button via Expo Router's Stack navigator.

## Fix

- Replaced the custom title `View` with `LargeTitleHeader`, matching the pattern used by `shopping-list.tsx`, `trail-conditions.tsx`, and other screens
- Updated `SafeAreaView` edges from `['top', 'bottom']` to `['bottom']` since `LargeTitleHeader` handles the top safe area

## Testing

1. Open the app and navigate to Dashboard
2. Tap **Gear Inventory**
3. Confirm back button appears in the header (iOS: chevron-left, Android: arrow-left)
4. Confirm tapping it navigates back correctly
5. Confirm swipe-to-dismiss gesture still works on iOS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined the header styling on the Gear Inventory screen for a more polished and consistent appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->