### PR TITLE
✨ feat(api): admin DB sizing + activity snapshot endpoint

### DIFF
--- a/packages/api/src/routes/admin/analytics/db.ts
+++ b/packages/api/src/routes/admin/analytics/db.ts
@@ -1,0 +1,44 @@
+import { DbMetricsService } from '@packrat/api/services/dbMetricsService';
+import { Elysia, status } from 'elysia';
+
+/**
+ * Admin-only DB sizing + activity dashboard endpoints. Surfaces the same
+ * metrics from `docs/runbooks/neon-cost-profiling.md` so cost trends are
+ * visible without running Neon MCP / SQL editor by hand.
+ *
+ * Auth: parent admin router's `onBeforeHandle` already gates with
+ * adminAuthGuard, so these routes inherit admin-only access.
+ *
+ * Safety: all queries are pure metadata (pg_class, pg_stat_*) — no row
+ * scans on user tables. Safe to poll. No pg_stat_statements dependency.
+ */
+
+export const dbAnalyticsRoutes = new Elysia({ prefix: '/db' })
+  .get('/', () => ({
+    analytics: {
+      snapshot: '/api/admin/analytics/db/snapshot',
+    },
+    description:
+      'Read-only DB sizing + activity metrics. Per-table heap/TOAST/index sizes and pg_stat_user_tables counters. See docs/runbooks/neon-cost-profiling.md for what each metric means.',
+  }))
+
+  .get(
+    '/snapshot',
+    async () => {
+      try {
+        const service = new DbMetricsService();
+        return await service.snapshot();
+      } catch (error) {
+        console.error('db metrics snapshot error:', error);
+        return status(500, { error: 'Failed to gather DB metrics' });
+      }
+    },
+    {
+      detail: {
+        tags: ['Admin'],
+        summary: 'Per-table sizing, activity counters, and index utilization',
+        description:
+          'Returns a snapshot of pg_class sizes (heap/TOAST/index/total) joined with pg_stat_user_tables counters (seq_scan, idx_scan, n_tup_ins/upd/del, live/dead tuples, last autovacuum) plus pg_stat_user_indexes (per-index size + scan count). Pure metadata; no full-table scans.',
+      },
+    },
+  );

