### PR TITLE
fix(expo): auth modal UX improvements

### DIFF
--- a/apps/expo/app/(app)/_layout.tsx
+++ b/apps/expo/app/(app)/_layout.tsx
@@ -16,12 +16,11 @@ import { getPackItemDetailOptions } from 'expo-app/features/packs/utils/getPackI
 import { getTripDetailOptions } from 'expo-app/features/trips/utils/getTripDetailOptions';
 import { useTranslation } from 'expo-app/lib/hooks/useTranslation';
 import type { TranslationFunction } from 'expo-app/lib/i18n/types';
-import { testIds } from 'expo-app/lib/testIds';
 import 'expo-app/lib/devClient';
-import { type Href, router, Stack, useRouter } from 'expo-router';
+import { type Href, router, Stack } from 'expo-router';
 import { useAtomValue } from 'jotai';
 import { useEffect, useRef } from 'react';
-import { Pressable, Text, View } from 'react-native';
+import { View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 export {
@@ -331,14 +330,6 @@ const getTripNewOptions = (t: TranslationFunction) => ({
   title: t('trips.createTrip'),
   presentation: 'modal' as const,
   animation: 'slide_from_bottom' as const,
-  headerLeft: () => {
-    const router = useRouter();
-    return (
-      <Pressable testID={testIds.trips.cancelBtn} onPress={() => router.back()} className="px-2">
-        <Text className="text-primary">{t('common.cancel')}</Text>
-      </Pressable>
-    );
-  },
 });
 
 const getTripEditOptions = (t: TranslationFunction) =>
@@ -364,14 +355,6 @@ const getPackNewOptions = (t: TranslationFunction) => ({
   title: t('packs.createPack'),
   presentation: 'modal' as const,
   animation: 'fade_from_bottom' as const,
-  headerLeft: () => {
-    const router = useRouter();
-    return (
-      <Pressable testID={testIds.packs.cancelBtn} onPress={() => router.back()} className="px-2">
-        <Text className="text-primary">{t('common.cancel')}</Text>
-      </Pressable>
-    );
-  },
 });
 
 const getItemNewOptions = (t: TranslationFunction) =>

--- a/apps/expo/app/auth/(login)/index.tsx
+++ b/apps/expo/app/auth/(login)/index.tsx
@@ -68,19 +68,7 @@ export default function LoginScreen() {
         options={{
           title: t('auth.signIn'),
           headerShadowVisible: false,
-          headerLeft() {
-            return (
-              <Button
-                variant="plain"
-                className="ios:px-0"
-                onPress={() => {
-                  router.back();
-                }}
-              >
-                <Text className="text-primary">{t('common.cancel')}</Text>
-              </Button>
-            );
-          },
+          headerShown: false,
         }}
       />
       <KeyboardAwareScrollView

--- a/apps/expo/app/auth/_layout.tsx
+++ b/apps/expo/app/auth/_layout.tsx
@@ -1,34 +1,10 @@
-import { Button, Text } from '@packrat/ui/nativewindui';
-import { useTranslation } from 'expo-app/lib/hooks/useTranslation';
-import { router, Stack } from 'expo-router';
-import { Platform } from 'react-native';
+import { Stack } from 'expo-router';
 
 export const unstable_settings = {
   anchor: 'index',
 };
 
 export default function AuthLayout() {
-  const { t } = useTranslation();
-
-  const CREATE_ACCOUNT_MODAL_OPTIONS = {
-    presentation: 'modal',
-    headerShown: Platform.OS === 'ios',
-    headerShadowVisible: false,
-    headerLeft() {
-      return (
-        <Button
-          variant="plain"
-          className="ios:px-0"
-          onPress={() => {
-            router.back();
-          }}
-        >
-          <Text className="text-primary">{t('common.cancel')}</Text>
-        </Button>
-      );
-    },
-  } as const;
-
   return (
     <Stack screenOptions={SCREEN_OPTIONS}>
       <Stack.Screen name="index" />
@@ -37,6 +13,11 @@ export default function AuthLayout() {
     </Stack>
   );
 }
+
+const CREATE_ACCOUNT_MODAL_OPTIONS = {
+  presentation: 'modal',
+  headerShown: false,
+} as const;
 
 const SCREEN_OPTIONS = {
   headerShown: false,

--- a/apps/expo/features/auth/hooks/useAuthActions.ts
+++ b/apps/expo/features/auth/hooks/useAuthActions.ts
@@ -28,9 +28,9 @@ import {
 function redirect(route: string) {
   try {
     const parsedRoute: Href = JSON.parse(route);
-    return router.dismissTo(parsedRoute);
+    return router.replace(parsedRoute);
   } catch {
-    router.dismissTo(route as Href); // safe-cast: Href = string | HrefObject; string literal branch failed JSON.parse so plain string is the correct type here
+    router.replace(route as Href); // safe-cast: Href = string | HrefObject; string literal branch failed JSON.parse so plain string is the correct type here
   }
 }
 


### PR DESCRIPTION
## Summary

Two auth modal UX fixes.

## Changes

### Fix: email login re-navigating to login screen on submit

`useAuthActions.redirect()` was calling `router.dismissTo()`, which dismisses a modal first (returning to `/auth/index`) and then asynchronously navigates to the target route. This two-step dismiss+navigate raced on completion, leaving users back on the login screen with cleared inputs — even though the button stayed in a loading state indicating a successful auth.

Switched to `router.replace()`, which navigates directly to the target from anywhere in the stack including inside a modal.

### Remove cancel buttons from modal screens

Removed the "Cancel" `headerLeft` button from:
- Create Account modal (`app/auth/_layout.tsx`)
- Sign In modal (`app/auth/(login)/index.tsx`)
- Create Trip modal (`app/(app)/_layout.tsx`)
- Create Pack modal (`app/(app)/_layout.tsx`)

Also cleaned up now-unused imports: `useRouter`, `Pressable`, `Text` (react-native), `testIds`.

---
*Built with [GitHub Copilot](https://github.com/features/copilot)*