### PR TITLE
feat(seasons): location picker sheet before generating suggestions

### DIFF
--- a/apps/expo/app/(app)/season-suggestions-results.tsx
+++ b/apps/expo/app/(app)/season-suggestions-results.tsx
@@ -158,7 +158,7 @@ export default function SeasonSuggestionsResultsScreen() {
                 <View className="flex-row items-center gap-1">
                   <Icon
                     namingScheme="sfSymbol"
-                    name="mappin"
+                    name="location"
                     materialIcon={{
                       type: 'MaterialIcons',
                       name: 'location-on',

--- a/apps/expo/app/(app)/season-suggestions-results.tsx
+++ b/apps/expo/app/(app)/season-suggestions-results.tsx
@@ -118,6 +118,95 @@ function classifyError(error: unknown): ErrorKind {
 
 const ICON_CIRCLE: ViewStyle = { width: 72, height: 72, borderRadius: 36 };
 
+// ---------------------------------------------------------------------------
+// Dev-only error simulator — tree-shaken in production builds (__DEV__ = false)
+// ---------------------------------------------------------------------------
+const DEV_ERROR_CHIPS: { label: string; error: Error }[] = __DEV__
+  ? [
+      {
+        label: '400',
+        error: new SeasonSuggestionsError({
+          httpStatus: 400,
+          serverMessage: 'Insufficient inventory',
+        }),
+      },
+      {
+        label: '401',
+        error: new SeasonSuggestionsError({ httpStatus: 401, serverMessage: 'Unauthorized' }),
+      },
+      { label: 'Net', error: new Error('Network request failed') },
+      {
+        label: 'AI',
+        error: new SeasonSuggestionsError({
+          httpStatus: 500,
+          serverMessage: 'AI generation failed',
+        }),
+      },
+      {
+        label: '503',
+        error: new SeasonSuggestionsError({
+          httpStatus: 503,
+          serverMessage: 'Service unavailable',
+        }),
+      },
+    ]
+  : [];
+
+interface DevErrorPanelProps {
+  active: Error | null;
+  onSelect: (err: Error | null) => void;
+}
+
+function DevErrorPanel({ active, onSelect }: DevErrorPanelProps) {
+  const { colors } = useColorScheme();
+  return (
+    <View
+      className="mb-4 rounded-xl p-3"
+      style={{ backgroundColor: colors.grey6, borderWidth: 1, borderColor: colors.grey4 }}
+    >
+      <Text variant="footnote" className="mb-2 font-semibold text-muted-foreground">
+        🧪 Dev — Force error state
+      </Text>
+      <View className="flex-row flex-wrap gap-2">
+        {DEV_ERROR_CHIPS.map((chip) => {
+          const isActive = active === chip.error;
+          return (
+            <TouchableOpacity
+              key={chip.label}
+              className="rounded-lg px-3 py-1.5"
+              style={{
+                backgroundColor: isActive ? colors.primary : colors.grey5,
+              }}
+              onPress={() => onSelect(isActive ? null : chip.error)}
+              activeOpacity={0.7}
+            >
+              <Text
+                variant="footnote"
+                className="font-semibold"
+                style={{ color: isActive ? 'white' : colors.foreground }}
+              >
+                {chip.label}
+              </Text>
+            </TouchableOpacity>
+          );
+        })}
+        {active !== null && (
+          <TouchableOpacity
+            className="rounded-lg px-3 py-1.5"
+            style={{ backgroundColor: colors.grey5 }}
+            onPress={() => onSelect(null)}
+            activeOpacity={0.7}
+          >
+            <Text variant="footnote" className="font-semibold text-muted-foreground">
+              ✕ Clear
+            </Text>
+          </TouchableOpacity>
+        )}
+      </View>
+    </View>
+  );
+}
+
 interface ErrorCardProps {
   error: unknown;
   onRetry: () => void;
@@ -246,6 +335,7 @@ export default function SeasonSuggestionsResultsScreen() {
   const seasonSuggestions = useSeasonSuggestions();
   const createPackWithItems = useCreatePackWithItems();
   const [createdPacks, setCreatedPacks] = useState<Record<number, string>>({});
+  const [devForcedError, setDevForcedError] = useState<Error | null>(null);
   const { colors } = useColorScheme();
   const triggered = useRef(false);
 
@@ -278,6 +368,11 @@ export default function SeasonSuggestionsResultsScreen() {
   };
 
   const { data, error } = seasonSuggestions;
+  const displayError = devForcedError ?? error;
+
+  const handleDevRetry = () => {
+    setDevForcedError(null);
+  };
 
   return (
     <>
@@ -285,19 +380,21 @@ export default function SeasonSuggestionsResultsScreen() {
 
       <ScrollView contentInsetAdjustmentBehavior="automatic" className="flex-1 px-4">
         <View className="pt-6">
-          {!data && !error && <SuggestionSkeleton />}
+          {__DEV__ && <DevErrorPanel active={devForcedError} onSelect={setDevForcedError} />}
 
-          {error && (
+          {!displayError && !data && <SuggestionSkeleton />}
+
+          {displayError && (
             <ErrorCard
-              error={error}
-              onRetry={handleRetry}
+              error={displayError}
+              onRetry={devForcedError ? handleDevRetry : handleRetry}
               onGoBack={() => router.back()}
               onGoToInventory={() => router.push('/(app)/(tabs)/(home)')}
               onSignIn={() => router.replace('/auth')}
             />
           )}
 
-          {data && (
+          {data && !displayError && (
             <View>
               <View className="flex-row items-center gap-2 mb-4">
                 <View className="flex-row items-center gap-1">

--- a/apps/expo/app/(app)/season-suggestions-results.tsx
+++ b/apps/expo/app/(app)/season-suggestions-results.tsx
@@ -5,13 +5,20 @@ import { PackItemImage } from 'expo-app/features/packs/components/PackItemImage'
 import { useCreatePackWithItems } from 'expo-app/features/packs/hooks/useCreatePackWithItems';
 import {
   type PackSuggestion,
+  SeasonSuggestionsError,
   useSeasonSuggestions,
 } from 'expo-app/features/packs/hooks/useSeasonSuggestions';
 import { useTranslation } from 'expo-app/lib/hooks/useTranslation';
 import { LinearGradient } from 'expo-linear-gradient';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import { useEffect, useRef, useState } from 'react';
-import { ScrollView, TouchableOpacity, useWindowDimensions, View } from 'react-native';
+import {
+  ScrollView,
+  TouchableOpacity,
+  useWindowDimensions,
+  View,
+  type ViewStyle,
+} from 'react-native';
 import Animated, {
   Easing,
   type SharedValue,
@@ -89,6 +96,149 @@ function SuggestionSkeleton() {
   );
 }
 
+type ErrorKind = 'insufficient_inventory' | 'unauthenticated' | 'network' | 'ai' | 'generic';
+
+function classifyError(error: unknown): ErrorKind {
+  if (error instanceof SeasonSuggestionsError) {
+    if (error.httpStatus === 400) return 'insufficient_inventory';
+    if (error.httpStatus === 401) return 'unauthenticated';
+    if (error.httpStatus >= 500) return 'ai';
+  }
+  const msg = error instanceof Error ? error.message.toLowerCase() : '';
+  if (
+    msg.includes('network') ||
+    msg.includes('fetch') ||
+    msg.includes('timeout') ||
+    msg.includes('connection')
+  ) {
+    return 'network';
+  }
+  return 'generic';
+}
+
+const ICON_CIRCLE: ViewStyle = { width: 72, height: 72, borderRadius: 36 };
+
+interface ErrorCardProps {
+  error: unknown;
+  onRetry: () => void;
+  onGoBack: () => void;
+  onGoToInventory: () => void;
+  onSignIn: () => void;
+}
+
+function ErrorCard({ error, onRetry, onGoBack, onGoToInventory, onSignIn }: ErrorCardProps) {
+  const { t } = useTranslation();
+  const { colors } = useColorScheme();
+  const kind = classifyError(error);
+
+  const config = {
+    insufficient_inventory: {
+      sfSymbol: 'bag.badge.plus' as const,
+      materialIcon: 'add-shopping-cart' as const,
+      title: t('seasons.errorNotEnoughGearTitle'),
+      body: t('seasons.errorNotEnoughGearBody'),
+      primaryLabel: t('seasons.errorNotEnoughGearAction'),
+      primaryAction: onGoToInventory,
+      secondaryLabel: t('seasons.goBack'),
+      secondaryAction: onGoBack,
+    },
+    unauthenticated: {
+      sfSymbol: 'person.badge.key' as const,
+      materialIcon: 'login' as const,
+      title: t('seasons.errorSessionTitle'),
+      body: t('seasons.errorSessionBody'),
+      primaryLabel: t('seasons.errorSessionAction'),
+      primaryAction: onSignIn,
+      secondaryLabel: t('seasons.goBack'),
+      secondaryAction: onGoBack,
+    },
+    network: {
+      sfSymbol: 'wifi.slash' as const,
+      materialIcon: 'wifi-off' as const,
+      title: t('seasons.errorNetworkTitle'),
+      body: t('seasons.errorNetworkBody'),
+      primaryLabel: t('seasons.tryAgain'),
+      primaryAction: onRetry,
+      secondaryLabel: t('seasons.goBack'),
+      secondaryAction: onGoBack,
+    },
+    ai: {
+      sfSymbol: 'sparkles' as const,
+      materialIcon: 'auto-awesome' as const,
+      title: t('seasons.errorAiTitle'),
+      body: t('seasons.errorAiBody'),
+      primaryLabel: t('seasons.tryAgain'),
+      primaryAction: onRetry,
+      secondaryLabel: t('seasons.goBack'),
+      secondaryAction: onGoBack,
+    },
+    generic: {
+      sfSymbol: 'exclamationmark.circle' as const,
+      materialIcon: 'error-outline' as const,
+      title: t('seasons.errorGenericTitle'),
+      body: t('seasons.errorGenericBody'),
+      primaryLabel: t('seasons.tryAgain'),
+      primaryAction: onRetry,
+      secondaryLabel: t('seasons.goBack'),
+      secondaryAction: onGoBack,
+    },
+  } as const;
+
+  const {
+    sfSymbol,
+    materialIcon,
+    title,
+    body,
+    primaryLabel,
+    primaryAction,
+    secondaryLabel,
+    secondaryAction,
+  } = config[kind];
+
+  return (
+    <View className="flex-1 items-center justify-center py-16 px-4">
+      <View
+        className="mb-6 items-center justify-center"
+        style={[ICON_CIRCLE, { backgroundColor: colors.grey6 }]}
+      >
+        <Icon
+          namingScheme="sfSymbol"
+          name={sfSymbol}
+          materialIcon={{ type: 'MaterialIcons', name: materialIcon }}
+          size={30}
+          color={colors.grey2}
+        />
+      </View>
+
+      <Text variant="title3" className="mb-2 text-center font-semibold">
+        {title}
+      </Text>
+      <Text variant="subhead" className="mb-8 text-center leading-relaxed text-muted-foreground">
+        {body}
+      </Text>
+
+      <View className="w-full gap-3">
+        <TouchableOpacity
+          className="w-full items-center rounded-xl bg-primary px-6 py-3.5"
+          onPress={primaryAction}
+          activeOpacity={0.8}
+        >
+          <Text className="font-semibold text-white">{primaryLabel}</Text>
+        </TouchableOpacity>
+
+        <TouchableOpacity
+          className="w-full items-center rounded-xl px-6 py-3.5"
+          style={{ backgroundColor: colors.grey6 }}
+          onPress={secondaryAction}
+          activeOpacity={0.8}
+        >
+          <Text className="font-medium text-muted-foreground">{secondaryLabel}</Text>
+        </TouchableOpacity>
+      </View>
+    </View>
+  );
+}
+
 export default function SeasonSuggestionsResultsScreen() {
   const router = useRouter();
   const { t } = useTranslation();
@@ -107,6 +257,13 @@ export default function SeasonSuggestionsResultsScreen() {
       triggerSuggestions({ location, date });
     }
   }, [triggerSuggestions, location, date]);
+
+  const handleRetry = () => {
+    if (location && date) {
+      seasonSuggestions.reset();
+      triggerSuggestions({ location, date });
+    }
+  };
 
   const handleCreatePack = ({
     suggestion,
@@ -131,14 +288,13 @@ export default function SeasonSuggestionsResultsScreen() {
           {!data && !error && <SuggestionSkeleton />}
 
           {error && (
-            <View className="rounded-xl border border-red-200 bg-red-50 p-4">
-              <Text variant="callout" className="font-medium text-red-800">
-                {t('errors.error')}
-              </Text>
-              <Text variant="body" className="text-red-700">
-                {error.message}
-              </Text>
-            </View>
+            <ErrorCard
+              error={error}
+              onRetry={handleRetry}
+              onGoBack={() => router.back()}
+              onGoToInventory={() => router.push('/(app)/(tabs)/(home)')}
+              onSignIn={() => router.replace('/auth')}
+            />
           )}
 
           {data && (

--- a/apps/expo/app/(app)/season-suggestions.tsx
+++ b/apps/expo/app/(app)/season-suggestions.tsx
@@ -1,7 +1,6 @@
 import type { BottomSheetModal } from '@gorhom/bottom-sheet';
-import { BottomSheetView } from '@gorhom/bottom-sheet';
 import { assertDefined } from '@packrat/guards';
-import { Button, LargeTitleHeader, Sheet, Text, useColorScheme } from '@packrat/ui/nativewindui';
+import { Button, LargeTitleHeader, Text } from '@packrat/ui/nativewindui';
 import * as Sentry from '@sentry/react-native';
 import { Icon } from 'expo-app/components/Icon';
 import { LocationSearchSheet } from 'expo-app/features/packs/components/LocationSearchSheet';
@@ -17,8 +16,6 @@ export default function SeasonSuggestionsScreen() {
   const router = useRouter();
   const { t } = useTranslation();
   const [isGettingLocation, setIsGettingLocation] = useState(false);
-  const { colors } = useColorScheme();
-  const permissionSheetRef = useRef<BottomSheetModal>(null);
   const locationSourceSheetRef = useRef<BottomSheetModal>(null);
   const locationSearchSheetRef = useRef<BottomSheetModal>(null);
   const { run: runSourceAction, handleDismiss: handleSourceDismiss } =
@@ -64,45 +61,7 @@ export default function SeasonSuggestionsScreen() {
     }
   };
 
-  const checkPermissionAndFetch = async () => {
-    const { status } = await Location.getForegroundPermissionsAsync();
-    if (status === 'granted') {
-      await fetchLocationAndNavigate();
-    } else {
-      permissionSheetRef.current?.present();
-    }
-  };
-
-  const handleGeneratePress = () => {
-    locationSourceSheetRef.current?.present();
-  };
-
-  const handleSourceSearchPress = () => {
-    runSourceAction(() => {
-      locationSearchSheetRef.current?.present();
-    });
-  };
-
-  const handleSourceCurrentLocationPress = () => {
-    runSourceAction(() => {
-      checkPermissionAndFetch();
-    });
-  };
-
-  const handleSearchBack = () => {
-    runSearchAction(() => {
-      locationSourceSheetRef.current?.present();
-    });
-  };
-
-  const handleLocationSelected = (location: string) => {
-    runSearchAction(() => {
-      navigateWithLocation(location);
-    });
-  };
-
-  const handlePermissionAllow = async () => {
-    permissionSheetRef.current?.dismiss();
+  const requestLocationAndFetch = async () => {
     const { status } = await Location.requestForegroundPermissionsAsync();
     if (status === 'granted') {
       await fetchLocationAndNavigate();
@@ -121,6 +80,34 @@ export default function SeasonSuggestionsScreen() {
         },
       ]);
     }
+  };
+
+  const handleGeneratePress = () => {
+    locationSourceSheetRef.current?.present();
+  };
+
+  const handleSourceSearchPress = () => {
+    runSourceAction(() => {
+      locationSearchSheetRef.current?.present();
+    });
+  };
+
+  const handleSourceCurrentLocationPress = () => {
+    runSourceAction(() => {
+      requestLocationAndFetch();
+    });
+  };
+
+  const handleSearchBack = () => {
+    runSearchAction(() => {
+      locationSourceSheetRef.current?.present();
+    });
+  };
+
+  const handleLocationSelected = (location: string) => {
+    runSearchAction(() => {
+      navigateWithLocation(location);
+    });
   };
 
   return (
@@ -170,49 +157,6 @@ export default function SeasonSuggestionsScreen() {
         onLocationSelected={handleLocationSelected}
         onDismiss={handleSearchDismiss}
       />
-
-      <Sheet
-        ref={permissionSheetRef}
-        enableDynamicSizing
-        enablePanDownToClose
-        backgroundStyle={{ backgroundColor: colors.card }}
-        handleIndicatorStyle={{ backgroundColor: colors.grey2 }}
-      >
-        <BottomSheetView className="px-6 pb-10 pt-2">
-          <View className="items-center gap-5">
-            <View className="h-16 w-16 items-center justify-center rounded-full bg-primary/10">
-              <Icon
-                ios={{ useMaterialIcon: true }}
-                materialIcon={{ type: 'MaterialIcons', name: 'my-location' }}
-                size={30}
-                color={colors.primary}
-              />
-            </View>
-
-            <View className="items-center gap-2">
-              <Text className="text-center text-lg font-semibold">
-                {t('seasons.locationPermissionTitle')}
-              </Text>
-              <Text className="text-center text-sm leading-relaxed text-muted-foreground">
-                {t('seasons.locationPermissionDescription')}
-              </Text>
-            </View>
-
-            <View className="w-full flex-row gap-3">
-              <Button
-                variant="secondary"
-                onPress={() => permissionSheetRef.current?.dismiss()}
-                className="flex-1"
-              >
-                <Text>{t('seasons.notNow')}</Text>
-              </Button>
-              <Button onPress={handlePermissionAllow} className="flex-1">
-                <Text className="font-medium text-white">{t('seasons.allowLocationAccess')}</Text>
-              </Button>
-            </View>
-          </View>
-        </BottomSheetView>
-      </Sheet>
     </>
   );
 }

--- a/apps/expo/app/(app)/season-suggestions.tsx
+++ b/apps/expo/app/(app)/season-suggestions.tsx
@@ -4,6 +4,9 @@ import { assertDefined } from '@packrat/guards';
 import { Button, LargeTitleHeader, Sheet, Text, useColorScheme } from '@packrat/ui/nativewindui';
 import * as Sentry from '@sentry/react-native';
 import { Icon } from 'expo-app/components/Icon';
+import { LocationSearchSheet } from 'expo-app/features/packs/components/LocationSearchSheet';
+import { LocationSourceSheet } from 'expo-app/features/packs/components/LocationSourceSheet';
+import { useBottomSheetAction } from 'expo-app/lib/hooks/useBottomSheetAction';
 import { useTranslation } from 'expo-app/lib/hooks/useTranslation';
 import * as Location from 'expo-location';
 import { useRouter } from 'expo-router';
@@ -16,6 +19,21 @@ export default function SeasonSuggestionsScreen() {
   const [isGettingLocation, setIsGettingLocation] = useState(false);
   const { colors } = useColorScheme();
   const permissionSheetRef = useRef<BottomSheetModal>(null);
+  const locationSourceSheetRef = useRef<BottomSheetModal>(null);
+  const locationSearchSheetRef = useRef<BottomSheetModal>(null);
+  const { run: runSourceAction, handleDismiss: handleSourceDismiss } =
+    useBottomSheetAction(locationSourceSheetRef);
+  const { run: runSearchAction, handleDismiss: handleSearchDismiss } =
+    useBottomSheetAction(locationSearchSheetRef);
+
+  const navigateWithLocation = (locationName: string) => {
+    const currentDate = new Date().toISOString().split('T')[0];
+    assertDefined(currentDate);
+    router.push({
+      pathname: '/season-suggestions-results',
+      params: { location: locationName, date: currentDate },
+    });
+  };
 
   const fetchLocationAndNavigate = async () => {
     setIsGettingLocation(true);
@@ -35,13 +53,7 @@ export default function SeasonSuggestionsScreen() {
         geocode?.country ??
         `${pos.coords.latitude.toFixed(2)}, ${pos.coords.longitude.toFixed(2)}`;
 
-      const currentDate = new Date().toISOString().split('T')[0];
-      assertDefined(currentDate);
-
-      router.push({
-        pathname: '/season-suggestions-results',
-        params: { location: locationName, date: currentDate },
-      });
+      navigateWithLocation(locationName);
     } catch (err) {
       Sentry.captureException(err, {
         tags: { feature: 'seasons', action: 'fetchLocationAndNavigate' },
@@ -52,13 +64,41 @@ export default function SeasonSuggestionsScreen() {
     }
   };
 
-  const handleGeneratePress = async () => {
+  const checkPermissionAndFetch = async () => {
     const { status } = await Location.getForegroundPermissionsAsync();
     if (status === 'granted') {
       await fetchLocationAndNavigate();
     } else {
       permissionSheetRef.current?.present();
     }
+  };
+
+  const handleGeneratePress = () => {
+    locationSourceSheetRef.current?.present();
+  };
+
+  const handleSourceSearchPress = () => {
+    runSourceAction(() => {
+      locationSearchSheetRef.current?.present();
+    });
+  };
+
+  const handleSourceCurrentLocationPress = () => {
+    runSourceAction(() => {
+      checkPermissionAndFetch();
+    });
+  };
+
+  const handleSearchBack = () => {
+    runSearchAction(() => {
+      locationSourceSheetRef.current?.present();
+    });
+  };
+
+  const handleLocationSelected = (location: string) => {
+    runSearchAction(() => {
+      navigateWithLocation(location);
+    });
   };
 
   const handlePermissionAllow = async () => {
@@ -117,6 +157,20 @@ export default function SeasonSuggestionsScreen() {
         </View>
       </ScrollView>
 
+      <LocationSourceSheet
+        ref={locationSourceSheetRef}
+        onSearchPress={handleSourceSearchPress}
+        onCurrentLocationPress={handleSourceCurrentLocationPress}
+        onDismiss={handleSourceDismiss}
+      />
+
+      <LocationSearchSheet
+        ref={locationSearchSheetRef}
+        onBack={handleSearchBack}
+        onLocationSelected={handleLocationSelected}
+        onDismiss={handleSearchDismiss}
+      />
+
       <Sheet
         ref={permissionSheetRef}
         enableDynamicSizing
@@ -126,7 +180,7 @@ export default function SeasonSuggestionsScreen() {
       >
         <BottomSheetView className="px-6 pb-10 pt-2">
           <View className="items-center gap-5">
-            <View className="h-16 w-16 rounded-full bg-primary/10 items-center justify-center">
+            <View className="h-16 w-16 items-center justify-center rounded-full bg-primary/10">
               <Icon
                 ios={{ useMaterialIcon: true }}
                 materialIcon={{ type: 'MaterialIcons', name: 'my-location' }}
@@ -136,10 +190,10 @@ export default function SeasonSuggestionsScreen() {
             </View>
 
             <View className="items-center gap-2">
-              <Text className="text-lg font-semibold text-center">
+              <Text className="text-center text-lg font-semibold">
                 {t('seasons.locationPermissionTitle')}
               </Text>
-              <Text className="text-muted-foreground text-center text-sm leading-relaxed">
+              <Text className="text-center text-sm leading-relaxed text-muted-foreground">
                 {t('seasons.locationPermissionDescription')}
               </Text>
             </View>
@@ -153,7 +207,7 @@ export default function SeasonSuggestionsScreen() {
                 <Text>{t('seasons.notNow')}</Text>
               </Button>
               <Button onPress={handlePermissionAllow} className="flex-1">
-                <Text className="text-white font-medium">{t('seasons.allowLocationAccess')}</Text>
+                <Text className="font-medium text-white">{t('seasons.allowLocationAccess')}</Text>
               </Button>
             </View>
           </View>

--- a/apps/expo/features/packs/components/LocationSearchSheet.tsx
+++ b/apps/expo/features/packs/components/LocationSearchSheet.tsx
@@ -105,6 +105,7 @@ export const LocationSearchSheet = React.forwardRef<BottomSheetModal, LocationSe
         snapPoints={['85%']}
         index={0}
         enablePanDownToClose
+        topInset={insets.top}
         onDismiss={onDismiss}
         backgroundStyle={{ backgroundColor: colors.card }}
         handleIndicatorStyle={{ backgroundColor: colors.grey2 }}
@@ -193,9 +194,9 @@ export const LocationSearchSheet = React.forwardRef<BottomSheetModal, LocationSe
               >
                 <Icon
                   namingScheme="sfSymbol"
-                  name="mappin"
+                  name="location.fill"
                   materialIcon={{ type: 'MaterialIcons', name: 'location-on' }}
-                  size={16}
+                  size={15}
                   color={colors.grey2}
                 />
               </View>

--- a/apps/expo/features/packs/components/LocationSearchSheet.tsx
+++ b/apps/expo/features/packs/components/LocationSearchSheet.tsx
@@ -1,0 +1,218 @@
+import type { BottomSheetModal } from '@gorhom/bottom-sheet';
+import { BottomSheetScrollView, BottomSheetTextInput } from '@gorhom/bottom-sheet';
+import { clientEnvs } from '@packrat/env/expo-client';
+import { isString, toRecordArray } from '@packrat/guards';
+import { Sheet, Text } from '@packrat/ui/nativewindui';
+import * as Sentry from '@sentry/react-native';
+import { Icon } from 'expo-app/components/Icon';
+import { useColorScheme } from 'expo-app/lib/hooks/useColorScheme';
+import { useTranslation } from 'expo-app/lib/hooks/useTranslation';
+import Constants from 'expo-constants';
+import * as React from 'react';
+import { ActivityIndicator, TouchableOpacity, View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
+const GOOGLE_MAPS_API_KEY =
+  Constants.expoConfig?.extra?.googleMapsApiKey || clientEnvs.EXPO_PUBLIC_GOOGLE_MAPS_API_KEY;
+
+interface GeocodingResult {
+  place_id: string;
+  formatted_address: string;
+}
+
+interface LocationSearchSheetProps {
+  onBack: () => void;
+  onLocationSelected: (location: string) => void;
+  onDismiss?: () => void;
+}
+
+export const LocationSearchSheet = React.forwardRef<BottomSheetModal, LocationSearchSheetProps>(
+  function LocationSearchSheet({ onBack, onLocationSelected, onDismiss }, ref) {
+    const { colors } = useColorScheme();
+    const { t } = useTranslation();
+    const insets = useSafeAreaInsets();
+    const [query, setQuery] = React.useState('');
+    const [results, setResults] = React.useState<GeocodingResult[]>([]);
+    const [isSearching, setIsSearching] = React.useState(false);
+
+    React.useEffect(() => {
+      if (query.trim().length < 2) {
+        setResults([]);
+        setIsSearching(false);
+        return;
+      }
+
+      setIsSearching(true);
+
+      const timer = setTimeout(async () => {
+        try {
+          if (!GOOGLE_MAPS_API_KEY) {
+            setResults([{ place_id: 'custom', formatted_address: query.trim() }]);
+            return;
+          }
+
+          const response = await fetch(
+            `https://maps.googleapis.com/maps/api/geocode/json?address=${encodeURIComponent(query.trim())}&key=${GOOGLE_MAPS_API_KEY}`,
+          );
+          const data = await response.json();
+
+          if (data.status === 'OK') {
+            const parsed = toRecordArray(data.results)
+              .slice(0, 5)
+              .map((r) => ({
+                place_id: isString(r.place_id) ? r.place_id : '',
+                formatted_address: isString(r.formatted_address) ? r.formatted_address : '',
+              }))
+              .filter((r) => r.place_id && r.formatted_address);
+            setResults(parsed);
+          } else {
+            setResults([]);
+          }
+        } catch (err) {
+          Sentry.captureException(err, {
+            tags: { feature: 'seasons', action: 'locationSearch' },
+          });
+          setResults([]);
+        } finally {
+          setIsSearching(false);
+        }
+      }, 400);
+
+      return () => clearTimeout(timer);
+    }, [query]);
+
+    const handleBack = () => {
+      setQuery('');
+      setResults([]);
+      onBack();
+    };
+
+    const handleSelect = (formattedAddress: string) => {
+      setQuery('');
+      setResults([]);
+      onLocationSelected(formattedAddress);
+    };
+
+    const getShortName = (address: string) => address.split(',')[0] ?? address;
+    const getSubtitle = (address: string) => {
+      const parts = address.split(',');
+      return parts.length > 1 ? parts.slice(1).join(',').trim() : '';
+    };
+
+    return (
+      <Sheet
+        ref={ref}
+        snapPoints={['85%']}
+        index={0}
+        enablePanDownToClose
+        onDismiss={onDismiss}
+        backgroundStyle={{ backgroundColor: colors.card }}
+        handleIndicatorStyle={{ backgroundColor: colors.grey2 }}
+      >
+        {/* Fixed header */}
+        <View>
+          <View className="flex-row items-center border-b border-border px-2 py-3">
+            <TouchableOpacity
+              className="flex-row items-center gap-0.5 px-3 py-1"
+              onPress={handleBack}
+              hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+            >
+              <Icon
+                namingScheme="sfSymbol"
+                name="chevron.left"
+                materialIcon={{ type: 'MaterialIcons', name: 'chevron-left' }}
+                size={18}
+                color={colors.primary}
+              />
+              <Text className="text-base text-primary">{t('common.back')}</Text>
+            </TouchableOpacity>
+
+            <View className="flex-1 items-center">
+              <Text variant="heading" className="font-semibold">
+                {t('seasons.searchLocationTitle')}
+              </Text>
+            </View>
+
+            {/* Mirror spacer for back button to keep title centered */}
+            <View className="w-20" />
+          </View>
+
+          {/* Search input */}
+          <View className="px-4 pb-2 pt-3">
+            <View
+              className="flex-row items-center gap-2 rounded-xl px-3"
+              style={{ backgroundColor: colors.grey6 }}
+            >
+              <Icon
+                namingScheme="sfSymbol"
+                name="magnifyingglass"
+                materialIcon={{ type: 'MaterialIcons', name: 'search' }}
+                size={16}
+                color={colors.grey}
+              />
+              <BottomSheetTextInput
+                autoFocus
+                value={query}
+                onChangeText={setQuery}
+                placeholder={t('seasons.searchLocationPlaceholder')}
+                placeholderTextColor={colors.grey}
+                returnKeyType="search"
+                style={{
+                  flex: 1,
+                  paddingVertical: 10,
+                  fontSize: 16,
+                  color: colors.foreground,
+                }}
+              />
+              {isSearching && <ActivityIndicator size="small" color={colors.grey} />}
+            </View>
+          </View>
+        </View>
+
+        {/* Scrollable results */}
+        <BottomSheetScrollView
+          keyboardShouldPersistTaps="handled"
+          contentContainerStyle={{ paddingBottom: insets.bottom + 20 }}
+        >
+          {query.trim().length >= 2 && !isSearching && results.length === 0 && (
+            <View className="items-center py-12">
+              <Text className="text-muted-foreground">{t('seasons.noLocationsFound')}</Text>
+            </View>
+          )}
+
+          {results.map((result) => (
+            <TouchableOpacity
+              key={result.place_id}
+              className="flex-row items-center gap-3 border-b border-border px-4 py-3.5"
+              onPress={() => handleSelect(result.formatted_address)}
+              activeOpacity={0.7}
+            >
+              <View
+                className="h-9 w-9 shrink-0 items-center justify-center rounded-full"
+                style={{ backgroundColor: `${colors.primary}15` }}
+              >
+                <Icon
+                  namingScheme="sfSymbol"
+                  name="mappin"
+                  materialIcon={{ type: 'MaterialIcons', name: 'location-on' }}
+                  size={16}
+                  color={colors.primary}
+                />
+              </View>
+              <View className="flex-1">
+                <Text variant="callout" className="font-medium" numberOfLines={1}>
+                  {getShortName(result.formatted_address)}
+                </Text>
+                {getSubtitle(result.formatted_address) ? (
+                  <Text variant="footnote" className="text-muted-foreground" numberOfLines={1}>
+                    {getSubtitle(result.formatted_address)}
+                  </Text>
+                ) : null}
+              </View>
+            </TouchableOpacity>
+          ))}
+        </BottomSheetScrollView>
+      </Sheet>
+    );
+  },
+);

--- a/apps/expo/features/packs/components/LocationSearchSheet.tsx
+++ b/apps/expo/features/packs/components/LocationSearchSheet.tsx
@@ -189,14 +189,14 @@ export const LocationSearchSheet = React.forwardRef<BottomSheetModal, LocationSe
             >
               <View
                 className="h-9 w-9 shrink-0 items-center justify-center rounded-full"
-                style={{ backgroundColor: `${colors.primary}15` }}
+                style={{ backgroundColor: colors.grey5 }}
               >
                 <Icon
                   namingScheme="sfSymbol"
                   name="mappin"
                   materialIcon={{ type: 'MaterialIcons', name: 'location-on' }}
                   size={16}
-                  color={colors.primary}
+                  color={colors.grey2}
                 />
               </View>
               <View className="flex-1">

--- a/apps/expo/features/packs/components/LocationSourceSheet.tsx
+++ b/apps/expo/features/packs/components/LocationSourceSheet.tsx
@@ -1,0 +1,82 @@
+import type { BottomSheetModal } from '@gorhom/bottom-sheet';
+import { BottomSheetView } from '@gorhom/bottom-sheet';
+import { Sheet, Text } from '@packrat/ui/nativewindui';
+import { Icon } from 'expo-app/components/Icon';
+import { useColorScheme } from 'expo-app/lib/hooks/useColorScheme';
+import { useTranslation } from 'expo-app/lib/hooks/useTranslation';
+import * as React from 'react';
+import { TouchableOpacity, View } from 'react-native';
+
+interface LocationSourceSheetProps {
+  onSearchPress: () => void;
+  onCurrentLocationPress: () => void;
+  onDismiss?: () => void;
+}
+
+export const LocationSourceSheet = React.forwardRef<BottomSheetModal, LocationSourceSheetProps>(
+  function LocationSourceSheet({ onSearchPress, onCurrentLocationPress, onDismiss }, ref) {
+    const { colors } = useColorScheme();
+    const { t } = useTranslation();
+
+    return (
+      <Sheet
+        ref={ref}
+        enableDynamicSizing
+        enablePanDownToClose
+        onDismiss={onDismiss}
+        backgroundStyle={{ backgroundColor: colors.card }}
+        handleIndicatorStyle={{ backgroundColor: colors.grey2 }}
+      >
+        <BottomSheetView className="px-6 pb-12 pt-4">
+          <Text variant="title3" className="mb-2 text-center font-semibold">
+            {t('seasons.chooseLocation')}
+          </Text>
+          <Text variant="subhead" className="mb-10 text-center text-muted-foreground">
+            {t('seasons.chooseLocationDescription')}
+          </Text>
+
+          <View className="flex-row justify-center gap-12">
+            <View className="items-center gap-3">
+              <TouchableOpacity
+                className="h-24 w-24 items-center justify-center rounded-full bg-secondary"
+                onPress={onSearchPress}
+                activeOpacity={0.7}
+              >
+                <Icon
+                  namingScheme="sfSymbol"
+                  name="magnifyingglass"
+                  materialIcon={{ type: 'MaterialIcons', name: 'search' }}
+                  size={32}
+                  color={colors.foreground}
+                />
+              </TouchableOpacity>
+              <Text variant="subhead" className="text-center font-medium">
+                {t('common.search')}
+              </Text>
+            </View>
+
+            <View className="items-center gap-3">
+              <TouchableOpacity
+                className="h-24 w-24 items-center justify-center rounded-full"
+                style={{ backgroundColor: `${colors.primary}1A` }}
+                onPress={onCurrentLocationPress}
+                activeOpacity={0.7}
+              >
+                <Icon
+                  namingScheme="sfSymbol"
+                  name="location.fill"
+                  materialIcon={{ type: 'MaterialIcons', name: 'my-location' }}
+                  size={32}
+                  color={colors.primary}
+                />
+              </TouchableOpacity>
+              <Text variant="subhead" className="max-w-24 text-center font-medium">
+                {t('seasons.useCurrentLocation')}
+              </Text>
+            </View>
+          </View>
+        </BottomSheetView>
+      </Sheet>
+    );
+  },
+);

--- a/apps/expo/features/packs/components/LocationSourceSheet.tsx
+++ b/apps/expo/features/packs/components/LocationSourceSheet.tsx
@@ -38,7 +38,8 @@ export const LocationSourceSheet = React.forwardRef<BottomSheetModal, LocationSo
           <View className="flex-row justify-center gap-12">
             <View className="items-center gap-3">
               <TouchableOpacity
-                className="h-24 w-24 items-center justify-center rounded-full bg-secondary"
+                className="h-24 w-24 items-center justify-center rounded-full"
+                style={{ backgroundColor: colors.grey6 }}
                 onPress={onSearchPress}
                 activeOpacity={0.7}
               >
@@ -46,8 +47,8 @@ export const LocationSourceSheet = React.forwardRef<BottomSheetModal, LocationSo
                   namingScheme="sfSymbol"
                   name="magnifyingglass"
                   materialIcon={{ type: 'MaterialIcons', name: 'search' }}
-                  size={32}
-                  color={colors.foreground}
+                  size={30}
+                  color={colors.grey}
                 />
               </TouchableOpacity>
               <Text variant="subhead" className="text-center font-medium">
@@ -58,7 +59,7 @@ export const LocationSourceSheet = React.forwardRef<BottomSheetModal, LocationSo
             <View className="items-center gap-3">
               <TouchableOpacity
                 className="h-24 w-24 items-center justify-center rounded-full"
-                style={{ backgroundColor: `${colors.primary}1A` }}
+                style={{ backgroundColor: colors.grey6 }}
                 onPress={onCurrentLocationPress}
                 activeOpacity={0.7}
               >
@@ -66,8 +67,8 @@ export const LocationSourceSheet = React.forwardRef<BottomSheetModal, LocationSo
                   namingScheme="sfSymbol"
                   name="location.fill"
                   materialIcon={{ type: 'MaterialIcons', name: 'my-location' }}
-                  size={32}
-                  color={colors.primary}
+                  size={30}
+                  color={colors.grey}
                 />
               </TouchableOpacity>
               <Text variant="subhead" className="max-w-24 text-center font-medium">

--- a/apps/expo/features/packs/components/LocationSourceSheet.tsx
+++ b/apps/expo/features/packs/components/LocationSourceSheet.tsx
@@ -39,16 +39,20 @@ export const LocationSourceSheet = React.forwardRef<BottomSheetModal, LocationSo
             <View className="items-center gap-3">
               <TouchableOpacity
                 className="h-24 w-24 items-center justify-center rounded-full"
-                style={{ backgroundColor: colors.grey6 }}
+                style={{
+                  backgroundColor: colors.grey6,
+                  borderWidth: 1.5,
+                  borderColor: colors.grey4,
+                }}
                 onPress={onSearchPress}
-                activeOpacity={0.7}
+                activeOpacity={0.65}
               >
                 <Icon
                   namingScheme="sfSymbol"
                   name="magnifyingglass"
                   materialIcon={{ type: 'MaterialIcons', name: 'search' }}
                   size={30}
-                  color={colors.grey}
+                  color={colors.grey2}
                 />
               </TouchableOpacity>
               <Text variant="subhead" className="text-center font-medium">
@@ -59,16 +63,20 @@ export const LocationSourceSheet = React.forwardRef<BottomSheetModal, LocationSo
             <View className="items-center gap-3">
               <TouchableOpacity
                 className="h-24 w-24 items-center justify-center rounded-full"
-                style={{ backgroundColor: colors.grey6 }}
+                style={{
+                  backgroundColor: colors.grey6,
+                  borderWidth: 1.5,
+                  borderColor: colors.grey4,
+                }}
                 onPress={onCurrentLocationPress}
-                activeOpacity={0.7}
+                activeOpacity={0.65}
               >
                 <Icon
                   namingScheme="sfSymbol"
                   name="location.fill"
                   materialIcon={{ type: 'MaterialIcons', name: 'my-location' }}
                   size={30}
-                  color={colors.grey}
+                  color={colors.grey2}
                 />
               </TouchableOpacity>
               <Text variant="subhead" className="max-w-24 text-center font-medium">

--- a/apps/expo/features/packs/components/LocationSourceSheet.tsx
+++ b/apps/expo/features/packs/components/LocationSourceSheet.tsx
@@ -27,23 +27,12 @@ export const LocationSourceSheet = React.forwardRef<BottomSheetModal, LocationSo
         backgroundStyle={{ backgroundColor: colors.card }}
         handleIndicatorStyle={{ backgroundColor: colors.grey2 }}
       >
-        <BottomSheetView className="px-6 pb-12 pt-4">
-          <Text variant="title3" className="mb-2 text-center font-semibold">
-            {t('seasons.chooseLocation')}
-          </Text>
-          <Text variant="subhead" className="mb-10 text-center text-muted-foreground">
-            {t('seasons.chooseLocationDescription')}
-          </Text>
-
-          <View className="flex-row justify-center gap-12">
-            <View className="items-center gap-3">
+        <BottomSheetView className="px-6 pb-14 pt-6">
+          <View className="flex-row justify-center gap-10">
+            <View className="items-center gap-4">
               <TouchableOpacity
-                className="h-24 w-24 items-center justify-center rounded-full"
-                style={{
-                  backgroundColor: colors.grey6,
-                  borderWidth: 1.5,
-                  borderColor: colors.grey4,
-                }}
+                className="h-32 w-32 items-center justify-center rounded-full"
+                style={{ backgroundColor: colors.grey6 }}
                 onPress={onSearchPress}
                 activeOpacity={0.65}
               >
@@ -51,7 +40,7 @@ export const LocationSourceSheet = React.forwardRef<BottomSheetModal, LocationSo
                   namingScheme="sfSymbol"
                   name="magnifyingglass"
                   materialIcon={{ type: 'MaterialIcons', name: 'search' }}
-                  size={30}
+                  size={38}
                   color={colors.grey2}
                 />
               </TouchableOpacity>
@@ -60,14 +49,10 @@ export const LocationSourceSheet = React.forwardRef<BottomSheetModal, LocationSo
               </Text>
             </View>
 
-            <View className="items-center gap-3">
+            <View className="items-center gap-4">
               <TouchableOpacity
-                className="h-24 w-24 items-center justify-center rounded-full"
-                style={{
-                  backgroundColor: colors.grey6,
-                  borderWidth: 1.5,
-                  borderColor: colors.grey4,
-                }}
+                className="h-32 w-32 items-center justify-center rounded-full"
+                style={{ backgroundColor: colors.grey6 }}
                 onPress={onCurrentLocationPress}
                 activeOpacity={0.65}
               >
@@ -75,11 +60,11 @@ export const LocationSourceSheet = React.forwardRef<BottomSheetModal, LocationSo
                   namingScheme="sfSymbol"
                   name="location.fill"
                   materialIcon={{ type: 'MaterialIcons', name: 'my-location' }}
-                  size={30}
+                  size={38}
                   color={colors.grey2}
                 />
               </TouchableOpacity>
-              <Text variant="subhead" className="max-w-24 text-center font-medium">
+              <Text variant="subhead" className="max-w-28 text-center font-medium">
                 {t('seasons.useCurrentLocation')}
               </Text>
             </View>

--- a/apps/expo/features/packs/components/LocationSourceSheet.tsx
+++ b/apps/expo/features/packs/components/LocationSourceSheet.tsx
@@ -27,12 +27,19 @@ export const LocationSourceSheet = React.forwardRef<BottomSheetModal, LocationSo
         backgroundStyle={{ backgroundColor: colors.card }}
         handleIndicatorStyle={{ backgroundColor: colors.grey2 }}
       >
-        <BottomSheetView className="px-6 pb-14 pt-6">
+        <BottomSheetView className="px-6 pb-14 pt-4">
+          <Text variant="title3" className="mb-2 text-center font-semibold">
+            {t('seasons.chooseLocation')}
+          </Text>
+          <Text variant="subhead" className="mb-10 text-center text-muted-foreground">
+            {t('seasons.chooseLocationDescription')}
+          </Text>
+
           <View className="flex-row justify-center gap-10">
             <View className="items-center gap-4">
               <TouchableOpacity
                 className="h-32 w-32 items-center justify-center rounded-full"
-                style={{ backgroundColor: colors.grey6 }}
+                style={{ backgroundColor: colors.grey5 }}
                 onPress={onSearchPress}
                 activeOpacity={0.65}
               >
@@ -52,7 +59,7 @@ export const LocationSourceSheet = React.forwardRef<BottomSheetModal, LocationSo
             <View className="items-center gap-4">
               <TouchableOpacity
                 className="h-32 w-32 items-center justify-center rounded-full"
-                style={{ backgroundColor: colors.grey6 }}
+                style={{ backgroundColor: colors.grey5 }}
                 onPress={onCurrentLocationPress}
                 activeOpacity={0.65}
               >
@@ -65,7 +72,7 @@ export const LocationSourceSheet = React.forwardRef<BottomSheetModal, LocationSo
                 />
               </TouchableOpacity>
               <Text variant="subhead" className="max-w-28 text-center font-medium">
-                {t('seasons.useCurrentLocation')}
+                {t('weather.useCurrentLocation')}
               </Text>
             </View>
           </View>

--- a/apps/expo/features/packs/hooks/useSeasonSuggestions.ts
+++ b/apps/expo/features/packs/hooks/useSeasonSuggestions.ts
@@ -23,12 +23,14 @@ export interface SeasonSuggestionsResponse {
 }
 
 export class SeasonSuggestionsError extends Error {
-  constructor(
-    public readonly httpStatus: number,
-    public readonly serverMessage: string,
-  ) {
+  readonly httpStatus: number;
+  readonly serverMessage: string;
+
+  constructor({ httpStatus, serverMessage }: { httpStatus: number; serverMessage: string }) {
     super(serverMessage);
     this.name = 'SeasonSuggestionsError';
+    this.httpStatus = httpStatus;
+    this.serverMessage = serverMessage;
   }
 }
 
@@ -47,7 +49,7 @@ const generateSeasonSuggestions = async (
   if (error) {
     const httpStatus = error.status ?? 500;
     const serverMessage = extractServerMessage(error.value);
-    const err = new SeasonSuggestionsError(httpStatus, serverMessage);
+    const err = new SeasonSuggestionsError({ httpStatus, serverMessage });
     Sentry.captureException(err, {
       tags: { feature: 'packs', action: 'generateSeasonSuggestions' },
       extra: {

--- a/apps/expo/features/packs/hooks/useSeasonSuggestions.ts
+++ b/apps/expo/features/packs/hooks/useSeasonSuggestions.ts
@@ -1,3 +1,4 @@
+import { isString, toRecord } from '@packrat/guards';
 import * as Sentry from '@sentry/react-native';
 import { useMutation } from '@tanstack/react-query';
 import { apiClient } from 'expo-app/lib/api/packrat';
@@ -21,19 +22,39 @@ export interface SeasonSuggestionsResponse {
   season: string;
 }
 
+export class SeasonSuggestionsError extends Error {
+  constructor(
+    public readonly httpStatus: number,
+    public readonly serverMessage: string,
+  ) {
+    super(serverMessage);
+    this.name = 'SeasonSuggestionsError';
+  }
+}
+
+function extractServerMessage(value: unknown): string {
+  if (isString(value)) return value;
+  const rec = toRecord(value);
+  if (isString(rec.error)) return rec.error;
+  if (isString(rec.message)) return rec.message;
+  return 'Failed to generate season suggestions';
+}
+
 const generateSeasonSuggestions = async (
   data: SeasonSuggestionsRequest,
 ): Promise<SeasonSuggestionsResponse> => {
   const { data: result, error } = await apiClient['season-suggestions'].post(data);
   if (error) {
-    const err = new Error(String(error.value ?? 'Failed to generate season suggestions'));
+    const httpStatus = error.status ?? 500;
+    const serverMessage = extractServerMessage(error.value);
+    const err = new SeasonSuggestionsError(httpStatus, serverMessage);
     Sentry.captureException(err, {
       tags: { feature: 'packs', action: 'generateSeasonSuggestions' },
       extra: {
         location: data.location,
         date: data.date,
-        apiError: error.value,
-        httpStatus: error.status,
+        httpStatus,
+        serverMessage,
       },
     });
     throw err;

--- a/apps/expo/lib/i18n/locales/en.json
+++ b/apps/expo/lib/i18n/locales/en.json
@@ -905,7 +905,6 @@
     "maybeLater": "Maybe later",
     "chooseLocation": "Choose Location",
     "chooseLocationDescription": "How would you like to set the location for your season suggestions?",
-    "useCurrentLocation": "Use Current Location",
     "searchLocationTitle": "Search Location",
     "searchLocationPlaceholder": "Search a city or location...",
     "noLocationsFound": "No locations found"

--- a/apps/expo/lib/i18n/locales/en.json
+++ b/apps/expo/lib/i18n/locales/en.json
@@ -902,7 +902,13 @@
     "unlockTitle": "Season Suggestions Unlocked",
     "unlockDescription": "You've built up a solid gear inventory. PackRat can now suggest what to pack based on the current season and your location — powered by AI.",
     "explore": "Explore",
-    "maybeLater": "Maybe later"
+    "maybeLater": "Maybe later",
+    "chooseLocation": "Choose Location",
+    "chooseLocationDescription": "How would you like to set the location for your season suggestions?",
+    "useCurrentLocation": "Use Current Location",
+    "searchLocationTitle": "Search Location",
+    "searchLocationPlaceholder": "Search a city or location...",
+    "noLocationsFound": "No locations found"
   },
   "experience": {
     "beginner": "Beginner",

--- a/apps/expo/lib/i18n/locales/en.json
+++ b/apps/expo/lib/i18n/locales/en.json
@@ -907,7 +907,21 @@
     "chooseLocationDescription": "How would you like to set the location for your season suggestions?",
     "searchLocationTitle": "Search Location",
     "searchLocationPlaceholder": "Search a city or location...",
-    "noLocationsFound": "No locations found"
+    "noLocationsFound": "No locations found",
+    "errorNotEnoughGearTitle": "Not enough gear yet",
+    "errorNotEnoughGearBody": "You need at least 20 items in your inventory before PackRat can suggest seasonal packs. Add more gear, then come back.",
+    "errorNotEnoughGearAction": "Go to Inventory",
+    "errorSessionTitle": "Session expired",
+    "errorSessionBody": "Your session has expired. Sign back in and try again.",
+    "errorSessionAction": "Sign In",
+    "errorNetworkTitle": "No internet connection",
+    "errorNetworkBody": "Check your connection and try again.",
+    "errorAiTitle": "Suggestions unavailable right now",
+    "errorAiBody": "Our AI couldn't process your request. This usually resolves quickly — try again in a moment.",
+    "errorGenericTitle": "Something went wrong",
+    "errorGenericBody": "We couldn't generate your suggestions. Try again or go back and pick a different location.",
+    "tryAgain": "Try Again",
+    "goBack": "Go Back"
   },
   "experience": {
     "beginner": "Beginner",


### PR DESCRIPTION
## Summary

- Tapping **Generate Season Suggestions** now opens a bottom sheet with two large circular icon buttons: **Search** and **Use Current Location**
- **Use Current Location** continues the existing GPS/permission flow unchanged
- **Search** slides in a tall (85%) bottom sheet with a centered title header, a back button on the left, and an auto-focused search bar
- The search bar debounces input (400 ms) and calls the Google Maps Geocoding API to return up to 5 real location results, each shown as a two-line row (city name + region/country)
- Tapping a result dismisses both sheets and navigates straight to the season suggestions results screen
- Back button in the search sheet re-presents the source picker sheet
- Falls back to echoing the typed text as a single result when no Google Maps API key is configured

## New files

- `features/packs/components/LocationSourceSheet.tsx` — two-button source picker sheet
- `features/packs/components/LocationSearchSheet.tsx` — search sheet with geocoding

## Test plan

- [ ] Tap "Generate Season Suggestions" → source picker sheet appears with Search + Use Current Location buttons
- [ ] Tap "Use Current Location" → existing permission/GPS flow runs as before
- [ ] Tap "Search" → source sheet dismisses, search sheet slides up with keyboard open
- [ ] Type a city → results appear after ~400 ms; each shows city name + region
- [ ] Tap a result → both sheets close, results screen loads for that location
- [ ] Tap back in search sheet → source picker re-appears
- [ ] Swipe down on either sheet to dismiss

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Choose location via a two-step bottom-sheet flow (search or use current location); generate button opens the chooser
  * Location search with geocoding results and selectable rows; permission-gated current-location path requests foreground permission and alerts on denial
  * Always supplies current date when navigating to results

* **Bug Fixes / UX**
  * Improved error handling and user-facing error screens with retry/go-back actions; updated header location icon

* **Documentation**
  * Added locale strings for new location flow and expanded error messages
<!-- end of auto-generated comment: release notes by coderabbit.ai -->