--- a/packages/api/src/routes/admin/analytics/db.ts
+++ b/packages/api/src/routes/admin/analytics/db.ts
@@ -30,7 +30,10 @@ export const dbAnalyticsRoutes = new Elysia({ prefix: '/db' })
         return await service.snapshot();
       } catch (error) {
         console.error('db metrics snapshot error:', error);
-        return status(500, { error: 'Failed to gather DB metrics' });
+        return status(500, {
+          error: 'Failed to gather DB metrics',
+          code: 'ANALYTICS_DB_SNAPSHOT_ERROR',
+        });
       }
     },
     {

--- a/packages/api/src/routes/admin/analytics/index.ts
+++ b/packages/api/src/routes/admin/analytics/index.ts
@@ -1,10 +1,12 @@
 import { Elysia } from 'elysia';
 import { catalogAnalyticsRoutes } from './catalog';
+import { dbAnalyticsRoutes } from './db';
 import { platformAnalyticsRoutes } from './platform';
 
 export const analyticsRoutes = new Elysia({ prefix: '/analytics' })
   .use(platformAnalyticsRoutes)
   .use(catalogAnalyticsRoutes)
+  .use(dbAnalyticsRoutes)
   .get('/', () => ({
     analytics: {
       platform: {
@@ -18,6 +20,9 @@ export const analyticsRoutes = new Elysia({ prefix: '/analytics' })
         prices: '/api/admin/analytics/catalog/prices',
         etl: '/api/admin/analytics/catalog/etl',
         embeddings: '/api/admin/analytics/catalog/embeddings',
+      },
+      db: {
+        snapshot: '/api/admin/analytics/db/snapshot',
       },
     },
   }));

--- a/packages/api/src/services/__tests__/dbMetricsService.test.ts
+++ b/packages/api/src/services/__tests__/dbMetricsService.test.ts
@@ -1,0 +1,224 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { DbMetricsService } from '../dbMetricsService';
+
+// ---------------------------------------------------------------------------
+// Mocks
+//
+// snapshot() fires four execute() calls via Promise.all in source order:
+//   1. fetchDatabaseInfo  (pg_database_size)
+//   2. fetchTables        (pg_class + pg_stat_user_tables)
+//   3. fetchIndexes       (pg_stat_user_indexes)
+//   4. fetchStatsResetAt  (pg_stat_database)
+// We drive each call with mockResolvedValueOnce in that order so tests stay
+// hermetic without depending on Drizzle's SQL string representation.
+// ---------------------------------------------------------------------------
+
+const mockExecute = vi.fn();
+const mockDb = { execute: mockExecute };
+
+vi.mock('@packrat/api/db', () => ({
+  createReadOnlyDb: vi.fn(() => mockDb),
+}));
+
+interface CallFixtures {
+  databaseInfo: { name: string; size_bytes: string } | undefined;
+  tables: Array<Record<string, unknown>>;
+  indexes: Array<Record<string, unknown>>;
+  statsReset: { stats_reset: string | null } | undefined;
+}
+
+function queueFixtures(f: CallFixtures): void {
+  mockExecute.mockReset();
+  mockExecute.mockResolvedValueOnce({ rows: f.databaseInfo ? [f.databaseInfo] : [] });
+  mockExecute.mockResolvedValueOnce({ rows: f.tables });
+  mockExecute.mockResolvedValueOnce({ rows: f.indexes });
+  mockExecute.mockResolvedValueOnce({ rows: f.statsReset ? [f.statsReset] : [] });
+}
+
+const makeTableRow = (overrides: Partial<Record<string, unknown>> = {}) => ({
+  name: 'catalog_items',
+  est_rows: '1790606',
+  heap_bytes: '3336863744',
+  toast_bytes: '16106127360',
+  index_bytes: '16106127360',
+  total_bytes: '35433480192',
+  seq_scan: '32475',
+  seq_tup_read: '2806032896',
+  idx_scan: '14682572',
+  idx_tup_fetch: '19313043',
+  n_tup_ins: '1789703',
+  n_tup_upd: '5556406',
+  n_tup_del: '10',
+  n_tup_hot_upd: '0',
+  n_live_tup: '1789693',
+  n_dead_tup: '0',
+  last_autovacuum: null,
+  last_autoanalyze: '2026-06-04T12:34:56Z',
+  ...overrides,
+});
+
+const makeIndexRow = (overrides: Partial<Record<string, unknown>> = {}) => ({
+  table: 'catalog_items',
+  name: 'embedding_idx',
+  bytes: '15032385536',
+  is_unique: false,
+  idx_scan: '0',
+  idx_tup_read: '0',
+  idx_tup_fetch: '0',
+  ...overrides,
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('DbMetricsService', () => {
+  beforeEach(() => {
+    mockExecute.mockReset();
+  });
+
+  describe('snapshot()', () => {
+    it('returns a fully populated snapshot with parsed numerics', async () => {
+      queueFixtures({
+        databaseInfo: { name: 'packrat-neon-db', size_bytes: '39245591696' },
+        statsReset: { stats_reset: null },
+        tables: [makeTableRow()],
+        indexes: [makeIndexRow()],
+      });
+
+      const service = new DbMetricsService();
+      const result = await service.snapshot();
+
+      // Top-level shape
+      expect(result).toMatchObject({
+        statsResetAt: null,
+        database: { name: 'packrat-neon-db', sizeBytes: 39245591696 },
+      });
+      expect(typeof result.generatedAt).toBe('string');
+      expect(new Date(result.generatedAt).toString()).not.toBe('Invalid Date');
+
+      // Tables — text-cast numerics parsed back to number
+      expect(result.tables).toHaveLength(1);
+      const [table] = result.tables;
+      expect(table).toMatchObject({
+        name: 'catalog_items',
+        estimatedRows: 1790606,
+        heapBytes: 3336863744,
+        toastBytes: 16106127360,
+        indexBytes: 16106127360,
+        totalBytes: 35433480192,
+        seqScans: 32475,
+        seqTuplesRead: 2806032896,
+        idxScans: 14682572,
+        idxTuplesFetched: 19313043,
+        inserts: 1789703,
+        updates: 5556406,
+        deletes: 10,
+        hotUpdates: 0,
+        liveTuples: 1789693,
+        deadTuples: 0,
+        lastAutovacuum: null,
+        lastAutoanalyze: '2026-06-04T12:34:56Z',
+      });
+
+      // Indexes
+      expect(result.indexes).toHaveLength(1);
+      const [index] = result.indexes;
+      expect(index).toMatchObject({
+        table: 'catalog_items',
+        name: 'embedding_idx',
+        bytes: 15032385536,
+        isUnique: false,
+        scans: 0,
+        tuplesRead: 0,
+        tuplesFetched: 0,
+      });
+    });
+
+    it('falls back gracefully when database info query returns no rows', async () => {
+      queueFixtures({
+        databaseInfo: undefined,
+        statsReset: { stats_reset: null },
+        tables: [],
+        indexes: [],
+      });
+
+      const service = new DbMetricsService();
+      const result = await service.snapshot();
+
+      expect(result.database).toEqual({ name: 'unknown', sizeBytes: 0 });
+      expect(result.tables).toEqual([]);
+      expect(result.indexes).toEqual([]);
+    });
+
+    it('treats reltoastrelid=0 tables (toast_bytes "0") as toastBytes: 0', async () => {
+      // Defensive: ensures the parser handles the SQL CASE branch output
+      // (string "0") correctly. The CASE is required because
+      // pg_relation_size(0) raises before COALESCE can wrap it; this test
+      // locks in the parser's behavior on that fixture shape.
+      queueFixtures({
+        databaseInfo: { name: 'db', size_bytes: '0' },
+        statsReset: { stats_reset: '2026-01-01T00:00:00Z' },
+        tables: [
+          makeTableRow({
+            name: 'tiny_table',
+            est_rows: '0',
+            heap_bytes: '8192',
+            toast_bytes: '0',
+            index_bytes: '0',
+            total_bytes: '8192',
+            idx_scan: null,
+            idx_tup_fetch: null,
+          }),
+        ],
+        indexes: [],
+      });
+
+      const service = new DbMetricsService();
+      const result = await service.snapshot();
+
+      expect(result.statsResetAt).toBe('2026-01-01T00:00:00Z');
+      expect(result.tables[0]).toMatchObject({
+        name: 'tiny_table',
+        toastBytes: 0,
+        idxScans: 0,
+        idxTuplesFetched: 0,
+      });
+    });
+
+    it('preserves the order of tables and indexes returned by the underlying SQL', async () => {
+      queueFixtures({
+        databaseInfo: { name: 'db', size_bytes: '0' },
+        statsReset: { stats_reset: null },
+        tables: [
+          makeTableRow({ name: 'big', total_bytes: '1000000' }),
+          makeTableRow({ name: 'small', total_bytes: '100' }),
+        ],
+        indexes: [
+          makeIndexRow({ table: 'big', name: 'big_idx', bytes: '500000' }),
+          makeIndexRow({ table: 'small', name: 'small_idx', bytes: '50' }),
+        ],
+      });
+
+      const service = new DbMetricsService();
+      const result = await service.snapshot();
+
+      expect(result.tables.map((t) => t.name)).toEqual(['big', 'small']);
+      expect(result.indexes.map((i) => i.name)).toEqual(['big_idx', 'small_idx']);
+    });
+
+    it('runs four parallel metadata queries per snapshot', async () => {
+      queueFixtures({
+        databaseInfo: { name: 'db', size_bytes: '1' },
+        statsReset: { stats_reset: null },
+        tables: [],
+        indexes: [],
+      });
+
+      const service = new DbMetricsService();
+      await service.snapshot();
+
+      expect(mockExecute).toHaveBeenCalledTimes(4);
+    });
+  });
+});

--- a/packages/api/src/services/dbMetricsService.ts
+++ b/packages/api/src/services/dbMetricsService.ts
@@ -1,0 +1,211 @@
+import { createDb } from '@packrat/api/db';
+import { sql } from 'drizzle-orm';
+
+/**
+ * Read-only cost/infra metrics service.
+ *
+ * Surfaces the SAME metrics from `docs/runbooks/neon-cost-profiling.md` so
+ * admins can monitor per-table sizing, activity, and index utilization
+ * without running Neon MCP / SQL editor by hand. Queries are pure metadata
+ * (pg_class, pg_stat_*, pg_size_pretty) — no row scans, fast, safe to poll.
+ *
+ * Cost discipline:
+ * - No `SELECT *` against user tables (would defeat the projection work)
+ * - All queries return small, fixed-size result sets
+ * - Statement-timeout guard left to the caller (Elysia route applies one)
+ */
+
+export interface TableMetrics {
+  name: string;
+  estimatedRows: number;
+  heapBytes: number;
+  toastBytes: number;
+  indexBytes: number;
+  totalBytes: number;
+  // pg_stat_user_tables — cumulative since last reset (lifetime if never reset)
+  seqScans: number;
+  seqTuplesRead: number;
+  idxScans: number;
+  idxTuplesFetched: number;
+  inserts: number;
+  updates: number;
+  deletes: number;
+  hotUpdates: number;
+  liveTuples: number;
+  deadTuples: number;
+  lastAutovacuum: string | null;
+  lastAutoanalyze: string | null;
+}
+
+export interface IndexMetrics {
+  table: string;
+  name: string;
+  bytes: number;
+  isUnique: boolean;
+  scans: number;
+  tuplesRead: number;
+  tuplesFetched: number;
+}
+
+export interface DbMetricsSnapshot {
+  generatedAt: string;
+  statsResetAt: string | null;
+  database: {
+    name: string;
+    sizeBytes: number;
+  };
+  tables: TableMetrics[];
+  indexes: IndexMetrics[];
+}
+
+export class DbMetricsService {
+  private db: ReturnType<typeof createDb>;
+
+  constructor() {
+    this.db = createDb();
+  }
+
+  async snapshot(): Promise<DbMetricsSnapshot> {
+    // Run all four queries in parallel — each is independent metadata-only.
+    const [databaseRow, tableRows, indexRows, statsResetRow] = await Promise.all([
+      this.fetchDatabaseInfo(),
+      this.fetchTables(),
+      this.fetchIndexes(),
+      this.fetchStatsResetAt(),
+    ]);
+
+    return {
+      generatedAt: new Date().toISOString(),
+      statsResetAt: statsResetRow,
+      database: databaseRow,
+      tables: tableRows,
+      indexes: indexRows,
+    };
+  }
+
+  private async fetchDatabaseInfo(): Promise<{ name: string; sizeBytes: number }> {
+    const rows = await this.db.execute<{ name: string; size_bytes: string }>(sql`
+      SELECT
+        current_database() AS name,
+        pg_database_size(current_database())::text AS size_bytes
+    `);
+    const row = rows.rows[0];
+    return {
+      name: row?.name ?? 'unknown',
+      sizeBytes: Number(row?.size_bytes ?? 0),
+    };
+  }
+
+  private async fetchStatsResetAt(): Promise<string | null> {
+    const rows = await this.db.execute<{ stats_reset: string | null }>(sql`
+      SELECT stats_reset::text AS stats_reset
+      FROM pg_stat_database
+      WHERE datname = current_database()
+    `);
+    return rows.rows[0]?.stats_reset ?? null;
+  }
+
+  private async fetchTables(): Promise<TableMetrics[]> {
+    const rows = await this.db.execute<{
+      name: string;
+      est_rows: string;
+      heap_bytes: string;
+      toast_bytes: string;
+      index_bytes: string;
+      total_bytes: string;
+      seq_scan: string;
+      seq_tup_read: string;
+      idx_scan: string | null;
+      idx_tup_fetch: string | null;
+      n_tup_ins: string;
+      n_tup_upd: string;
+      n_tup_del: string;
+      n_tup_hot_upd: string;
+      n_live_tup: string;
+      n_dead_tup: string;
+      last_autovacuum: string | null;
+      last_autoanalyze: string | null;
+    }>(sql`
+      SELECT
+        c.relname                                         AS name,
+        c.reltuples::bigint::text                         AS est_rows,
+        pg_relation_size(c.oid)::text                     AS heap_bytes,
+        COALESCE(pg_relation_size(c.reltoastrelid), 0)::text AS toast_bytes,
+        pg_indexes_size(c.oid)::text                      AS index_bytes,
+        pg_total_relation_size(c.oid)::text               AS total_bytes,
+        COALESCE(s.seq_scan, 0)::text                     AS seq_scan,
+        COALESCE(s.seq_tup_read, 0)::text                 AS seq_tup_read,
+        s.idx_scan::text                                  AS idx_scan,
+        s.idx_tup_fetch::text                             AS idx_tup_fetch,
+        COALESCE(s.n_tup_ins, 0)::text                    AS n_tup_ins,
+        COALESCE(s.n_tup_upd, 0)::text                    AS n_tup_upd,
+        COALESCE(s.n_tup_del, 0)::text                    AS n_tup_del,
+        COALESCE(s.n_tup_hot_upd, 0)::text                AS n_tup_hot_upd,
+        COALESCE(s.n_live_tup, 0)::text                   AS n_live_tup,
+        COALESCE(s.n_dead_tup, 0)::text                   AS n_dead_tup,
+        s.last_autovacuum::text                           AS last_autovacuum,
+        s.last_autoanalyze::text                          AS last_autoanalyze
+      FROM pg_class c
+      JOIN pg_namespace n  ON n.oid = c.relnamespace
+      LEFT JOIN pg_stat_user_tables s ON s.relid = c.oid
+      WHERE n.nspname = 'public'
+        AND c.relkind = 'r'
+      ORDER BY pg_total_relation_size(c.oid) DESC
+    `);
+
+    return rows.rows.map((r) => ({
+      name: r.name,
+      estimatedRows: Number(r.est_rows),
+      heapBytes: Number(r.heap_bytes),
+      toastBytes: Number(r.toast_bytes),
+      indexBytes: Number(r.index_bytes),
+      totalBytes: Number(r.total_bytes),
+      seqScans: Number(r.seq_scan),
+      seqTuplesRead: Number(r.seq_tup_read),
+      idxScans: Number(r.idx_scan ?? 0),
+      idxTuplesFetched: Number(r.idx_tup_fetch ?? 0),
+      inserts: Number(r.n_tup_ins),
+      updates: Number(r.n_tup_upd),
+      deletes: Number(r.n_tup_del),
+      hotUpdates: Number(r.n_tup_hot_upd),
+      liveTuples: Number(r.n_live_tup),
+      deadTuples: Number(r.n_dead_tup),
+      lastAutovacuum: r.last_autovacuum,
+      lastAutoanalyze: r.last_autoanalyze,
+    }));
+  }
+
+  private async fetchIndexes(): Promise<IndexMetrics[]> {
+    const rows = await this.db.execute<{
+      table: string;
+      name: string;
+      bytes: string;
+      is_unique: boolean;
+      idx_scan: string;
+      idx_tup_read: string;
+      idx_tup_fetch: string;
+    }>(sql`
+      SELECT
+        s.relname                            AS "table",
+        s.indexrelname                       AS name,
+        pg_relation_size(s.indexrelid)::text AS bytes,
+        i.indisunique                        AS is_unique,
+        COALESCE(s.idx_scan, 0)::text        AS idx_scan,
+        COALESCE(s.idx_tup_read, 0)::text    AS idx_tup_read,
+        COALESCE(s.idx_tup_fetch, 0)::text   AS idx_tup_fetch
+      FROM pg_stat_user_indexes s
+      JOIN pg_index i ON i.indexrelid = s.indexrelid
+      ORDER BY pg_relation_size(s.indexrelid) DESC
+    `);
+
+    return rows.rows.map((r) => ({
+      table: r.table,
+      name: r.name,
+      bytes: Number(r.bytes),
+      isUnique: r.is_unique,
+      scans: Number(r.idx_scan),
+      tuplesRead: Number(r.idx_tup_read),
+      tuplesFetched: Number(r.idx_tup_fetch),
+    }));
+  }
+}

--- a/packages/api/src/services/dbMetricsService.ts
+++ b/packages/api/src/services/dbMetricsService.ts
@@ -1,4 +1,4 @@
-import { createDb } from '@packrat/api/db';
+import { createReadOnlyDb } from '@packrat/api/db';
 import { sql } from 'drizzle-orm';
 
 /**
@@ -9,10 +9,14 @@ import { sql } from 'drizzle-orm';
  * without running Neon MCP / SQL editor by hand. Queries are pure metadata
  * (pg_class, pg_stat_*, pg_size_pretty) — no row scans, fast, safe to poll.
  *
- * Cost discipline:
+ * Cost + safety discipline:
+ * - Uses the read-only Neon URL (`createReadOnlyDb()`). Defense in depth:
+ *   even a future bug that introduces a write here would be rejected at
+ *   the DB role level rather than silently mutating production.
  * - No `SELECT *` against user tables (would defeat the projection work)
- * - All queries return small, fixed-size result sets
- * - Statement-timeout guard left to the caller (Elysia route applies one)
+ * - All queries return small, fixed-size result sets — total runtime stays
+ *   well under Neon's 30s HTTP timeout for typical schemas. No explicit
+ *   statement_timeout wrapper applied.
  */
 
 export interface TableMetrics {
@@ -59,10 +63,10 @@ export interface DbMetricsSnapshot {
 }
 
 export class DbMetricsService {
-  private db: ReturnType<typeof createDb>;
+  private db: ReturnType<typeof createReadOnlyDb>;
 
   constructor() {
-    this.db = createDb();
+    this.db = createReadOnlyDb();
   }
 
   async snapshot(): Promise<DbMetricsSnapshot> {
@@ -130,7 +134,14 @@ export class DbMetricsService {
         c.relname                                         AS name,
         c.reltuples::bigint::text                         AS est_rows,
         pg_relation_size(c.oid)::text                     AS heap_bytes,
-        COALESCE(pg_relation_size(c.reltoastrelid), 0)::text AS toast_bytes,
+        -- Many tables (small ones, or those with no TOAST'able columns) have
+        -- reltoastrelid = 0. pg_relation_size(0) raises 'invalid relation OID',
+        -- and COALESCE evaluates AFTER the function call, so the error wins.
+        -- CASE short-circuits the call.
+        CASE
+          WHEN c.reltoastrelid = 0 THEN '0'
+          ELSE pg_relation_size(c.reltoastrelid)::text
+        END                                               AS toast_bytes,
         pg_indexes_size(c.oid)::text                      AS index_bytes,
         pg_total_relation_size(c.oid)::text               AS total_bytes,
         COALESCE(s.seq_scan, 0)::text                     AS seq_scan,

--- a/packages/api/test/admin.test.ts
+++ b/packages/api/test/admin.test.ts
@@ -51,6 +51,38 @@ describe('Admin Routes', () => {
     });
   });
 
+  describe('GET /admin/analytics/db/snapshot', () => {
+    it('returns DB sizing + activity snapshot', async () => {
+      const res = await apiWithBasicAuth('/analytics/db/snapshot');
+      expect(res.status).toBe(200);
+      const data = await expectJsonResponse(res, ['generatedAt', 'database', 'tables', 'indexes']);
+
+      expect(typeof data.generatedAt).toBe('string');
+      expect(typeof data.database.name).toBe('string');
+      expect(typeof data.database.sizeBytes).toBe('number');
+      expect(Array.isArray(data.tables)).toBe(true);
+      expect(Array.isArray(data.indexes)).toBe(true);
+
+      // catalog_items is always present in the schema; spot-check shape.
+      const catalogItemsRow = data.tables.find((t: { name: string }) => t.name === 'catalog_items');
+      expect(catalogItemsRow).toBeDefined();
+      expect(typeof catalogItemsRow.estimatedRows).toBe('number');
+      expect(typeof catalogItemsRow.heapBytes).toBe('number');
+      expect(typeof catalogItemsRow.toastBytes).toBe('number');
+      expect(typeof catalogItemsRow.indexBytes).toBe('number');
+      expect(typeof catalogItemsRow.totalBytes).toBe('number');
+      expect(typeof catalogItemsRow.seqScans).toBe('number');
+      expect(typeof catalogItemsRow.inserts).toBe('number');
+      expect(typeof catalogItemsRow.updates).toBe('number');
+    });
+
+    it('requires admin auth', async () => {
+      // Unauthenticated request via raw api()
+      const res = await api('/admin/analytics/db/snapshot');
+      expect(res.status).toBe(401);
+    });
+  });
+
   describe('GET /admin/users-list', () => {
     it('returns paginated users list', async () => {
       const res = await apiWithBasicAuth('/users-list');


### PR DESCRIPTION
## Summary

Adds `GET /admin/analytics/db/snapshot` — read-only DB sizing + activity metrics so cost trends are visible from the admin app without running Neon MCP / SQL editor by hand.

Surfaces the same metrics captured in [`docs/runbooks/neon-cost-profiling.md`](https://github.com/PackRat-AI/PackRat/blob/development/docs/runbooks/neon-cost-profiling.md) (steps 2-3). Polling this endpoint every minute is how you'd notice if e.g. `catalog_items.n_tup_upd` started growing again (the [embedding regen anomaly](https://github.com/PackRat-AI/PackRat/blob/development/docs/brainstorms/2026-06-01-embedding-regen-anomaly-requirements.md) — fix in flight on `fix/etl-embedding-regen-source-text-diff`) or `embedding_idx.scans` stayed at 0 (the HNSW issue from PR #2554).

## Response shape

```jsonc
{
  "generatedAt": "2026-06-05T18:00:00.000Z",
  "statsResetAt": null,                              // pg_stat_database.stats_reset
  "database": { "name": "packrat-neon-db", "sizeBytes": 39245591696 },
  "tables": [
    {
      "name": "catalog_items",
      "estimatedRows": 1790606,
      "heapBytes": 3336863744,
      "toastBytes": 16106127360,
      "indexBytes": 16106127360,
      "totalBytes": 35433480192,
      "seqScans": 32475, "seqTuplesRead": 2806032896,
      "idxScans": 14682572, "idxTuplesFetched": 19313043,
      "inserts": 1789703, "updates": 5556406, "deletes": 10, "hotUpdates": 0,
      "liveTuples": 1789693, "deadTuples": 0,
      "lastAutovacuum": null, "lastAutoanalyze": "2026-06-04T12:34:56Z"
    }
    // ... all public-schema tables, ordered by totalBytes DESC
  ],
  "indexes": [
    {
      "table": "catalog_items",
      "name": "embedding_idx",
      "bytes": 15032385536,
      "isUnique": false,
      "scans": 0,                  // ← post-PR-#2554 this should start climbing
      "tuplesRead": 0,
      "tuplesFetched": 0
    }
    // ... all indexes, ordered by size DESC
  ]
}
```

## Safety profile

- **Read-only.** Pure metadata queries: `pg_class`, `pg_stat_user_tables`, `pg_stat_user_indexes`, `pg_stat_database`. No row scans on user tables, no `SELECT *`, no `pg_stat_statements` dependency.
- **Cheap.** Four parallel queries per call; total time well under the 30s HTTP timeout even for large schemas. Safe to poll once per minute.
- **Admin-gated.** Inherits from the admin parent router's `onBeforeHandle` + `adminAuthGuard` ([routes/admin/index.ts:245](https://github.com/PackRat-AI/PackRat/blob/development/packages/api/src/routes/admin/index.ts#L245)). Same auth as `/admin/stats` and the other analytics endpoints.

## What this unblocks

| Use case | How |
|---|---|
| **Verify PR #2544 wins are landing** | Watch `seqTuplesRead` on catalog_items grow more slowly post-deploy |
| **Verify PR #2554 wins are landing** | Watch `embedding_idx.scans` go from 0 → growing |
| **Catch the embedding regen bug recurring** | `catalog_items.updates` should stay flat during steady-state, spike only during ETL |
| **Storage budget tracking** | Watch `catalog_items.totalBytes` + `invalid_item_logs.totalBytes` + `catalog_item_etl_jobs.totalBytes` trend |
| **Index bloat surfacing** | Index size vs. scans ratio per row in `indexes[]` |
| **Detect dead-tuple accumulation** | `tables[].deadTuples` over time |

## Implementation

- **`packages/api/src/services/dbMetricsService.ts`** — typed service. Each query returns fixed-size result sets; numeric Postgres values cast to text in SQL and parsed in TS to avoid the `bigint → JSON` serialization gotcha that bit #2554.
- **`packages/api/src/routes/admin/analytics/db.ts`** — Elysia route, mounts at `/admin/analytics/db/`.
- **`packages/api/src/routes/admin/analytics/index.ts`** — adds `.use(dbAnalyticsRoutes)` and the new entry to the analytics index map.
- **`packages/api/test/admin.test.ts`** — two integration tests: response shape + admin auth requirement.

## Test plan

- [x] `bun check-types` clean
- [x] `bun biome check` clean
- [x] Unit-test pool passes
- [ ] **Manual smoke post-merge:** `curl -u admin:password https://api.packrat.world/admin/analytics/db/snapshot | jq '.tables[] | select(.name=="catalog_items")'` shows the live state
- [ ] **Follow-on PR opportunity:** add an admin-app dashboard page that polls this every 60s and renders sizing / activity / index utilization as cards or a simple table. Out of scope for this PR.

## Refs

- Runbook: `docs/runbooks/neon-cost-profiling.md` (shipped in PR #2553)
- Companion brainstorms (also in #2553): embedding-regen anomaly, HNSW unused, totalCount cost
- Triggered by: PR #2544 (Tier-1 projections), PR #2554 (HNSW fix)