### PR TITLE
fix(expo): move trip detail action buttons to nav header, remove extra top space

### DIFF
--- a/apps/expo/features/trips/screens/TripDetailScreen.tsx
+++ b/apps/expo/features/trips/screens/TripDetailScreen.tsx
@@ -1,25 +1,16 @@
 import { assertDefined } from '@packrat/guards';
-import type { AlertMethods } from '@packrat/ui/nativewindui';
-import {
-  ActivityIndicator,
-  Alert as AlertComponent,
-  Button,
-  Card,
-  Text,
-} from '@packrat/ui/nativewindui';
+import { ActivityIndicator, Button, Card, Text } from '@packrat/ui/nativewindui';
 import { Icon } from 'expo-app/components/Icon';
 import { featureFlags } from 'expo-app/config';
 import { SubmitConditionReportForm } from 'expo-app/features/trail-conditions/components/SubmitConditionReportForm';
 import { useColorScheme } from 'expo-app/lib/hooks/useColorScheme';
 import { useTranslation } from 'expo-app/lib/hooks/useTranslation';
-import { testIds } from 'expo-app/lib/testIds';
 import { useLocalSearchParams, useRouter } from 'expo-router';
-import { useMemo, useRef, useState } from 'react';
-import { Modal, ScrollView, Share, View } from 'react-native';
+import { useMemo, useState } from 'react';
+import { Modal, ScrollView, View } from 'react-native';
 import MapView, { Marker } from 'react-native-maps';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useDetailedPacks } from '../../packs/hooks/useDetailedPacks';
-import { useDeleteTrip } from '../hooks';
 import { useTripDetailsFromStore } from '../hooks/useTripDetailsFromStore';
 import type { Trip } from '../types';
 
