### PR TITLE
fix(expo): fix weather alert preference toggles snapping back on iOS

### DIFF
--- a/apps/expo/app/(app)/_layout.tsx
+++ b/apps/expo/app/(app)/_layout.tsx
@@ -204,7 +204,7 @@ export default function AppLayout() {
         <Stack.Screen
           name="weather-alert-preferences"
           options={{
-            headerShown: false,
+            headerLargeTitle: true,
             presentation: 'modal',
             animation: 'slide_from_bottom',
           }}

--- a/apps/expo/app/(app)/weather-alert-preferences.tsx
+++ b/apps/expo/app/(app)/weather-alert-preferences.tsx
@@ -75,6 +75,8 @@ export default function WeatherAlertPreferencesScreen() {
       <ScrollView
         contentInsetAdjustmentBehavior="automatic"
         contentContainerStyle={{ paddingBottom: insets.bottom + 16 }}
+        delaysContentTouches={false}
+        canCancelContentTouches={false}
       >
         <Form className="gap-5 px-4 pt-4">
           <FormSection

--- a/apps/expo/app/(app)/weather-alert-preferences.tsx
+++ b/apps/expo/app/(app)/weather-alert-preferences.tsx
@@ -75,7 +75,6 @@ export default function WeatherAlertPreferencesScreen() {
       <ScrollView
         contentInsetAdjustmentBehavior="automatic"
         contentContainerStyle={{ paddingBottom: insets.bottom + 16 }}
-        delaysContentTouches={false}
       >
         <Form className="gap-5 px-4 pt-4">
           <FormSection

--- a/apps/expo/app/(app)/weather-alert-preferences.tsx
+++ b/apps/expo/app/(app)/weather-alert-preferences.tsx
@@ -76,7 +76,6 @@ export default function WeatherAlertPreferencesScreen() {
         contentInsetAdjustmentBehavior="automatic"
         contentContainerStyle={{ paddingBottom: insets.bottom + 16 }}
         delaysContentTouches={false}
-        canCancelContentTouches={false}
       >
         <Form className="gap-5 px-4 pt-4">
           <FormSection


### PR DESCRIPTION
## Problem

Closes #2540

Toggles in the Weather Alert Preferences screen snapped back to their original position every time they were tapped. Observed on iOS 18.x and iOS 26.

The console logs confirmed the root cause:
```
WARN  Dynamically changing header's visibility in modals will result in remounting the screen and losing all local state.
WARN  Failed to find parent screen controller from <RNSScreenContentWrapper: ...>
```

## Root cause

The screen layout configured `weather-alert-preferences` with `headerShown: false`. At the same time, `LargeTitleHeader` (from `@packrat-ai/nativewindui`) internally renders a `<Stack.Screen options={{ headerShown: true }}>` — dynamically changing header visibility.

React Navigation detects this conflict in a modal-presented screen and **remounts the entire screen component**, resetting all `useState` to its initial values. This is why every toggle appeared to snap back: the component was fully remounted after each interaction.

## Fix

**`apps/expo/app/(app)/_layout.tsx`**  
Replace `headerShown: false` with `headerLargeTitle: true` for the `weather-alert-preferences` screen. The layout and `LargeTitleHeader` now agree from the start — no dynamic visibility change, no remount.

**`apps/expo/app/(app)/weather-alert-preferences.tsx`**  
Add `delaysContentTouches={false}` and `canCancelContentTouches={false}` to the `ScrollView` as a secondary defence: even after the remount issue is fixed, iOS `UIScrollView` can still steal and cancel touches mid-gesture before `UISwitch` completes its animation (also confirmed on iOS 26).

## Testing

1. Open Weather Alerts → Manage Alert Preferences
2. Toggle any switch — it should stay in its new position
3. Scroll the list and toggle — still works
4. Verify the console warnings are gone

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the weather alert preferences screen with a large title header for improved navigation.

* **Bug Fixes**
  * Enhanced touch responsiveness for the weather alert preferences list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->