### PR TITLE
fix(expo): add contentInsetAdjustmentBehavior to GearInventory ScrollView

### DIFF
--- a/apps/expo/app/(app)/gear-inventory.tsx
+++ b/apps/expo/app/(app)/gear-inventory.tsx
@@ -66,7 +66,7 @@ export default function GearInventoryScreen() {
   return (
     <SafeAreaView className="flex-1" edges={['bottom']}>
       <LargeTitleHeader title={t('packs.gearInventory')} />
-      <ScrollView className="flex-1 px-4">
+      <ScrollView className="flex-1 px-4" contentInsetAdjustmentBehavior="automatic">
         <View className="flex-row items-center justify-between p-4">
           <Text variant="subhead" className="text-muted-foreground">
             {t('packs.itemsInInventory', { count: items?.length })}


### PR DESCRIPTION
## Summary

Adds `contentInsetAdjustmentBehavior="automatic"` to the `ScrollView` in `GearInventoryScreen`. This prop lets iOS automatically adjust the scroll view's content inset to account for the navigation bar and large title header, preventing content from being obscured underneath the header on scroll.

## Changes

- `apps/expo/app/(app)/gear-inventory.tsx` — adds `contentInsetAdjustmentBehavior="automatic"` to the root `ScrollView`

## Why

Without this prop the scroll content starts at the top of the screen rather than below the large title header on iOS, meaning the first row of inventory items can be hidden under the navigation bar on initial render or after scroll.

---
*Built with [GitHub Copilot](https://github.com/features/copilot)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed content display in the gear inventory screen on devices with notches and screen obstructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->