### PR TITLE
fix(packs): include full item list in share message

### DIFF
--- a/apps/expo/features/packs/screens/PackDetailScreen.tsx
+++ b/apps/expo/features/packs/screens/PackDetailScreen.tsx
@@ -296,10 +296,34 @@ export function PackDetailScreen() {
   };
   const handleSharePack = async () => {
     try {
-      const lines: string[] = [`${pack.name}`];
+      const lines: string[] = [pack.name];
       if (pack.category) lines.push(pack.category);
       if (pack.description) lines.push(`\n${pack.description}`);
       lines.push(`\n${pack.items?.length || 0} items · ${pack.totalWeight || 0}g`);
+
+      const items = pack.items ?? [];
+      if (items.length > 0) {
+        const byCategory = items.reduce<Record<string, typeof items>>((acc, item) => {
+          const cat = item.category || 'Other';
+          if (!acc[cat]) acc[cat] = [];
+          acc[cat].push(item);
+          return acc;
+        }, {});
+
+        for (const [cat, catItems] of Object.entries(byCategory)) {
+          lines.push(`\n${cat}`);
+          for (const item of catItems) {
+            const flags = [item.worn && 'worn', item.consumable && 'consumable']
+              .filter(Boolean)
+              .join(', ');
+            const flagSuffix = flags ? ` (${flags})` : '';
+            lines.push(
+              `  • ${item.quantity}x ${item.name} — ${item.weight}${item.weightUnit}${flagSuffix}`,
+            );
+          }
+        }
+      }
+
       await Share.share({ message: lines.join('\n') });
     } catch {
       // ignore


### PR DESCRIPTION
## Summary

Fixes #2586 — pack sharing via WhatsApp (or any platform) now includes the complete item list instead of just the pack name and item count.

**Before:** shared message contained only the pack name, category, description, and a total `N items · Xg` line.

**After:** shared message also includes every item grouped by category, with quantity, weight (`weightUnit`), and optional `(worn)` / `(consumable)` flags.

Example output:
```
Weekend Hiking Pack
Hiking

2 items · 1450g

Clothing
  • 1x Rain Jacket — 400g (worn)

Shelter
  • 1x Tent — 1050g
```

## Test plan

- [ ] Open any pack with multiple items (across different categories, some marked worn/consumable)
- [ ] Tap Share → choose WhatsApp (or Messages, Notes, etc.)
- [ ] Confirm the shared text includes the full item list grouped by category with weights
- [ ] Confirm packs with no items still share correctly (just name + summary line)