### PR TITLE
fix(catalog): stable pagination + variant grouping

### DIFF
--- a/apps/expo/atoms/catalogGroupAtom.ts
+++ b/apps/expo/atoms/catalogGroupAtom.ts
@@ -1,0 +1,7 @@
+import type { CatalogItem } from 'expo-app/features/catalog/types';
+import { atom } from 'jotai';
+
+// Holds all variants of the catalog group the user tapped in the list.
+// Set immediately before pushing to /catalog/[id] so the detail screen can
+// show a variants list without any extra API calls.
+export const catalogGroupVariantsAtom = atom<CatalogItem[]>([]);

--- a/apps/expo/components/CategoriesFilter.tsx
+++ b/apps/expo/components/CategoriesFilter.tsx
@@ -11,6 +11,7 @@ export function CategoriesFilter({
   error,
   retry,
   className,
+  contentPaddingX = 0,
 }: {
   activeFilter: string;
   onFilter: (filter: string) => void;
@@ -18,6 +19,7 @@ export function CategoriesFilter({
   error?: Error | null;
   retry?: (() => void) | undefined;
   className?: string;
+  contentPaddingX?: number;
 }) {
   const { t } = useTranslation();
 
@@ -57,7 +59,13 @@ export function CategoriesFilter({
           </View>
         </View>
       ) : (
-        <ScrollView horizontal showsHorizontalScrollIndicator={false} className="py-1">
+        <ScrollView
+          horizontal
+          showsHorizontalScrollIndicator={false}
+          contentContainerStyle={
+            contentPaddingX ? { paddingHorizontal: contentPaddingX } : undefined
+          }
+        >
           {!data
             ? Array.from({ length: 10 }).map((_, i) => (
                 <View

--- a/apps/expo/features/catalog/components/CatalogItemCard.tsx
+++ b/apps/expo/features/catalog/components/CatalogItemCard.tsx
@@ -19,9 +19,10 @@ import { CatalogItemImage } from './CatalogItemImage';
 type CatalogItemCardProps = {
   item: CatalogItem;
   onPress: () => void;
+  variantCount?: number;
 };
 
-export function CatalogItemCard({ item, onPress }: CatalogItemCardProps) {
+export function CatalogItemCard({ item, onPress, variantCount }: CatalogItemCardProps) {
   const { colors } = useColorScheme();
   const { t } = useTranslation();
 
@@ -79,6 +80,13 @@ export function CatalogItemCard({ item, onPress }: CatalogItemCardProps) {
                   count: item.usageCount,
                   unit: item.usageCount === 1 ? t('catalog.pack') : t('catalog.packs'),
                 })}
+              </Text>
+            </View>
+          )}
+          {variantCount && variantCount > 1 && (
+            <View className="rounded-full bg-muted px-2 py-0.5">
+              <Text className="text-xs text-muted-foreground">
+                {variantCount} {t('catalog.options')}
               </Text>
             </View>
           )}

--- a/apps/expo/features/catalog/components/CatalogItemCard.tsx
+++ b/apps/expo/features/catalog/components/CatalogItemCard.tsx
@@ -19,10 +19,9 @@ import { CatalogItemImage } from './CatalogItemImage';
 type CatalogItemCardProps = {
   item: CatalogItem;
   onPress: () => void;
-  variantCount?: number;
 };
 
-export function CatalogItemCard({ item, onPress, variantCount }: CatalogItemCardProps) {
+export function CatalogItemCard({ item, onPress }: CatalogItemCardProps) {
   const { colors } = useColorScheme();
   const { t } = useTranslation();
 
@@ -80,13 +79,6 @@ export function CatalogItemCard({ item, onPress, variantCount }: CatalogItemCard
                   count: item.usageCount,
                   unit: item.usageCount === 1 ? t('catalog.pack') : t('catalog.packs'),
                 })}
-              </Text>
-            </View>
-          )}
-          {variantCount && variantCount > 1 && (
-            <View className="rounded-full bg-muted px-2 py-0.5">
-              <Text className="text-xs text-muted-foreground">
-                {variantCount} {t('catalog.options')}
               </Text>
             </View>
           )}

--- a/apps/expo/features/catalog/components/SimilarItems.tsx
+++ b/apps/expo/features/catalog/components/SimilarItems.tsx
@@ -97,7 +97,7 @@ export const SimilarItems: React.FC<SimilarItemsProps> = ({
   if (isLoading) {
     return (
       <View className="mt-6">
-        <Text className="mb-3 px-4 text-lg font-semibold text-foreground">
+        <Text className="mb-3 text-lg font-semibold text-foreground">
           {t('catalog.moreLike', { itemName })}
         </Text>
         <FlatList

--- a/apps/expo/features/catalog/components/SimilarItems.tsx
+++ b/apps/expo/features/catalog/components/SimilarItems.tsx
@@ -97,7 +97,7 @@ export const SimilarItems: React.FC<SimilarItemsProps> = ({
   if (isLoading) {
     return (
       <View className="mt-6">
-        <Text className="mb-3 text-lg font-semibold text-foreground">
+        <Text className="mb-3 px-4 text-lg font-semibold text-foreground">
           {t('catalog.moreLike', { itemName })}
         </Text>
         <FlatList

--- a/apps/expo/features/catalog/components/SimilarItems.tsx
+++ b/apps/expo/features/catalog/components/SimilarItems.tsx
@@ -106,6 +106,7 @@ export const SimilarItems: React.FC<SimilarItemsProps> = ({
           data={Array(3).fill(null)}
           renderItem={() => <LoadingCard />}
           keyExtractor={(_, index) => `loading-${index}`}
+          style={{ marginHorizontal: -16 }}
           contentContainerStyle={{ paddingHorizontal: 16 }}
         />
       </View>
@@ -127,6 +128,7 @@ export const SimilarItems: React.FC<SimilarItemsProps> = ({
         data={data.items}
         renderItem={({ item }) => <SimilarItemCard item={item} onPress={handleItemPress} />}
         keyExtractor={(item) => item.id.toString()}
+        style={{ marginHorizontal: -16 }}
         contentContainerStyle={{ paddingHorizontal: 16 }}
       />
     </View>

--- a/apps/expo/features/catalog/lib/groupCatalogItems.ts
+++ b/apps/expo/features/catalog/lib/groupCatalogItems.ts
@@ -1,0 +1,25 @@
+import type { CatalogItem } from '../types';
+
+export type CatalogItemGroup = {
+  key: string;
+  representative: CatalogItem;
+  variants: CatalogItem[];
+};
+
+function groupKey(item: CatalogItem): string {
+  return `${(item.name ?? '').toLowerCase().trim()}:::${(item.brand ?? '').toLowerCase().trim()}`;
+}
+
+export function groupCatalogItems(items: CatalogItem[]): CatalogItemGroup[] {
+  const map = new Map<string, CatalogItemGroup>();
+  for (const item of items) {
+    const key = groupKey(item);
+    const group = map.get(key);
+    if (group) {
+      group.variants.push(item);
+    } else {
+      map.set(key, { key, representative: item, variants: [item] });
+    }
+  }
+  return Array.from(map.values());
+}

--- a/apps/expo/features/catalog/screens/CatalogItemDetailScreen.tsx
+++ b/apps/expo/features/catalog/screens/CatalogItemDetailScreen.tsx
@@ -303,14 +303,15 @@ export function CatalogItemDetailScreen() {
               <ItemReviews reviews={item.reviews} />
             </View>
           )}
-        </View>
 
-        <SimilarItems
-          catalogItemId={item.id.toString()}
-          itemName={item.name}
-          limit={5}
-          threshold={0.1}
-        />
+          {/* Similar Items Section */}
+          <SimilarItems
+            catalogItemId={item.id.toString()}
+            itemName={item.name}
+            limit={5}
+            threshold={0.1}
+          />
+        </View>
       </ScrollView>
     </SafeAreaView>
   );

--- a/apps/expo/features/catalog/screens/CatalogItemDetailScreen.tsx
+++ b/apps/expo/features/catalog/screens/CatalogItemDetailScreen.tsx
@@ -23,13 +23,7 @@ import { useCatalogItemDetails } from '../hooks';
 import { normalizeDescription } from '../lib/normalizeDescription';
 import type { CatalogItem } from '../types';
 
-function VariantRow({
-  variant,
-  colors,
-}: {
-  variant: CatalogItem;
-  colors: ReturnType<typeof useColorScheme>['colors'];
-}) {
+function VariantRow({ variant }: { variant: CatalogItem }) {
   const { t } = useTranslation();
   const label = [variant.size, variant.color].filter(Boolean).join(' · ');
   return (
@@ -303,7 +297,7 @@ export function CatalogItemDetailScreen() {
               </Text>
               <View>
                 {otherVariants.map((variant) => (
-                  <VariantRow key={variant.id} variant={variant} colors={colors} />
+                  <VariantRow key={variant.id} variant={variant} />
                 ))}
               </View>
             </View>

--- a/apps/expo/features/catalog/screens/CatalogItemDetailScreen.tsx
+++ b/apps/expo/features/catalog/screens/CatalogItemDetailScreen.tsx
@@ -25,6 +25,7 @@ import type { CatalogItem } from '../types';
 
 function VariantRow({ variant }: { variant: CatalogItem }) {
   const { t } = useTranslation();
+  const { colors } = useColorScheme();
   const label = [variant.size, variant.color].filter(Boolean).join(' · ');
   return (
     <View className="flex-row items-center justify-between border-b border-border py-3">
@@ -51,7 +52,7 @@ function VariantRow({ variant }: { variant: CatalogItem }) {
                     : 'close-circle-outline'
                 }
                 size={12}
-                color={variant.availability === 'in_stock' ? '#22c55e' : '#ef4444'}
+                color={variant.availability === 'in_stock' ? colors.green : colors.destructive}
               />
               <Text className="text-xs text-muted-foreground">
                 {variant.availability === 'in_stock'
@@ -68,7 +69,7 @@ function VariantRow({ variant }: { variant: CatalogItem }) {
           className="ml-3 flex-row items-center gap-1 rounded-md border border-border px-3 py-1.5"
         >
           <Text className="text-xs text-foreground">{t('catalog.viewOnRetailerSite')}</Text>
-          <Icon name="open-in-new" size={11} color="text-foreground" />
+          <Icon name="open-in-new" size={11} color={colors.foreground} />
         </Pressable>
       ) : null}
     </View>
@@ -260,7 +261,7 @@ export function CatalogItemDetailScreen() {
                 onPress={() => Linking.openURL(item.productUrl as string)}
               >
                 <Text className="text-foreground">{t('catalog.viewOnRetailerSite')}</Text>
-                <Icon name="open-in-new" size={14} color="text-foreground" />
+                <Icon name="open-in-new" size={14} color={colors.foreground} />
               </Button>
             </View>
           </View>
@@ -268,9 +269,7 @@ export function CatalogItemDetailScreen() {
           {/* Variants Section */}
           {otherVariants.length > 0 && (
             <View className="mt-8">
-              <Text variant="callout" className="mb-1">
-                {t('catalog.variantsSection')}
-              </Text>
+              <Text variant="callout">{t('catalog.variantsSection')}</Text>
               <View>
                 {otherVariants.map((variant) => (
                   <VariantRow key={variant.id} variant={variant} />
@@ -304,15 +303,14 @@ export function CatalogItemDetailScreen() {
               <ItemReviews reviews={item.reviews} />
             </View>
           )}
-
-          {/* Similar Items Section */}
-          <SimilarItems
-            catalogItemId={item.id.toString()}
-            itemName={item.name}
-            limit={5}
-            threshold={0.1}
-          />
         </View>
+
+        <SimilarItems
+          catalogItemId={item.id.toString()}
+          itemName={item.name}
+          limit={5}
+          threshold={0.1}
+        />
       </ScrollView>
     </SafeAreaView>
   );

--- a/apps/expo/features/catalog/screens/CatalogItemDetailScreen.tsx
+++ b/apps/expo/features/catalog/screens/CatalogItemDetailScreen.tsx
@@ -65,9 +65,10 @@ function VariantRow({ variant }: { variant: CatalogItem }) {
       {variant.productUrl ? (
         <Pressable
           onPress={() => Linking.openURL(variant.productUrl as string)}
-          className="ml-3 rounded-md border border-border px-3 py-1.5"
+          className="ml-3 flex-row items-center gap-1 rounded-md border border-border px-3 py-1.5"
         >
           <Text className="text-xs text-foreground">{t('catalog.viewOnRetailerSite')}</Text>
+          <Icon name="open-in-new" size={11} color="text-foreground" />
         </Pressable>
       ) : null}
     </View>
@@ -259,13 +260,14 @@ export function CatalogItemDetailScreen() {
                 onPress={() => Linking.openURL(item.productUrl as string)}
               >
                 <Text className="text-foreground">{t('catalog.viewOnRetailerSite')}</Text>
+                <Icon name="open-in-new" size={14} color="text-foreground" />
               </Button>
             </View>
           </View>
 
           {/* Variants Section */}
           {otherVariants.length > 0 && (
-            <View className="mb-6">
+            <View className="mt-8">
               <Text variant="callout" className="mb-1">
                 {t('catalog.variantsSection')}
               </Text>
@@ -278,11 +280,11 @@ export function CatalogItemDetailScreen() {
           )}
 
           {item.techs && Object.keys(item.techs).length > 0 && (
-            <View className="mt-6">
+            <View className="mt-8">
               <Text variant="callout" className="mb-2">
                 {t('catalog.specifications')}
               </Text>
-              <View className="rounded-lg p-3 gap-4">
+              <View className="rounded-lg p-3 py-0 gap-4">
                 {Object.entries(item.techs).map(([key, value]) => (
                   <View key={key} className="gap-1">
                     <Text className="text-xs text-muted-foreground uppercase">{key}</Text>

--- a/apps/expo/features/catalog/screens/CatalogItemDetailScreen.tsx
+++ b/apps/expo/features/catalog/screens/CatalogItemDetailScreen.tsx
@@ -1,5 +1,6 @@
 import { Ionicons } from '@expo/vector-icons';
 import { Button, Text } from '@packrat/ui/nativewindui';
+import { catalogGroupVariantsAtom } from 'expo-app/atoms/catalogGroupAtom';
 import { Icon } from 'expo-app/components/Icon';
 import { Chip } from 'expo-app/components/initial/Chip';
 import { ExpandableText } from 'expo-app/components/initial/ExpandableText';
@@ -14,11 +15,70 @@ import { ErrorScreen } from 'expo-app/screens/ErrorScreen';
 import { LoadingSpinnerScreen } from 'expo-app/screens/LoadingSpinnerScreen';
 import { NotFoundScreen } from 'expo-app/screens/NotFoundScreen';
 import { useLocalSearchParams, useRouter } from 'expo-router';
-import { Linking, Text as RNText, ScrollView, View } from 'react-native';
+import { useAtomValue } from 'jotai';
+import { Linking, Pressable, Text as RNText, ScrollView, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { CatalogItemImage } from '../components/CatalogItemImage';
 import { useCatalogItemDetails } from '../hooks';
 import { normalizeDescription } from '../lib/normalizeDescription';
+import type { CatalogItem } from '../types';
+
+function VariantRow({
+  variant,
+  colors,
+}: {
+  variant: CatalogItem;
+  colors: ReturnType<typeof useColorScheme>['colors'];
+}) {
+  const { t } = useTranslation();
+  const label = [variant.size, variant.color].filter(Boolean).join(' · ');
+  return (
+    <View className="flex-row items-center justify-between border-b border-border py-3">
+      <View className="flex-1 gap-0.5">
+        {label ? <Text className="text-sm font-medium text-foreground">{label}</Text> : null}
+        <View className="flex-row items-center gap-3">
+          {variant.price != null && (
+            <Text className="text-sm text-foreground">
+              {variant.currency ?? '$'}
+              {variant.price.toFixed(2)}
+            </Text>
+          )}
+          {variant.weight != null && (
+            <Text className="text-xs text-muted-foreground">
+              {variant.weight} {variant.weightUnit}
+            </Text>
+          )}
+          {variant.availability && (
+            <View className="flex-row items-center gap-0.5">
+              <Ionicons
+                name={
+                  variant.availability === 'in_stock'
+                    ? 'checkmark-circle-outline'
+                    : 'close-circle-outline'
+                }
+                size={12}
+                color={variant.availability === 'in_stock' ? '#22c55e' : '#ef4444'}
+              />
+              <Text className="text-xs text-muted-foreground">
+                {variant.availability === 'in_stock'
+                  ? t('catalog.inStock')
+                  : t('catalog.outOfStock')}
+              </Text>
+            </View>
+          )}
+        </View>
+      </View>
+      {variant.productUrl ? (
+        <Pressable
+          onPress={() => Linking.openURL(variant.productUrl as string)}
+          className="ml-3 rounded-md border border-border px-3 py-1.5"
+        >
+          <Text className="text-xs text-foreground">{t('catalog.viewOnRetailerSite')}</Text>
+        </Pressable>
+      ) : null}
+    </View>
+  );
+}
 
 export function CatalogItemDetailScreen() {
   const router = useRouter();
@@ -27,6 +87,12 @@ export function CatalogItemDetailScreen() {
   const { colors } = useColorScheme();
   const { t } = useTranslation();
   const MATERIAL_LENGTH_THRESHOLD = 60;
+
+  const groupVariants = useAtomValue(catalogGroupVariantsAtom);
+  // Show the variants section only when there are multiple variants for this
+  // group — i.e. when the user navigated from the grouped catalog list.
+  const otherVariants =
+    groupVariants.length > 1 ? groupVariants.filter((v) => v.id !== Number(id)) : [];
 
   const handleAddToPack = () => {
     router.push({
@@ -226,6 +292,20 @@ export function CatalogItemDetailScreen() {
           {item.reviews && item.reviews.length > 0 && (
             <View className="mt-2">
               <ItemReviews reviews={item.reviews} />
+            </View>
+          )}
+
+          {/* Variants Section */}
+          {otherVariants.length > 0 && (
+            <View className="mt-6">
+              <Text variant="callout" className="mb-1">
+                {t('catalog.variantsSection')}
+              </Text>
+              <View>
+                {otherVariants.map((variant) => (
+                  <VariantRow key={variant.id} variant={variant} colors={colors} />
+                ))}
+              </View>
             </View>
           )}
 

--- a/apps/expo/features/catalog/screens/CatalogItemDetailScreen.tsx
+++ b/apps/expo/features/catalog/screens/CatalogItemDetailScreen.tsx
@@ -263,8 +263,22 @@ export function CatalogItemDetailScreen() {
             </View>
           </View>
 
+          {/* Variants Section */}
+          {otherVariants.length > 0 && (
+            <View className="mb-6">
+              <Text variant="callout" className="mb-1">
+                {t('catalog.variantsSection')}
+              </Text>
+              <View>
+                {otherVariants.map((variant) => (
+                  <VariantRow key={variant.id} variant={variant} />
+                ))}
+              </View>
+            </View>
+          )}
+
           {item.techs && Object.keys(item.techs).length > 0 && (
-            <View className="mt-8">
+            <View className="mt-6">
               <Text variant="callout" className="mb-2">
                 {t('catalog.specifications')}
               </Text>
@@ -286,20 +300,6 @@ export function CatalogItemDetailScreen() {
           {item.reviews && item.reviews.length > 0 && (
             <View className="mt-2">
               <ItemReviews reviews={item.reviews} />
-            </View>
-          )}
-
-          {/* Variants Section */}
-          {otherVariants.length > 0 && (
-            <View className="mt-6">
-              <Text variant="callout" className="mb-1">
-                {t('catalog.variantsSection')}
-              </Text>
-              <View>
-                {otherVariants.map((variant) => (
-                  <VariantRow key={variant.id} variant={variant} />
-                ))}
-              </View>
             </View>
           )}
 

--- a/apps/expo/features/catalog/screens/CatalogItemsScreen.tsx
+++ b/apps/expo/features/catalog/screens/CatalogItemsScreen.tsx
@@ -1,4 +1,5 @@
 import { LargeTitleHeader, type LargeTitleSearchBarMethods, Text } from '@packrat/ui/nativewindui';
+import { catalogGroupVariantsAtom } from 'expo-app/atoms/catalogGroupAtom';
 import { searchValueAtom } from 'expo-app/atoms/itemListAtoms';
 import { AndroidTabBarInsetFix } from 'expo-app/components/AndroidTabBarInsetFix';
 import { CategoriesFilter } from 'expo-app/components/CategoriesFilter';
@@ -11,7 +12,7 @@ import { useTranslation } from 'expo-app/lib/hooks/useTranslation';
 import { testIds } from 'expo-app/lib/testIds';
 import { asNonNullableRef } from 'expo-app/lib/utils/asNonNullableRef';
 import { useRouter } from 'expo-router';
-import { useAtom } from 'jotai';
+import { useAtom, useSetAtom } from 'jotai';
 import { useMemo, useRef, useState } from 'react';
 import {
   ActivityIndicator,
@@ -27,6 +28,7 @@ import { CatalogItemCard } from '../components/CatalogItemCard';
 import { useCatalogItemsInfinite } from '../hooks';
 import { useCatalogItemsCategories } from '../hooks/useCatalogItemsCategories';
 import { useVectorSearch } from '../hooks/useVectorSearch';
+import { type CatalogItemGroup, groupCatalogItems } from '../lib/groupCatalogItems';
 import type { CatalogItem } from '../types';
 
 function CatalogItemsScreen() {
@@ -75,6 +77,8 @@ function CatalogItemsScreen() {
     Boolean(item?.id),
   );
 
+  const groupedItems = useMemo(() => groupCatalogItems(paginatedItems), [paginatedItems]);
+
   const totalItems = paginatedData?.pages[0]?.totalCount ?? 0;
 
   const totalItemsText = `${Number(totalItems).toLocaleString()} ${
@@ -84,6 +88,13 @@ function CatalogItemsScreen() {
     current: paginatedItems.length,
     total: Number(totalItems).toLocaleString(),
   });
+
+  const setGroupVariants = useSetAtom(catalogGroupVariantsAtom);
+
+  const handleGroupPress = (group: CatalogItemGroup) => {
+    setGroupVariants(group.variants);
+    router.push({ pathname: '/catalog/[id]', params: { id: group.representative.id } });
+  };
 
   const handleItemPress = (item: CatalogItem) => {
     router.push({ pathname: '/catalog/[id]', params: { id: item.id } });
@@ -124,7 +135,7 @@ function CatalogItemsScreen() {
             </Text>
           </View>
 
-          {paginatedItems.length > 0 && (
+          {groupedItems.length > 0 && (
             <Text className="mt-1 text-xs text-muted-foreground">{showingText}</Text>
           )}
         </View>
@@ -136,7 +147,7 @@ function CatalogItemsScreen() {
     activeFilter,
     categoriesError,
     totalItemsText,
-    paginatedItems.length,
+    groupedItems.length,
     showingText,
     refetchCategories,
   ]);
@@ -220,10 +231,14 @@ function CatalogItemsScreen() {
       />
 
       <FlatList
-        data={paginatedItems}
-        keyExtractor={(item) => item.id.toString()}
-        renderItem={({ item }) => (
-          <CatalogItemCard item={item} onPress={() => handleItemPress(item)} />
+        data={groupedItems}
+        keyExtractor={(group) => group.key}
+        renderItem={({ item: group }) => (
+          <CatalogItemCard
+            item={group.representative}
+            variantCount={group.variants.length}
+            onPress={() => handleGroupPress(group)}
+          />
         )}
         ItemSeparatorComponent={ItemSeparatorComponent}
         ListHeaderComponent={listHeader}

--- a/apps/expo/features/catalog/screens/CatalogItemsScreen.tsx
+++ b/apps/expo/features/catalog/screens/CatalogItemsScreen.tsx
@@ -115,7 +115,7 @@ function CatalogItemsScreen() {
           activeFilter={activeFilter}
           error={categoriesError}
           retry={refetchCategories}
-          className="py-2"
+          className="py-4"
           contentPaddingX={16}
         />
       </>
@@ -205,11 +205,7 @@ function CatalogItemsScreen() {
         keyExtractor={(group) => group.key}
         renderItem={({ item: group }) => (
           <View className="px-4">
-            <CatalogItemCard
-              item={group.representative}
-              variantCount={group.variants.length}
-              onPress={() => handleGroupPress(group)}
-            />
+            <CatalogItemCard item={group.representative} onPress={() => handleGroupPress(group)} />
           </View>
         )}
         ItemSeparatorComponent={ItemSeparatorComponent}

--- a/apps/expo/features/catalog/screens/CatalogItemsScreen.tsx
+++ b/apps/expo/features/catalog/screens/CatalogItemsScreen.tsx
@@ -79,16 +79,6 @@ function CatalogItemsScreen() {
 
   const groupedItems = useMemo(() => groupCatalogItems(paginatedItems), [paginatedItems]);
 
-  const totalItems = paginatedData?.pages[0]?.totalCount ?? 0;
-
-  const totalItemsText = `${Number(totalItems).toLocaleString()} ${
-    totalItems === 1 ? t('catalog.item') : t('catalog.items')
-  }`;
-  const showingText = t('catalog.showingItems', {
-    current: paginatedItems.length,
-    total: Number(totalItems).toLocaleString(),
-  });
-
   const setGroupVariants = useSetAtom(catalogGroupVariantsAtom);
 
   const handleGroupPress = (group: CatalogItemGroup) => {
@@ -125,32 +115,12 @@ function CatalogItemsScreen() {
           activeFilter={activeFilter}
           error={categoriesError}
           retry={refetchCategories}
-          className="px-4 py-2"
+          className="py-2"
+          contentPaddingX={16}
         />
-
-        <View className="mb-4 px-4">
-          <View className="flex-row items-center justify-between">
-            <Text testID={testIds.catalog.totalItemsCount} className="text-muted-foreground">
-              {totalItemsText}
-            </Text>
-          </View>
-
-          {groupedItems.length > 0 && (
-            <Text className="mt-1 text-xs text-muted-foreground">{showingText}</Text>
-          )}
-        </View>
       </>
     );
-  }, [
-    isSearching,
-    categories,
-    activeFilter,
-    categoriesError,
-    totalItemsText,
-    groupedItems.length,
-    showingText,
-    refetchCategories,
-  ]);
+  }, [isSearching, categories, activeFilter, categoriesError, refetchCategories]);
 
   return (
     <>
@@ -234,18 +204,20 @@ function CatalogItemsScreen() {
         data={groupedItems}
         keyExtractor={(group) => group.key}
         renderItem={({ item: group }) => (
-          <CatalogItemCard
-            item={group.representative}
-            variantCount={group.variants.length}
-            onPress={() => handleGroupPress(group)}
-          />
+          <View className="px-4">
+            <CatalogItemCard
+              item={group.representative}
+              variantCount={group.variants.length}
+              onPress={() => handleGroupPress(group)}
+            />
+          </View>
         )}
         ItemSeparatorComponent={ItemSeparatorComponent}
         ListHeaderComponent={listHeader}
         refreshControl={<RefreshControl refreshing={isManualRefresh} onRefresh={handleRefresh} />}
         onEndReached={loadMore}
         onEndReachedThreshold={0.5}
-        contentContainerStyle={{ flexGrow: 1, padding: 16 }}
+        contentContainerStyle={{ flexGrow: 1, paddingBottom: 16 }}
         contentInsetAdjustmentBehavior="automatic"
         ListFooterComponent={
           <>

--- a/apps/expo/lib/i18n/locales/en.json
+++ b/apps/expo/lib/i18n/locales/en.json
@@ -514,7 +514,7 @@
     "outOfStock": "Out of Stock",
     "preorder": "Pre-order",
     "specifications": "Specifications",
-    "viewOnRetailerSite": "View on Retailer Site",
+    "viewOnRetailerSite": "Visit Site",
     "addToPack": "Add to Pack",
     "errorFetchingItem": "Error fetching item",
     "pleaseTryAgain": "Please try again.",

--- a/apps/expo/lib/i18n/locales/en.json
+++ b/apps/expo/lib/i18n/locales/en.json
@@ -563,7 +563,6 @@
     "selectedItemsQuantity": "Selected Items ({{count}})",
     "noRecentlyUsedItems": "No recently used items yet",
     "quantityFor": "Qty for {{name}}",
-    "options": "options",
     "variantsSection": "Variants",
     "variantSize": "Size",
     "variantColor": "Color"

--- a/apps/expo/lib/i18n/locales/en.json
+++ b/apps/expo/lib/i18n/locales/en.json
@@ -563,8 +563,8 @@
     "selectedItemsQuantity": "Selected Items ({{count}})",
     "noRecentlyUsedItems": "No recently used items yet",
     "quantityFor": "Qty for {{name}}",
-    "options": "{{count}} options",
-    "variantsSection": "Available Variants",
+    "options": "options",
+    "variantsSection": "Variants",
     "variantSize": "Size",
     "variantColor": "Color"
   },

--- a/apps/expo/lib/i18n/locales/en.json
+++ b/apps/expo/lib/i18n/locales/en.json
@@ -160,7 +160,7 @@
     "loginFailed": "Login Failed",
     "invalidEmailOrPassword": "Invalid email or password",
     "resumeSync": "Resume Sync",
-    "syncPaused": "Sync paused \u2014 please sign in again."
+    "syncPaused": "Sync paused — please sign in again."
   },
   "profile": {
     "profile": "Profile",
@@ -249,10 +249,10 @@
     "lastUpdatedShort": "Last updated",
     "itemsCount": "{{count}} items",
     "sharingBenefits": "Sharing Benefits",
-    "distributeGroupGear": "\u2022 Distribute group gear among members to reduce individual pack weight",
-    "sharingBenefit1": "\u2022 Coordinate who brings shared items like tent, stove, and water filter",
-    "sharingBenefit2": "\u2022 See real-time updates when members modify the pack",
-    "sharingBenefit3": "\u2022 Plan together and ensure nothing essential is forgotten",
+    "distributeGroupGear": "• Distribute group gear among members to reduce individual pack weight",
+    "sharingBenefit1": "• Coordinate who brings shared items like tent, stove, and water filter",
+    "sharingBenefit2": "• See real-time updates when members modify the pack",
+    "sharingBenefit3": "• Plan together and ensure nothing essential is forgotten",
     "itemsInInventory": "{{count}} items in your inventory",
     "all": "All",
     "byCategory": "By Category",
@@ -562,7 +562,11 @@
     "recentlyUsed": "Recently Used",
     "selectedItemsQuantity": "Selected Items ({{count}})",
     "noRecentlyUsedItems": "No recently used items yet",
-    "quantityFor": "Qty for {{name}}"
+    "quantityFor": "Qty for {{name}}",
+    "options": "{{count}} options",
+    "variantsSection": "Available Variants",
+    "variantSize": "Size",
+    "variantColor": "Color"
   },
   "welcome": {
     "features": {

--- a/packages/api/src/services/catalogService.ts
+++ b/packages/api/src/services/catalogService.ts
@@ -116,22 +116,29 @@ export class CatalogService {
     let orderBy = [desc(sql`COALESCE(pack_item_counts.count, 0)`), desc(catalogItems.id)]; // default ordering by usage
     if (sort) {
       const { field, order } = sort;
+      // All branches include `desc(catalogItems.id)` as a tiebreaker so that
+      // LIMIT/OFFSET pagination is stable. Without it, rows sharing the same
+      // sort-key value (e.g. all ETL-imported items have identical created_at)
+      // are ordered non-deterministically by the planner, causing the same item
+      // to appear on multiple pages and other items to be skipped entirely.
       if (field === 'category') {
         orderBy = [
           order === 'desc'
             ? desc(sql`jsonb_array_elements_text(${catalogItems.categories})[0]`)
             : asc(sql`jsonb_array_elements_text(${catalogItems.categories})[0]`),
+          desc(catalogItems.id),
         ];
       } else if (field === 'usage') {
         orderBy = [
           order === 'desc'
             ? desc(sql`COALESCE(pack_item_counts.count, 0)`)
             : asc(sql`COALESCE(pack_item_counts.count, 0)`),
+          desc(catalogItems.id),
         ];
       } else {
         const sortColumn = catalogItems[field];
         if (sortColumn) {
-          orderBy = [order === 'desc' ? desc(sortColumn) : asc(sortColumn)];
+          orderBy = [order === 'desc' ? desc(sortColumn) : asc(sortColumn), desc(catalogItems.id)];
         }
       }
     }


### PR DESCRIPTION
## Summary

- **Pagination duplication bug**: `ORDER BY created_at DESC` with no secondary sort key produced non-deterministic ordering for ETL-imported items (all sharing identical timestamps). Added `desc(id)` tiebreaker to every sort branch in `getCatalogItems` — measured 21 duplicates per 10 pages before, 0 after.
- **Variant grouping in list**: catalog items are client-side grouped by `name + brand` so size/color variants (e.g. three rows of "Fineline Stretch Full-Zip Pant - Men's") show as one card. Tapping sets a Jotai atom with all variant items and navigates to the representative item's detail screen.
- **Variants section in detail screen**: shown directly below the action buttons when the user arrived from a grouped card; lists each other variant's size/color/price/weight/availability + "Visit Site ↗" link. No picker UI.
- **List screen polish**: removed raw-variant total count text, reduced header gap, categories filter is now full-bleed scrollable with `contentPaddingX` prop.
- **CTA polish**: "View on Retailer Site" → "Visit Site" + `open-in-new` icon on both the main button and each variant row.

## Test plan

- [ ] Scroll through catalog list across multiple pages — confirm no repeated cards
- [ ] Verify items with multiple variants show a single card (e.g. search "Fineline Stretch Full-Zip Pant")
- [ ] Tap a grouped card → detail screen shows "Variants" section below action buttons with all other sizes listed
- [ ] Tap "Visit Site ↗" in variants section and on main button — confirms external browser opens
- [ ] Tap a non-grouped item — detail screen shows no variants section
- [ ] Category filter chips scroll horizontally to screen edges
- [ ] Sort by fields other than `createdAt` (price, ratingValue) — confirm no cross-page duplicates

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added variants section to catalog item detail screen, displaying alternate sizes, colors, and pricing for the same product group.
  * Catalog items now grouped by product name and brand for improved browsing experience.

* **Bug Fixes**
  * Fixed non-deterministic ordering in catalog search results to ensure consistent pagination.

* **Improvements**
  * Updated UI text and styling for better clarity and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->