### PR TITLE
fix(api/packs): make gap analysis schema fields required for OpenAI structured outputs

### DIFF
--- a/packages/api/src/routes/packs/index.ts
+++ b/packages/api/src/routes/packs/index.ts
@@ -707,10 +707,10 @@ Limit to maximum 6 recommendations, prioritizing the most important gaps. Only s
                 reason: z.string(),
                 consumable: z.boolean(),
                 worn: z.boolean(),
-                priority: z.enum(['must-have', 'nice-to-have', 'optional']).optional(),
+                priority: z.enum(['must-have', 'nice-to-have', 'optional']),
               }),
             ),
-            summary: z.string().optional(),
+            summary: z.string(),
           }),
           temperature: 0.3,
         });


### PR DESCRIPTION
## Summary

- Removes `.optional()` from `priority` and `summary` fields in the gap analysis `generateObject` schema
- OpenAI's `response_format` structured outputs require every property key to be listed in `required`; the `.optional()` modifier was omitting those keys, causing a `400 invalid_json_schema` error

## Root cause

OpenAI's structured output validation is stricter than standard JSON Schema — it disallows optional properties entirely. Zod's `.optional()` maps to a schema without the field in `required`, which OpenAI rejects.

Closes #2573