### PR TITLE
🐛 fix(api): skip OpenAI embedding calls for unchanged catalog ETL items (F4)

### DIFF
--- a/docs/brainstorms/2026-06-01-embedding-regen-anomaly-requirements.md
+++ b/docs/brainstorms/2026-06-01-embedding-regen-anomaly-requirements.md
@@ -102,3 +102,77 @@ The investigation should distinguish these contributions rather than assume the 
 Recommended next step: assign a small `/ce-plan` to investigate (1-2 hours of code reading + SQL + AI Gateway log inspection). The plan's first unit is "confirm or refute F4 via observability + code re-read"; if confirmed, subsequent units are the fix + the bloat-cleanup VACUUM consideration.
 
 If F4 is confirmed and the AI Gateway logs show 5M+ embedding calls, this is likely a non-trivial OpenAI cost recovery in addition to the Neon side — worth prioritizing.
+
+---
+
+## Refined understanding (2026-06-05 investigation, post-merge)
+
+**Hypothesis confirmed at the code level. The bug shape is different than first framed.** Reading the merged `catalogService.ts:451-495`:
+
+The UPSERT `set` clause uses `excluded.<col>` for the embedding-watched columns (name/description/categories/brand). After UPSERT runs, the returned row's values exactly equal the input's values. Therefore `inputItem[field] !== item[field]` is **structurally always false**, `itemsToUpdate` is always empty, and the regen branch on line 497 **never fires**. The diff is dead code.
+
+**So where do the embeddings actually come from?** Upstream, in `processValidItemsBatch`:
+
+```ts
+const embeddings = await generateManyEmbeddings({ ... });  // ALWAYS called for every batch row
+const itemsWithEmbeddings = mergedItems.map((item, index) => ({
+  ...item,
+  embedding: embeddings[index],
+}));
+const upsertedItems = await catalogService.upsertCatalogItems(itemsWithEmbeddings);
+```
+
+Every ETL row gets a fresh OpenAI text-embedding-3 call, regardless of whether the catalog row already exists with a byte-identical embedding from unchanged source text. The UPSERT then writes `embedding = excluded.embedding` for every row.
+
+**`pg_stat_user_tables` delta Jun 1 → Jun 5 confirms the steady-state hypothesis:**
+- `catalog_items.n_tup_ins`: 1,789,703 → 1,789,703 (no change)
+- `catalog_items.n_tup_upd`: 5,556,406 → 5,556,406 (no change in 4 days)
+
+Zero updates during 4 days of live traffic. The runaway only fires during ETL ingest. 5.56M lifetime updates ÷ 1.79M rows ≈ 3.1 lifetime ETL re-runs touching every row — matches "we did a lot of data loading this month for catalog."
+
+## Real cost lines, in priority
+
+1. **OpenAI text-embedding-3 API spend** — biggest hit, real $. Every ETL row × every run.
+2. **Cloudflare AI Gateway hit count** — likely caching identical embedding requests automatically. If caching is enabled with reasonable TTL, may already absorb most of the OpenAI cost. **Verify before designing the fix.**
+3. **Postgres n_tup_upd churn** — every UPSERT conflict counts. Bytes are likely identical (text-embedding-3 is deterministic on identical input), so HOT-update suppression may avoid HNSW index churn. Needs `pg_stat_user_indexes.embedding_idx.idx_tup_read` delta after next ETL run to verify.
+4. **Network + Worker compute** — round trip + serialization on every redundant call.
+
+## Fix shape
+
+**Move the diff upstream into `processValidItemsBatch`.** Before calling `generateManyEmbeddings`:
+
+```ts
+// 1. Bulk-fetch existing rows by SKU, projecting only the fields getEmbeddingText reads
+const existingBySku = await catalogService.fetchExistingForRegen(skus);  // new method
+
+// 2. Partition: needs-fresh-embedding vs reuse-existing
+const itemsNeedingEmbedding = mergedItems.filter(item => {
+  const existing = existingBySku.get(item.sku);
+  if (!existing) return true;
+  return getEmbeddingText({ item }) !== getEmbeddingText({ item: existing });
+});
+
+// 3. Generate only for the partition
+const freshEmbeddings = itemsNeedingEmbedding.length > 0
+  ? await generateManyEmbeddings({ values: itemsNeedingEmbedding.map(getEmbeddingText), ... })
+  : [];
+
+// 4. Upsert all items; only carry embedding for those that got fresh ones
+const embeddingBySku = new Map(itemsNeedingEmbedding.map((item, i) => [item.sku, freshEmbeddings[i]]));
+const itemsToUpsert = mergedItems.map(item => ({
+  ...item,
+  embedding: embeddingBySku.get(item.sku) ?? undefined,
+}));
+```
+
+UPSERT `set` clause needs modification so `embedding` column is only written when explicitly provided (e.g., `embedding = COALESCE(excluded.embedding, catalog_items.embedding)`).
+
+**Also delete the dead diff in `upsertCatalogItems`** — confusing and never-firing.
+
+**Optional durable safeguard:** add an `embedding_source_hash` column (sha256 of `getEmbeddingText` output). Compare hashes instead of re-running `getEmbeddingText` on existing rows. Faster, and avoids fetching JSONB columns for the diff.
+
+## Open questions for the fix
+
+- **Is Cloudflare AI Gateway already deduplicating identical embedding requests?** If yes, the OpenAI $ cost is already minimal; the fix recovers Worker compute + Postgres writes only. If no, the fix recovers full OpenAI $.
+- **Should we add the `embedding_source_hash` column** for durable dedup, or rely on per-call `getEmbeddingText` comparison? Hash column needs migration + backfill; comparison is simpler but recomputes text every time.
+- **What's `processValidItemsBatch`'s typical N per batch?** If small (<100), the existence-check round-trip cost matters less; if large (~30K), batch the SKU lookup with reasonable IN-clause limits.

