### PR TITLE
🔥 chore: drop dead `next lint` scripts from Next apps

### DIFF
--- a/apps/admin/next.config.mjs
+++ b/apps/admin/next.config.mjs
@@ -1,6 +1,7 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   output: 'export',
+  // Linting is handled by Biome (repo standard) — never run ESLint during builds.
   eslint: {
     ignoreDuringBuilds: true,
   },

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -8,7 +8,6 @@
     "clean": "bunx rimraf node_modules .next out",
     "dev": "next dev --port 3002",
     "doctor:react": "bunx react-doctor",
-    "lint": "next lint",
     "start": "next start"
   },
   "dependencies": {

--- a/apps/guides/next.config.mjs
+++ b/apps/guides/next.config.mjs
@@ -1,6 +1,7 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   output: 'export',
+  // Linting is handled by Biome (repo standard) — never run ESLint during builds.
   eslint: {
     ignoreDuringBuilds: true,
   },

--- a/apps/guides/package.json
+++ b/apps/guides/package.json
@@ -14,7 +14,6 @@
     "generate-og-images": "bun run scripts/generate-og-images.ts",
     "lighthouse": "bun run build && bunx lhci autorun",
     "lighthouse:ci": "lhci autorun",
-    "lint": "next lint",
     "start": "next start",
     "sync-to-r2": "bun run scripts/sync-to-r2.ts",
     "test": "vitest run --config vitest.config.ts",

--- a/apps/landing/next.config.mjs
+++ b/apps/landing/next.config.mjs
@@ -1,6 +1,7 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   output: 'export',
+  // Linting is handled by Biome (repo standard) — never run ESLint during builds.
   eslint: {
     ignoreDuringBuilds: true,
   },

--- a/apps/landing/package.json
+++ b/apps/landing/package.json
@@ -11,7 +11,6 @@
     "generate-og-images": "bun run scripts/generate-og-images.ts",
     "lighthouse": "bun run build && bunx lhci autorun",
     "lighthouse:ci": "lhci autorun",
-    "lint": "next lint",
     "start": "next start",
     "test": "vitest run --config vitest.config.ts",
     "test:og-meta": "vitest run --config vitest.config.ts __tests__/og-meta.test.ts"

--- a/apps/trails/package.json
+++ b/apps/trails/package.json
@@ -9,7 +9,6 @@
     "dev": "next dev",
     "doctor:react": "bunx react-doctor",
     "generate-og-images": "bun run scripts/generate-og-images.ts",
-    "lint": "next lint",
     "start": "next start",
     "test": "vitest run --config vitest.config.ts",
     "test:og-meta": "vitest run --config vitest.config.ts __tests__/og-meta.test.ts"


### PR DESCRIPTION
## What

Removes the `lint: next lint` script from `apps/landing`, `apps/guides`, `apps/admin`, and `apps/trails`.

## Why

Each of these had `"lint": "next lint"` but **no ESLint deps and no ESLint config** — the script would just error if run. The repo lints with **Biome 2.0** (`bun lint` / `bun check` at the root, enforced via lefthook). So these per-app scripts are dead scaffolding from `create-next-app`.

Also adds a one-line comment to each `next.config.mjs` documenting that the existing `eslint.ignoreDuringBuilds: true` is **intentional** — Biome owns linting, so Next must never invoke ESLint during builds.

## Notes

- No behavior change: nothing in CI or the build invokes these scripts (CI uses Biome; `next build` already skips ESLint via `ignoreDuringBuilds`).
- `apps/web` had no `lint` script (nothing to remove); `apps/trails` has no eslint block in next.config (no comment added there).
- Spun out of the CF Pages deploy investigation (#2534).