### PR TITLE
fix(expo/packs): fix double-tap required on pack details more-actions sheet

### DIFF
--- a/apps/expo/lib/hooks/useBottomSheetAction.ts
+++ b/apps/expo/lib/hooks/useBottomSheetAction.ts
@@ -1,8 +1,15 @@
 import type { BottomSheetModal } from '@gorhom/bottom-sheet';
-import { useCallback, useState } from 'react';
+import { useCallback, useRef } from 'react';
 
 export function useBottomSheetAction(sheetRef: React.RefObject<BottomSheetModal | null>) {
-  const [pending, setPending] = useState<(() => void) | null>(null);
+  // useRef instead of useState so handleDismiss always reads the latest value.
+  // @gorhom/bottom-sheet captures the onDismiss callback reference when the
+  // close animation begins — before a setState re-render has been committed.
+  // A state-based pending would still be null in that captured closure, causing
+  // the action to silently no-op on the first tap and only fire on the second
+  // (after the stale render cycle has flushed). A ref is mutated synchronously
+  // so the dismiss handler always sees whatever was written by run().
+  const pendingRef = useRef<(() => void) | null>(null);
 
   const run = useCallback(
     (fn: () => void, { defer = true } = {}) => {
@@ -11,19 +18,19 @@ export function useBottomSheetAction(sheetRef: React.RefObject<BottomSheetModal 
         fn();
         return;
       }
-      setPending(() => fn);
+      pendingRef.current = fn;
       sheetRef.current.close();
     },
     [sheetRef],
   );
 
   const handleDismiss = useCallback(() => {
-    if (pending) {
-      const fn = pending;
-      setPending(null);
+    const fn = pendingRef.current;
+    if (fn) {
+      pendingRef.current = null;
       fn();
     }
-  }, [pending]);
+  }, []);
 
   return { run, handleDismiss };
 }


### PR DESCRIPTION
## Problem

On the pack details screen, tapping the ⋯ more-actions button opens a bottom sheet. Selecting any option does nothing on the first tap — the user must open the sheet again and select the same option a second time.

Closes #2576

## Root Cause

Stale closure in `apps/expo/lib/hooks/useBottomSheetAction.ts`.

`handleDismiss` was a `useCallback` that closed over `pending` state:

```ts
const [pending, setPending] = useState<(() => void) | null>(null);

const handleDismiss = useCallback(() => {
  if (pending) { ... fn() }
}, [pending]); // captured before re-render
```

When the user tapped an option, `run(fn)` called `setPending(() => fn)` then `sheetRef.current.close()`. `@gorhom/bottom-sheet` captures the `onDismiss` prop reference when the close animation begins — before React commits the `setPending` re-render. The captured `handleDismiss` still sees `pending = null`, silently no-ops, and the action is lost.

On the second tap, `pending` holds the first tap's function (never cleared), so it fires — exactly the double-tap behaviour users reported.

## Fix

Replace `useState` with `useRef` (`apps/expo/lib/hooks/useBottomSheetAction.ts`):

```ts
const pendingRef = useRef<(() => void) | null>(null);

const run = useCallback((fn, { defer = true } = {}) => {
  pendingRef.current = fn;   // synchronous — visible immediately to all closures
  sheetRef.current.close();
}, [sheetRef]);

const handleDismiss = useCallback(() => {
  const fn = pendingRef.current;
  if (fn) { pendingRef.current = null; fn(); }
}, []); // no [pending] dep — always reads latest from ref
```

A ref mutation is synchronous. When `@gorhom/bottom-sheet` fires `onDismiss` after the animation completes, `handleDismiss` reads `pendingRef.current` which already holds the action — no stale capture possible.

## Scope

Only `useBottomSheetAction.ts` changed. All consumers (pack details more-actions sheet and any future bottom-sheet actions) are fixed automatically.

## Test Plan

- [ ] Open any pack's detail screen
- [ ] Tap ⋯ more-actions button → bottom sheet opens with four options
- [ ] Tap **Ask AI** → AI chat opens on first tap (no second tap needed)
- [ ] Tap **Add Item** → item-add flow opens on first tap
- [ ] Tap **Start Packing** → packing mode starts on first tap
- [ ] Tap **Analyze Gaps** → gap analysis runs on first tap
- [ ] Dismiss the sheet by swiping down → no action triggered