### PR TITLE
fix(pack-templates): remove AI chat button from template item detail

### DIFF
--- a/apps/expo/features/pack-templates/screens/PackTemplateItemDetailScreen.tsx
+++ b/apps/expo/features/pack-templates/screens/PackTemplateItemDetailScreen.tsx
@@ -1,6 +1,5 @@
 import { assertDefined } from '@packrat/guards';
-import { Button, Text, useColorScheme } from '@packrat/ui/nativewindui';
-import { Icon } from 'expo-app/components/Icon';
+import { Text } from '@packrat/ui/nativewindui';
 import { Chip } from 'expo-app/components/initial/Chip';
 import { WeightBadge } from 'expo-app/components/initial/WeightBadge';
 import { useTranslation } from 'expo-app/lib/hooks/useTranslation';
@@ -13,14 +12,13 @@ import {
   isWorn,
   shouldShowQuantity,
 } from 'expo-app/lib/utils/itemCalculations';
-import { router, useLocalSearchParams } from 'expo-router';
+import { useLocalSearchParams } from 'expo-router';
 import { Platform, ScrollView, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { PackTemplateItemImage } from '../components/PackTemplateItemImage';
 import { usePackTemplateItem } from '../hooks/usePackTemplateItem';
 
 export function PackTemplateItemDetailScreen() {
-  const { colors } = useColorScheme();
   const { t } = useTranslation();
 
   const { id } = useLocalSearchParams<{ id: string }>();
@@ -37,17 +35,6 @@ export function PackTemplateItemDetailScreen() {
   const isItemWorn = isWorn(item);
   const itemHasNotes = hasNotes(item);
   const itemNotes = getNotes(item);
-
-  const navigateToChat = () => {
-    router.push({
-      pathname: '/ai-chat',
-      params: {
-        itemId: item.id,
-        itemName: item.name,
-        contextType: 'templateItem',
-      },
-    });
-  };
 
   return (
     <SafeAreaView className="flex-1 bg-background">
@@ -120,17 +107,6 @@ export function PackTemplateItemDetailScreen() {
               <Text className="text-foreground">{itemNotes}</Text>
             </View>
           )}
-        </View>
-
-        <View className="pb-16 mt-4 px-4">
-          <Button
-            variant="secondary"
-            onPress={navigateToChat}
-            className="flex-row items-center justify-center rounded-full px-4 py-3"
-          >
-            <Icon name="message-outline" size={20} color={colors.foreground} />
-            <Text className="ml-2 font-semibold">{t('packTemplates.askAIAboutItem')}</Text>
-          </Button>
         </View>
       </ScrollView>
     </SafeAreaView>

--- a/apps/expo/lib/i18n/locales/en.json
+++ b/apps/expo/lib/i18n/locales/en.json
@@ -1009,7 +1009,6 @@
     "weightEach": "WEIGHT (EACH)",
     "quantity": "QUANTITY",
     "notes": "NOTES",
-    "askAIAboutItem": "Ask AI About This Item",
     "addManually": "Add Manually",
     "scanItemsFromPhoto": "Scan Items from Photo",
     "addFromCatalog": "Add from Catalog",


### PR DESCRIPTION
## Summary

- Removes the broken "Ask AI About This Item" button from `PackTemplateItemDetailScreen` — it opened a generic chat with no item context, making it misleading and non-functional
- Removes the `packTemplates.askAIAboutItem` i18n key since it is now unused
- Cleans up related imports (`Icon`, `useColorScheme`, `router`) that were only needed for the chat button

## Related

Closes #2588

## Test plan

- [ ] Open any pack template → tap an item → confirm no AI chat button appears on the item detail screen
- [ ] Verify all other item detail info (name, weight, quantity, badges, notes) still renders correctly