@@ -30,13 +21,11 @@ export function TripDetailScreen() {
   const { t } = useTranslation();
 
   const [showConditionReport, setShowConditionReport] = useState(false);
-  const alertRef = useRef<AlertMethods>(null);
 
   // safe-cast: trip may be undefined before the store is hydrated; the guard at line ~38 handles
   // the undefined case and returns early, ensuring trip is non-null at render time below.
   const trip = useTripDetailsFromStore(id as string) as Trip;
   const packs = useDetailedPacks();
-  const deleteTrip = useDeleteTrip();
 
   // Create a stable key for MapView based on location coordinates
   // This forces remount when location changes, fixing iOS initialRegion issue
@@ -63,38 +52,6 @@ export function TripDetailScreen() {
     return new Date(dateString).toISOString().split('T')[0];
   };
 
-  const handleShareTrip = async () => {
-    try {
-      const lines: string[] = [`${trip.name}`];
-      if (trip.location?.name) lines.push(` ${trip.location.name.split(',')[0]}`);
-      if (trip.startDate || trip.endDate) {
-        lines.push(`${formatDate(trip.startDate)} – ${formatDate(trip.endDate)}`);
-      }
-      if (trip.description) lines.push(`\n${trip.description}`);
-      await Share.share({ message: lines.join('\n') });
-    } catch {
-      // ignore
-    }
-  };
-
-  const handleDeleteTrip = () => {
-    alertRef.current?.alert({
-      title: t('trips.deleteTrip'),
-      message: t('trips.deleteTripConfirmation'),
-      buttons: [
-        { text: t('common.cancel'), style: 'cancel' },
-        {
-          text: t('common.delete'),
-          style: 'destructive',
-          onPress: async () => {
-            await deleteTrip(id as string);
-            router.back();
-          },
-        },
-      ],
-    });
-  };
-
   const handleWeatherPress = () => {
     if (!trip.location) return;
 
@@ -107,50 +64,14 @@ export function TripDetailScreen() {
   };
 
   return (
-    <SafeAreaView className="flex-1 bg-background">
+    <SafeAreaView className="flex-1 bg-background" edges={['bottom']}>
       <ScrollView
         showsVerticalScrollIndicator={false}
         contentContainerStyle={{ paddingBottom: 40 }}
       >
         <View className="p-4">
-          {/* Header */}
-          <View className="mb-3 flex-row items-start justify-between">
-            <Text className="flex-1 text-3xl font-bold text-foreground">{trip.name}</Text>
-            <Button variant="plain" size="icon" onPress={handleShareTrip}>
-              <Icon
-                materialIcon={{ type: 'MaterialIcons', name: 'share' }}
-                ios={{ name: 'square.and.arrow.up' }}
-                size={22}
-                color={colors.grey2}
-              />
-            </Button>
-            <Button
-              variant="plain"
-              size="icon"
-              testID={testIds.trips.editBtn}
-              onPress={() => router.push(`/trip/${id}/edit`)}
-            >
-              <Icon
-                materialIcon={{ type: 'MaterialCommunityIcons', name: 'pencil-box-outline' }}
-                ios={{ name: 'pencil' }}
-                size={22}
-                color={colors.grey2}
-              />
-            </Button>
-            <Button
-              variant="plain"
-              size="icon"
-              testID={testIds.trips.deleteBtn}
-              onPress={handleDeleteTrip}
-            >
-              <Icon
-                materialIcon={{ type: 'MaterialCommunityIcons', name: 'trash-can-outline' }}
-                ios={{ name: 'trash' }}
-                size={22}
-                color={colors.grey2}
-              />
-            </Button>
-          </View>
+          {/* Trip name */}
+          <Text className="mb-3 text-3xl font-bold text-foreground">{trip.name}</Text>
 
           {/* Dates */}
           <View className="mb-6">
@@ -317,7 +238,6 @@ export function TripDetailScreen() {
           />
         </View>
       </Modal>
-      <AlertComponent title="" buttons={[]} ref={alertRef} />
     </SafeAreaView>
   );
 }

--- a/apps/expo/features/trips/utils/getTripDetailOptions.tsx
+++ b/apps/expo/features/trips/utils/getTripDetailOptions.tsx
@@ -1,9 +1,10 @@
 import { Alert, Button, useColorScheme } from '@packrat/ui/nativewindui';
 import { Icon } from 'expo-app/components/Icon';
+import { useTripDetailsFromStore } from 'expo-app/features/trips/hooks/useTripDetailsFromStore';
 import { useTranslation } from 'expo-app/lib/hooks/useTranslation';
 import { t } from 'expo-app/lib/i18n';
 import { useRouter } from 'expo-router';
-import { View } from 'react-native';
+import { Share, View } from 'react-native';
 import { useDeleteTrip } from '../hooks';
 
 export function getTripDetailOptions(id: string) {
@@ -14,9 +15,34 @@ export function getTripDetailOptions(id: string) {
       const { t } = useTranslation();
       const router = useRouter();
       const deleteTrip = useDeleteTrip();
+      const trip = useTripDetailsFromStore(id);
+
+      const handleShare = async () => {
+        if (!trip) return;
+        try {
+          const formatDate = (d?: string) => (d ? new Date(d).toISOString().split('T')[0] : '—');
+          const lines: string[] = [trip.name];
+          if (trip.location?.name) lines.push(` ${trip.location.name.split(',')[0]}`);
+          if (trip.startDate || trip.endDate) {
+            lines.push(`${formatDate(trip.startDate)} – ${formatDate(trip.endDate)}`);
+          }
+          if (trip.description) lines.push(`\n${trip.description}`);
+          await Share.share({ message: lines.join('\n') });
+        } catch {
+          // ignore
+        }
+      };
 
       return (
         <View className="flex-row items-center gap-2">
+          <Button variant="plain" size="icon" onPress={handleShare}>
+            <Icon
+              materialIcon={{ type: 'MaterialIcons', name: 'share' }}
+              ios={{ name: 'square.and.arrow.up' }}
+              color={colors.grey2}
+            />
+          </Button>
+
           <Alert
             title={t('trips.deleteTrip')}
             message={t('trips.deleteTripConfirmation')}


### PR DESCRIPTION
## Summary

Cleans up the Trip Detail screen layout by moving action buttons into the navigation header and removing the duplicate safe area top inset.

## Changes

- `apps/expo/features/trips/screens/TripDetailScreen.tsx` — removes action button row from the title section; changes `SafeAreaView` to use `edges={['bottom']}` so the nav header's own inset is not double-counted; removes unused imports (`Alert`, `AlertMethods`, `Share`, `testIds`, `useDeleteTrip`, `useRef`)
- `apps/expo/features/trips/utils/getTripDetailOptions.tsx` — adds share button to `headerRight` alongside the existing edit/delete/+ buttons

## Why

The title row had a row of icon buttons (share, edit, delete) that duplicated the header's existing edit/delete/+ buttons and created visual clutter. Moving share into the header consolidates all actions in one place. The extra `SafeAreaView` top inset was adding blank space above the trip name since the navigation header already handles the top safe area.