--- a/packages/api/src/services/catalogService.ts
+++ b/packages/api/src/services/catalogService.ts
@@ -479,51 +479,14 @@ export class CatalogService {
       }
     ).returning(returningFields);
 
-    // Check if any embedding-related fields have changed. Scope to the keys
-    // present in the narrowed `.returning(...)` projection above so TS can
-    // index both `inputItem[field]` and `item[field]` without complaint.
-    const embeddingFields = ['name', 'description', 'categories', 'brand'] as const;
-
-    const itemsToUpdate = upsertedItems.filter((item) => {
-      const inputItem = items.find((i) => i.sku === item.sku);
-      if (!inputItem) return false;
-
-      return embeddingFields.some(
-        (field) =>
-          inputItem[field] && JSON.stringify(inputItem[field]) !== JSON.stringify(item[field]),
-      );
-    });
-
-    if (itemsToUpdate.length > 0) {
-      // Regenerate embeddings for updated items. Use the INPUT items as the
-      // source text — they have every field getEmbeddingText reads
-      // (model, variants, techs, color, size, material, reviews, qas, faqs).
-      // The narrow `.returning(...)` projection above does not include those,
-      // so the returned rows can't feed the helper.
-      const embeddingTexts = itemsToUpdate.map((item) => {
-        const inputItem = items.find((i) => i.sku === item.sku);
-        return getEmbeddingText({ item: inputItem ?? item });
-      });
-      const embeddings = await generateManyEmbeddings({
-        openAiApiKey: this.env.OPENAI_API_KEY,
-        values: embeddingTexts,
-        cloudflareAccountId: this.env.CLOUDFLARE_ACCOUNT_ID,
-        cloudflareGatewayId: this.env.CLOUDFLARE_AI_GATEWAY_ID,
-        cloudflareApiToken: this.env.CLOUDFLARE_API_TOKEN,
-        provider: this.env.AI_PROVIDER,
-        cloudflareAiBinding: this.env.AI,
-      });
-
-      // Update items with new embeddings
-      const updatePromises = itemsToUpdate.map((item, index) =>
-        this.db
-          .update(catalogItems)
-          .set({ embedding: embeddings[index] })
-          .where(eq(catalogItems.sku, item.sku)),
-      );
-
-      await Promise.all(updatePromises);
-    }
+    // F4: an embedding-regen diff loop previously lived here. It was dead
+    // code — the UPSERT `set` clause uses `excluded.<col>` for the
+    // embedding-watched columns, so the returned row's values were always
+    // equal to the input's values, making `inputItem[field] !== item[field]`
+    // structurally always-false. The actual source-text diff now lives
+    // upstream in `processValidItemsBatch` (where it can run BEFORE
+    // generateManyEmbeddings, avoiding redundant OpenAI calls entirely).
+    // See docs/brainstorms/2026-06-01-embedding-regen-anomaly-requirements.md.
 
     return upsertedItems;
   }
@@ -541,6 +504,70 @@ export class CatalogService {
         etlJobId: jobId,
       })),
     );
+  }
+
+  /**
+   * Bulk-fetch existing catalog rows by SKU, projecting only the columns the
+   * ETL embedding-regen diff needs: the existing embedding (so unchanged
+   * source-text items can reuse it instead of re-calling OpenAI) plus every
+   * field `getEmbeddingText` reads.
+   *
+   * Used by `processValidItemsBatch` to skip redundant OpenAI embedding calls
+   * when the upserted row's source text hasn't changed — fixes the F4
+   * embedding-regen anomaly captured in
+   * `docs/brainstorms/2026-06-01-embedding-regen-anomaly-requirements.md`.
+   *
+   * Projection is explicit (not getTableColumns) per the U9 lint discipline.
+   */
+  async fetchExistingForRegen(
+    skus: string[],
+  ): Promise<
+    Map<
+      string,
+      Pick<
+        CatalogItem,
+        | 'id'
+        | 'sku'
+        | 'embedding'
+        | 'name'
+        | 'description'
+        | 'brand'
+        | 'model'
+        | 'categories'
+        | 'variants'
+        | 'techs'
+        | 'color'
+        | 'size'
+        | 'material'
+        | 'reviews'
+        | 'qas'
+        | 'faqs'
+      >
+    >
+  > {
+    if (skus.length === 0) return new Map();
+    const rows = await this.db
+      .select({
+        id: catalogItems.id,
+        sku: catalogItems.sku,
+        embedding: catalogItems.embedding,
+        name: catalogItems.name,
+        description: catalogItems.description,
+        brand: catalogItems.brand,
+        model: catalogItems.model,
+        categories: catalogItems.categories,
+        variants: catalogItems.variants,
+        techs: catalogItems.techs,
+        color: catalogItems.color,
+        size: catalogItems.size,
+        material: catalogItems.material,
+        reviews: catalogItems.reviews,
+        qas: catalogItems.qas,
+        faqs: catalogItems.faqs,
+      })
+      .from(catalogItems)
+      .where(inArray(catalogItems.sku, skus));
+    return new Map(rows.map((r) => [r.sku, r]));
   }
 
   async queueEmbeddingJobs(): Promise<{ count: number }> {

--- a/packages/api/src/services/catalogService.ts
+++ b/packages/api/src/services/catalogService.ts
@@ -460,6 +460,16 @@ export class CatalogService {
             // weight_unit stays in sync with weight validity
             acc[col.name] =
               sql`CASE WHEN excluded.${sql.identifier('weight')} IS NOT NULL AND excluded.${sql.identifier('weight')} > 0 THEN excluded.${sql.identifier('weight_unit')} ELSE COALESCE(${catalogItems.weightUnit}, excluded.${sql.identifier('weight_unit')}) END`;
+          } else if (col.name === 'embedding') {
+            // Preserve existing embedding when input doesn't provide one.
+            // processValidItemsBatch passes embedding: undefined (→ NULL in
+            // INSERT) for the "reuse existing" partition; COALESCE keeps the
+            // stored vector, avoiding a redundant write that would count as
+            // n_tup_upd + dirty the HNSW page even when bytes are identical.
+            // Fresh items always carry a non-null embedding so this branch
+            // doesn't affect them.
+            acc[col.name] =
+              sql`COALESCE(excluded.${sql.identifier(col.name)}, ${catalogItems.embedding})`;
           } else {
             acc[col.name] = sql`excluded.${sql.identifier(col.name)}`;
           }

--- a/packages/api/src/services/etl/__tests__/processValidItemsBatch.test.ts
+++ b/packages/api/src/services/etl/__tests__/processValidItemsBatch.test.ts
@@ -1,0 +1,201 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { processValidItemsBatch } from '../processValidItemsBatch';
+
+// ---------------------------------------------------------------------------
+// Mocks
+//
+// Cover the partition + skip-redundant-embedding logic without a real DB.
+// Service collaborators are mocked at module load so we can drive existing-
+// row state and assert which items reach generateManyEmbeddings.
+// ---------------------------------------------------------------------------
+
+const mockFetchExistingForRegen = vi.fn();
+const mockUpsertCatalogItems = vi.fn();
+const mockTrackEtlJob = vi.fn();
+
+vi.mock('../../catalogService', () => ({
+  CatalogService: vi.fn().mockImplementation(function (this: unknown) {
+    return {
+      fetchExistingForRegen: mockFetchExistingForRegen,
+      upsertCatalogItems: mockUpsertCatalogItems,
+      trackEtlJob: mockTrackEtlJob,
+    };
+  }),
+}));
+
+const mockGenerateManyEmbeddings = vi.fn();
+vi.mock('../../embeddingService', () => ({
+  generateManyEmbeddings: (...args: unknown[]) => mockGenerateManyEmbeddings(...args),
+}));
+
+vi.mock('../updateEtlJobProgress', () => ({
+  updateEtlJobProgress: vi.fn(),
+}));
+
+vi.mock('../mergeItemsBySku', () => ({
+  // Identity merge — each item already has a unique SKU in test fixtures.
+  mergeItemsBySku: (items: unknown[]) => items,
+}));
+
+vi.mock('@packrat/api/db', () => ({
+  createDbClient: vi.fn(() => ({
+    update: vi.fn(() => ({ set: vi.fn(() => ({ where: vi.fn() })) })),
+  })),
+}));
+
+vi.mock('@packrat/api/utils/logger', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const TEST_ENV = {
+  OPENAI_API_KEY: 'sk-test',
+  AI_PROVIDER: 'openai',
+  CLOUDFLARE_ACCOUNT_ID: 'acct',
+  CLOUDFLARE_AI_GATEWAY_ID: 'gw',
+  CLOUDFLARE_API_TOKEN: 'token',
+  AI: {},
+  // biome-ignore lint/suspicious/noExplicitAny: test stub for the Env shape
+} as any;
+
+const makeItem = (sku: string, overrides: Record<string, unknown> = {}) => ({
+  sku,
+  name: `Item ${sku}`,
+  description: `desc ${sku}`,
+  productUrl: `https://example.com/${sku}`,
+  brand: 'Brand',
+  weight: 100,
+  weightUnit: 'g' as const,
+  ...overrides,
+});
+
+const fakeEmbedding = (seed: number): number[] =>
+  Array.from({ length: 1536 }, (_, i) => (i + seed) / 1536);
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('processValidItemsBatch — source-text diff', () => {
+  beforeEach(() => {
+    mockFetchExistingForRegen.mockReset();
+    mockUpsertCatalogItems.mockReset();
+    mockTrackEtlJob.mockReset();
+    mockGenerateManyEmbeddings.mockReset();
+    mockUpsertCatalogItems.mockResolvedValue([{ id: 1, sku: 'A' }]);
+    mockTrackEtlJob.mockResolvedValue(undefined);
+  });
+
+  it('calls generateManyEmbeddings only for items whose source text changed (or are new)', async () => {
+    const items = [
+      makeItem('NEW-1'), // brand new → fresh embedding
+      makeItem('CHANGED-1', { description: 'NEW desc' }), // existing but text changed
+      makeItem('UNCHANGED-1'), // existing + source text identical
+    ];
+
+    const existingForUnchanged = makeItem('UNCHANGED-1');
+    mockFetchExistingForRegen.mockResolvedValue(
+      new Map([
+        [
+          'CHANGED-1',
+          { ...makeItem('CHANGED-1', { description: 'OLD desc' }), embedding: fakeEmbedding(1) },
+        ],
+        ['UNCHANGED-1', { ...existingForUnchanged, embedding: fakeEmbedding(2) }],
+      ]),
+    );
+
+    const freshEmbeddings = [fakeEmbedding(10), fakeEmbedding(11)];
+    mockGenerateManyEmbeddings.mockResolvedValue(freshEmbeddings);
+
+    await processValidItemsBatch({ jobId: 'job1', items, env: TEST_ENV });
+
+    // generateManyEmbeddings called exactly once, with only 2 strings
+    // (NEW-1 + CHANGED-1, NOT UNCHANGED-1).
+    expect(mockGenerateManyEmbeddings).toHaveBeenCalledTimes(1);
+    const callArgs = mockGenerateManyEmbeddings.mock.calls[0]?.[0] as { values: string[] };
+    expect(callArgs.values).toHaveLength(2);
+    expect(callArgs.values.some((v: string) => v.includes('NEW-1'))).toBe(true);
+    expect(callArgs.values.some((v: string) => v.includes('CHANGED-1'))).toBe(true);
+    expect(callArgs.values.some((v: string) => v.includes('UNCHANGED-1'))).toBe(false);
+
+    // Upserted items received the right embeddings: fresh for NEW/CHANGED,
+    // reused for UNCHANGED.
+    const upserted = mockUpsertCatalogItems.mock.calls[0]?.[0] as Array<{
+      sku: string;
+      embedding: number[] | null;
+    }>;
+    expect(upserted.find((u) => u.sku === 'NEW-1')?.embedding).toEqual(freshEmbeddings[0]);
+    expect(upserted.find((u) => u.sku === 'CHANGED-1')?.embedding).toEqual(freshEmbeddings[1]);
+    expect(upserted.find((u) => u.sku === 'UNCHANGED-1')?.embedding).toEqual(fakeEmbedding(2));
+  });
+
+  it('skips generateManyEmbeddings entirely when every item is unchanged', async () => {
+    const items = [makeItem('U1'), makeItem('U2')];
+
+    mockFetchExistingForRegen.mockResolvedValue(
+      new Map([
+        ['U1', { ...makeItem('U1'), embedding: fakeEmbedding(1) }],
+        ['U2', { ...makeItem('U2'), embedding: fakeEmbedding(2) }],
+      ]),
+    );
+
+    await processValidItemsBatch({ jobId: 'jobNoCall', items, env: TEST_ENV });
+
+    expect(mockGenerateManyEmbeddings).not.toHaveBeenCalled();
+
+    const upserted = mockUpsertCatalogItems.mock.calls[0]?.[0] as Array<{
+      sku: string;
+      embedding: number[];
+    }>;
+    expect(upserted[0]?.embedding).toEqual(fakeEmbedding(1));
+    expect(upserted[1]?.embedding).toEqual(fakeEmbedding(2));
+  });
+
+  it('treats an existing row with a null embedding as needing fresh generation', async () => {
+    // Edge case: row was inserted but embedding column is NULL (failed prior
+    // run, or pre-pipeline-fix data). Must regenerate even though source text
+    // is identical.
+    const items = [makeItem('NULL-EMB')];
+
+    mockFetchExistingForRegen.mockResolvedValue(
+      new Map([['NULL-EMB', { ...makeItem('NULL-EMB'), embedding: null }]]),
+    );
+    mockGenerateManyEmbeddings.mockResolvedValue([fakeEmbedding(42)]);
+
+    await processValidItemsBatch({ jobId: 'jobNullEmb', items, env: TEST_ENV });
+
+    expect(mockGenerateManyEmbeddings).toHaveBeenCalledTimes(1);
+    const upserted = mockUpsertCatalogItems.mock.calls[0]?.[0] as Array<{
+      embedding: number[];
+    }>;
+    expect(upserted[0]?.embedding).toEqual(fakeEmbedding(42));
+  });
+
+  it('handles the all-new partition (zero existing rows)', async () => {
+    const items = [makeItem('N1'), makeItem('N2'), makeItem('N3')];
+
+    mockFetchExistingForRegen.mockResolvedValue(new Map());
+    mockGenerateManyEmbeddings.mockResolvedValue([
+      fakeEmbedding(1),
+      fakeEmbedding(2),
+      fakeEmbedding(3),
+    ]);
+
+    await processValidItemsBatch({ jobId: 'jobAllNew', items, env: TEST_ENV });
+
+    expect(mockGenerateManyEmbeddings).toHaveBeenCalledTimes(1);
+    const callArgs = mockGenerateManyEmbeddings.mock.calls[0]?.[0] as { values: string[] };
+    expect(callArgs.values).toHaveLength(3);
+
+    const upserted = mockUpsertCatalogItems.mock.calls[0]?.[0] as Array<{ embedding: number[] }>;
+    expect(upserted).toHaveLength(3);
+    expect(upserted.every((u) => Array.isArray(u.embedding))).toBe(true);
+  });
+});

--- a/packages/api/src/services/etl/__tests__/processValidItemsBatch.test.ts
+++ b/packages/api/src/services/etl/__tests__/processValidItemsBatch.test.ts
@@ -62,8 +62,7 @@ const TEST_ENV = {
   CLOUDFLARE_AI_GATEWAY_ID: 'gw',
   CLOUDFLARE_API_TOKEN: 'token',
   AI: {},
-  // biome-ignore lint/suspicious/noExplicitAny: test stub for the Env shape
-} as any;
+} as unknown as Parameters<typeof processValidItemsBatch>[0]['env'];
 
 const makeItem = (sku: string, overrides: Record<string, unknown> = {}) => ({
   sku,
@@ -125,15 +124,17 @@ describe('processValidItemsBatch — source-text diff', () => {
     expect(callArgs.values.some((v: string) => v.includes('CHANGED-1'))).toBe(true);
     expect(callArgs.values.some((v: string) => v.includes('UNCHANGED-1'))).toBe(false);
 
-    // Upserted items received the right embeddings: fresh for NEW/CHANGED,
-    // reused for UNCHANGED.
+    // Upserted items: fresh partition gets the newly-generated embedding;
+    // reuse partition gets embedding: undefined so the UPSERT's
+    // COALESCE(excluded.embedding, catalog_items.embedding) preserves the
+    // stored vector without a redundant write.
     const upserted = mockUpsertCatalogItems.mock.calls[0]?.[0] as Array<{
       sku: string;
-      embedding: number[] | null;
+      embedding: number[] | undefined;
     }>;
     expect(upserted.find((u) => u.sku === 'NEW-1')?.embedding).toEqual(freshEmbeddings[0]);
     expect(upserted.find((u) => u.sku === 'CHANGED-1')?.embedding).toEqual(freshEmbeddings[1]);
-    expect(upserted.find((u) => u.sku === 'UNCHANGED-1')?.embedding).toEqual(fakeEmbedding(2));
+    expect(upserted.find((u) => u.sku === 'UNCHANGED-1')?.embedding).toBeUndefined();
   });
 
   it('skips generateManyEmbeddings entirely when every item is unchanged', async () => {
@@ -150,12 +151,15 @@ describe('processValidItemsBatch — source-text diff', () => {
 
     expect(mockGenerateManyEmbeddings).not.toHaveBeenCalled();
 
+    // All items are reuse — UPSERT receives embedding: undefined, which
+    // becomes NULL in the INSERT and triggers the COALESCE branch on
+    // conflict, preserving the stored vector without a write.
     const upserted = mockUpsertCatalogItems.mock.calls[0]?.[0] as Array<{
       sku: string;
-      embedding: number[];
+      embedding: number[] | undefined;
     }>;
-    expect(upserted[0]?.embedding).toEqual(fakeEmbedding(1));
-    expect(upserted[1]?.embedding).toEqual(fakeEmbedding(2));
+    expect(upserted[0]?.embedding).toBeUndefined();
+    expect(upserted[1]?.embedding).toBeUndefined();
   });
 
   it('treats an existing row with a null embedding as needing fresh generation', async () => {
@@ -197,5 +201,37 @@ describe('processValidItemsBatch — source-text diff', () => {
     const upserted = mockUpsertCatalogItems.mock.calls[0]?.[0] as Array<{ embedding: number[] }>;
     expect(upserted).toHaveLength(3);
     expect(upserted.every((u) => Array.isArray(u.embedding))).toBe(true);
+  });
+
+  it('throws → catch-block fallback path when generateManyEmbeddings returns short', async () => {
+    // Defense against silent NULL embeddings if the embedding provider ever
+    // returns fewer embeddings than inputs. The throw routes execution to the
+    // surrounding try/catch which records the failure on
+    // etl_jobs.total_embedding_failures and upserts the batch without
+    // embeddings (degraded but consistent).
+    const items = [makeItem('N1'), makeItem('N2'), makeItem('N3')];
+
+    mockFetchExistingForRegen.mockResolvedValue(new Map());
+    // Returns 2 embeddings for 3 fresh inputs — provider bug simulation.
+    mockGenerateManyEmbeddings.mockResolvedValue([fakeEmbedding(1), fakeEmbedding(2)]);
+
+    await processValidItemsBatch({ jobId: 'jobShortResp', items, env: TEST_ENV });
+
+    // The throw should cause the catch-block fallback path to run, which
+    // still upserts (without embeddings) — exactly once. The success path
+    // and fallback path each upsert exactly once, so we expect 1 total call
+    // (the catch block's upsert).
+    expect(mockUpsertCatalogItems).toHaveBeenCalledTimes(1);
+
+    // The fallback path passes mergedItems verbatim (no embedding key set),
+    // so the upsert items don't carry the partial freshEmbeddings.
+    const upserted = mockUpsertCatalogItems.mock.calls[0]?.[0] as Array<{
+      sku: string;
+      embedding?: number[];
+    }>;
+    expect(upserted).toHaveLength(3);
+    // None of the fallback items should carry one of the partial fresh
+    // embeddings — that would mean we silently shipped NULL on the third.
+    expect(upserted.some((u) => u.embedding === fakeEmbedding(1))).toBe(false);
   });
 });

--- a/packages/api/src/services/etl/processValidItemsBatch.ts
+++ b/packages/api/src/services/etl/processValidItemsBatch.ts
@@ -84,17 +84,33 @@ export async function processValidItemsBatch({
           })
         : [];
 
-    // Combine items with their embeddings (fresh for changed/new, existing
-    // for unchanged). text-embedding-3 is deterministic, so reused embeddings
-    // are byte-equivalent to what would have been regenerated.
+    // Guard: any short response from generateManyEmbeddings would silently
+    // write NULL embeddings for some fresh items, losing vector coverage on
+    // them. Throw so the surrounding try/catch routes to the existing
+    // "embedding generation failed" fallback path which records the failure
+    // count on etl_jobs.total_embedding_failures.
+    if (freshEmbeddings.length !== needFresh.length) {
+      throw new Error(
+        `generateManyEmbeddings returned ${freshEmbeddings.length} embeddings for ${needFresh.length} inputs`,
+      );
+    }
+
+    // Combine items with their embeddings:
+    //  - fresh partition: gets the newly-generated embedding (must be non-null,
+    //    enforced by the length guard above)
+    //  - reuse partition: gets `embedding: undefined` so the UPSERT's
+    //    `embedding = COALESCE(excluded.embedding, catalog_items.embedding)`
+    //    set clause preserves the stored vector without writing it back.
+    //    text-embedding-3 is deterministic, so this is byte-equivalent to
+    //    re-passing the existing embedding — minus the redundant write.
     let freshIndex = 0;
     const itemsWithEmbeddings = partitioned.map((p) => {
       if (p.kind === 'fresh') {
-        const embedding = freshEmbeddings[freshIndex] ?? null;
+        const embedding = freshEmbeddings[freshIndex];
         freshIndex += 1;
         return { ...p.item, embedding };
       }
-      return { ...p.item, embedding: p.existingEmbedding };
+      return { ...p.item, embedding: undefined };
     });
 
     const upsertedItems = await catalogService.upsertCatalogItems(itemsWithEmbeddings);

--- a/packages/api/src/services/etl/processValidItemsBatch.ts
+++ b/packages/api/src/services/etl/processValidItemsBatch.ts
@@ -3,6 +3,7 @@ import { getEmbeddingText } from '@packrat/api/utils/embeddingHelper';
 import type { Env } from '@packrat/api/utils/env-validation';
 import { logger } from '@packrat/api/utils/logger';
 import { etlJobs, type NewCatalogItem } from '@packrat/db';
+import { isString } from '@packrat/guards';
 import { eq, sql } from 'drizzle-orm';
 import { CatalogService } from '../catalogService';
 import { generateManyEmbeddings } from '../embeddingService';
@@ -22,26 +23,79 @@ export async function processValidItemsBatch({
 
   const mergedItems = mergeItemsBySku(items as NewCatalogItem[]); // safe-cast: items are Partial<NewCatalogItem> at the type level, but all required fields have been confirmed present by CatalogItemValidator before reaching here
 
-  // Prepare texts for batch embedding
-  const embeddingTexts = mergedItems.map((item) => getEmbeddingText({ item }));
+  // Source-text diff: skip OpenAI calls when an existing row has byte-identical
+  // embedding-source text. Fixes the F4 embedding-regen anomaly (see
+  // docs/brainstorms/2026-06-01-embedding-regen-anomaly-requirements.md):
+  // previously every ETL row triggered a fresh embedding call regardless of
+  // whether the source text had changed, costing OpenAI $$ + churning the
+  // HNSW index on every re-ingest. text-embedding-3 is deterministic on
+  // identical input, so reusing the existing embedding for unchanged rows
+  // is byte-equivalent to regenerating.
+  const existingBySku = await catalogService.fetchExistingForRegen(
+    mergedItems.map((item) => item.sku).filter(isString),
+  );
+
+  // Partition: "needs fresh embedding" (new items + existing-but-changed) vs
+  // "reuse existing embedding" (existing + source-text unchanged).
+  type Partitioned =
+    | { kind: 'fresh'; item: NewCatalogItem; sourceText: string }
+    | { kind: 'reuse'; item: NewCatalogItem; existingEmbedding: number[] | null };
+
+  const partitioned: Partitioned[] = mergedItems.map((item): Partitioned => {
+    const existing = existingBySku.get(item.sku);
+    if (!existing) {
+      return { kind: 'fresh', item, sourceText: getEmbeddingText({ item }) };
+    }
+    const newText = getEmbeddingText({ item });
+    const oldText = getEmbeddingText({ item: existing });
+    if (newText !== oldText || !existing.embedding) {
+      return { kind: 'fresh', item, sourceText: newText };
+    }
+    return { kind: 'reuse', item, existingEmbedding: existing.embedding };
+  });
+
+  const needFresh = partitioned.filter(
+    (p): p is Extract<Partitioned, { kind: 'fresh' }> => p.kind === 'fresh',
+  );
+
+  logger.info({
+    event: 'etl.embedding.diff',
+    ctx: {
+      jobId,
+      total: mergedItems.length,
+      fresh: needFresh.length,
+      reused: partitioned.length - needFresh.length,
+    },
+  });
 
   try {
-    // Generate embeddings in batch
-    const embeddings = await generateManyEmbeddings({
-      openAiApiKey: env.OPENAI_API_KEY,
-      values: embeddingTexts,
-      cloudflareAccountId: env.CLOUDFLARE_ACCOUNT_ID,
-      cloudflareGatewayId: env.CLOUDFLARE_AI_GATEWAY_ID,
-      cloudflareApiToken: env.CLOUDFLARE_API_TOKEN,
-      provider: env.AI_PROVIDER,
-      cloudflareAiBinding: env.AI,
-    });
+    // Generate embeddings only for the rows whose source text changed (or
+    // are brand new). Skipped for the reuse-existing partition.
+    const freshEmbeddings =
+      needFresh.length > 0
+        ? await generateManyEmbeddings({
+            openAiApiKey: env.OPENAI_API_KEY,
+            values: needFresh.map((p) => p.sourceText),
+            cloudflareAccountId: env.CLOUDFLARE_ACCOUNT_ID,
+            cloudflareGatewayId: env.CLOUDFLARE_AI_GATEWAY_ID,
+            cloudflareApiToken: env.CLOUDFLARE_API_TOKEN,
+            provider: env.AI_PROVIDER,
+            cloudflareAiBinding: env.AI,
+          })
+        : [];
 
-    // Combine items with their embeddings
-    const itemsWithEmbeddings = mergedItems.map((item, index) => ({
-      ...item,
-      embedding: embeddings[index],
-    }));
+    // Combine items with their embeddings (fresh for changed/new, existing
+    // for unchanged). text-embedding-3 is deterministic, so reused embeddings
+    // are byte-equivalent to what would have been regenerated.
+    let freshIndex = 0;
+    const itemsWithEmbeddings = partitioned.map((p) => {
+      if (p.kind === 'fresh') {
+        const embedding = freshEmbeddings[freshIndex] ?? null;
+        freshIndex += 1;
+        return { ...p.item, embedding };
+      }
+      return { ...p.item, embedding: p.existingEmbedding };
+    });
 
     const upsertedItems = await catalogService.upsertCatalogItems(itemsWithEmbeddings);
     // Track the ETL job that processed these items


### PR DESCRIPTION
## Summary

Implements the source-text diff upstream of `generateManyEmbeddings` in `processValidItemsBatch`, fixing the F4 embedding-regen anomaly captured in [`docs/brainstorms/2026-06-01-embedding-regen-anomaly-requirements.md`](https://github.com/PackRat-AI/PackRat/blob/development/docs/brainstorms/2026-06-01-embedding-regen-anomaly-requirements.md).

**Cost recovery surface:** OpenAI text-embedding-3 spend on every ETL re-run. The 5.56M lifetime `n_tup_upd` on `catalog_items` (verified via the admin DB snapshot endpoint from PR #2565) shows ~3 lifetime ETL re-runs each touching all 1.79M rows — every one of those rows paid for a fresh OpenAI call regardless of whether its source text had changed.

## What was broken

Two issues compounded:

1. **`processValidItemsBatch` called `generateManyEmbeddings` for every batch row** before the upsert, with no check against existing rows.
2. **The diff loop inside `upsertCatalogItems` was structurally dead code.** The UPSERT `set` clause uses `excluded.<col>` for embedding-watched columns, so the returned row's values always equal the input's values, making `inputItem[field] !== item[field]` always-false. EXPLAIN verified in the brainstorm. Even if it had worked, it ran AFTER the OpenAI call — too late to recover the cost.

`pg_stat_user_tables` delta over 4 days post-Tier-1-merge confirmed the pattern: zero updates during steady-state, all 5.56M attributable to ETL re-runs.

## The fix

| Where | What |
|---|---|
| `CatalogService.fetchExistingForRegen(skus)` (new) | Bulk-projects each existing row's `embedding` + the fields `getEmbeddingText` reads. Explicit column projection per the U9 lint rule. |
| `processValidItemsBatch` | Partitions incoming items: `fresh` (new or source-text-changed) vs `reuse` (existing + source-text-unchanged). Calls `generateManyEmbeddings` only on the `fresh` partition. |
| `upsertCatalogItems` | Removed dead diff loop. Comment points at this fix. |

`text-embedding-3` is deterministic on identical input, so reused embeddings are byte-equivalent to what would have been regenerated. No vector quality drift.

## Observability

```ts
logger.info({
  event: 'etl.embedding.diff',
  ctx: { jobId, total, fresh, reused },
});
```

Reports per-batch fresh/reused counts. The savings will be visible:
- **Cloudflare AI Gateway dashboard:** total OpenAI calls per ETL run drops to the fresh-count
- **Admin DB snapshot endpoint** (PR #2565): `catalog_items.n_tup_upd` growth between ETL re-runs goes flat
- **Worker logs:** the `etl.embedding.diff` events let you spot anomalies (e.g. an ETL re-run with `fresh: 1789703, reused: 0` means the diff isn't working)

## Test plan

- [x] `bun check-types` clean
- [x] `bun biome check` clean (no-raw-typeof red flagged my initial `typeof sku === 'string'` filter — swapped for `isString` from `@packrat/guards`)
- [x] 4 new unit tests in `src/services/etl/__tests__/processValidItemsBatch.test.ts` covering:
  - Mixed partition: generateManyEmbeddings called once with only the fresh subset
  - All-unchanged: generateManyEmbeddings not called at all
  - Existing row with NULL embedding: regenerates (defensive against bad data)
  - All-new: generateManyEmbeddings called with full set
- [x] All 435 existing api unit tests pass
- [ ] **Post-deploy verify:** trigger a small ETL re-run and confirm `etl.embedding.diff` log + AI Gateway dashboard show non-zero `reused`
- [ ] **Post-deploy 24-48h:** `catalog_items.n_tup_upd` flat between ETL runs in the admin DB snapshot

## Complementary, not redundant, with AI Gateway caching

This fix prevents the redundant request from being made at all (saves Worker compute + network round trip + AI Gateway cache pollution). AI Gateway caching is defense-in-depth for anything that slips past the diff (other code paths, regressions). Doing both is correct.

## Deferred follow-up

**`embedding_source_hash` column.** Adding a stored SHA-256 of `getEmbeddingText` output on `catalog_items` would let the diff skip the JSONB fetch entirely for existing rows — only compare 32-byte hashes instead of re-fetching reviews/qas/faqs/etc. to recompute the source text. Native Web Crypto in Workers, no dep. The cost is a migration + backfill, so it's its own plan.

## Refs

- Brainstorm with the full investigation + EXPLAIN evidence: `docs/brainstorms/2026-06-01-embedding-regen-anomaly-requirements.md`
- Companion observability surface: PR #2565 admin DB snapshot endpoint
- Originating cost work: PR #2544 (Tier-1 projections), PR #2554 (HNSW fix)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized embedding generation to reduce redundant API calls and database operations.
  * Removed unused code paths in the catalog service.

* **Tests**
  * Added comprehensive test suite for embedding regeneration scenarios.

* **Documentation**
  * Updated investigation findings on embedding generation performance and optimization strategy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->