### PR TITLE
feat(gap-analysis): larger overlay qty controls with container-transform transition

### DIFF
--- a/apps/expo/features/packs/components/GapSuggestionRow.tsx
+++ b/apps/expo/features/packs/components/GapSuggestionRow.tsx
@@ -17,6 +17,7 @@ import Animated, {
   useSharedValue,
   withRepeat,
   withTiming,
+  ZoomIn,
 } from 'react-native-reanimated';
 import type { GapAnalysisItem } from '../hooks/usePackGapAnalysis';
 
@@ -155,9 +156,10 @@ export function GapSuggestionRow({
     opacity: interpolate(controlsProgress.value, [0, 0.5, 1], [0, 0, 1]),
   }));
 
-  // Pill padding breathes slightly wider when controls are open
+  // Pill padding breathes wider + taller when controls are open
   const pillPaddingStyle = useAnimatedStyle(() => ({
     paddingHorizontal: interpolate(controlsProgress.value, [0, 1], [10, 14]),
+    paddingVertical: interpolate(controlsProgress.value, [0, 1], [5, 8]),
   }));
 
   useEffect(() => {
@@ -279,128 +281,33 @@ export function GapSuggestionRow({
                 </View>
               </View>
 
-              {/* Right side: base row always rendered; overlay morphs in on top */}
-              <View
-                style={{
-                  width: 104,
-                  minHeight: 34,
-                  alignItems: 'flex-end',
-                  justifyContent: 'center',
-                  position: 'relative',
-                }}
-              >
-                {/* Base row — always in flow */}
-                <View
-                  style={{
-                    flexDirection: 'row',
-                    alignItems: 'center',
-                    gap: 8,
-                  }}
+              {/* Right side: Swap + single morphing pill (no layout shift — fixed slot) */}
+              <View style={{ flexDirection: 'row', alignItems: 'center', gap: 8 }}>
+                <ScalePress
+                  onPress={onSwapPress}
+                  hitSlop={{ top: 8, bottom: 8, left: 8, right: 6 }}
                 >
-                  <ScalePress
-                    onPress={onSwapPress}
-                    hitSlop={{ top: 8, bottom: 8, left: 8, right: 6 }}
-                  >
-                    <Text
-                      style={{
-                        fontSize: 13,
-                        fontWeight: '600',
-                        color: colors.grey,
-                      }}
-                    >
-                      Swap
-                    </Text>
-                  </ScalePress>
+                  <Text style={{ fontSize: 13, fontWeight: '600', color: colors.grey }}>Swap</Text>
+                </ScalePress>
 
+                {/* Fixed-width slot reserves space so pill growth doesn't shift the row */}
+                <View style={{ width: 120, alignItems: 'flex-end', justifyContent: 'center' }}>
                   {selected ? (
                     <Animated.View
-                      key="compact-pill"
-                      entering={FadeIn.duration(180)}
-                      exiting={FadeOut.duration(120)}
-                    >
-                      <ScalePress
-                        onPress={handleQtyPillPress}
-                        hitSlop={{ top: 8, bottom: 8, left: 4, right: 10 }}
-                      >
-                        <View
-                          style={{
-                            backgroundColor: colors.primary,
-                            borderRadius: 100,
-                            paddingHorizontal: 10,
-                            paddingVertical: 5,
-                            minWidth: 30,
-                            alignItems: 'center',
-                          }}
-                        >
-                          <Text
-                            style={{
-                              fontSize: 13,
-                              fontWeight: '700',
-                              color: '#fff',
-                              lineHeight: 16,
-                            }}
-                          >
-                            {quantity}
-                          </Text>
-                        </View>
-                      </ScalePress>
-                    </Animated.View>
-                  ) : (
-                    <Animated.View
-                      key="add"
-                      entering={FadeIn.duration(180)}
-                      exiting={FadeOut.duration(120)}
-                    >
-                      <ScalePress
-                        onPress={() => displayItem && handleAdd(displayItem)}
-                        hitSlop={{ top: 8, bottom: 8, left: 8, right: 10 }}
-                      >
-                        <Text
-                          style={{
-                            fontSize: 13,
-                            fontWeight: '600',
-                            color: colors.primary,
-                          }}
-                        >
-                          Add
-                        </Text>
-                      </ScalePress>
-                    </Animated.View>
-                  )}
-                </View>
-
-                {/* Morphing expanded pill — covers base row while controls are open.
-                  No Pressable wrapper; minus/qty/plus are sibling Pressables inside. */}
-                {selected && showControls && (
-                  <Animated.View
-                    key="expanded-pill"
-                    entering={FadeIn.duration(120)}
-                    exiting={FadeOut.duration(180)}
-                    style={{
-                      position: 'absolute',
-                      left: 0,
-                      right: 0,
-                      top: 0,
-                      bottom: 0,
-                      justifyContent: 'center',
-                      alignItems: 'flex-end',
-                      zIndex: 10,
-                      backgroundColor: colors.background,
-                    }}
-                  >
-                    <Animated.View
+                      key="pill"
+                      entering={ZoomIn.springify().damping(18).stiffness(220)}
+                      exiting={FadeOut.duration(150)}
                       style={[
                         {
                           flexDirection: 'row',
                           alignItems: 'center',
                           backgroundColor: colors.primary,
                           borderRadius: 100,
-                          paddingVertical: 8,
                         },
                         pillPaddingStyle,
                       ]}
                     >
-                      {/* Minus — grows from left outer edge inward */}
+                      {/* Minus — expands from left as controls open */}
                       <Animated.View
                         style={[{ overflow: 'hidden', alignItems: 'flex-start' }, iconWrapStyle]}
                       >
@@ -431,7 +338,7 @@ export function GapSuggestionRow({
                         </Text>
                       </Pressable>
 
-                      {/* Plus — grows from right outer edge inward */}
+                      {/* Plus — expands from right as controls open */}
                       <Animated.View
                         style={[{ overflow: 'hidden', alignItems: 'flex-end' }, iconWrapStyle]}
                       >
@@ -443,8 +350,23 @@ export function GapSuggestionRow({
                         </Pressable>
                       </Animated.View>
                     </Animated.View>
-                  </Animated.View>
-                )}
+                  ) : (
+                    <Animated.View
+                      key="add"
+                      entering={FadeIn.duration(180)}
+                      exiting={FadeOut.duration(120)}
+                    >
+                      <ScalePress
+                        onPress={() => displayItem && handleAdd(displayItem)}
+                        hitSlop={{ top: 8, bottom: 8, left: 8, right: 10 }}
+                      >
+                        <Text style={{ fontSize: 13, fontWeight: '600', color: colors.primary }}>
+                          Add
+                        </Text>
+                      </ScalePress>
+                    </Animated.View>
+                  )}
+                </View>
               </View>
             </>
           ) : (

--- a/apps/expo/features/packs/components/GapSuggestionRow.tsx
+++ b/apps/expo/features/packs/components/GapSuggestionRow.tsx
@@ -17,7 +17,6 @@ import Animated, {
   useSharedValue,
   withRepeat,
   withTiming,
-  ZoomIn,
 } from 'react-native-reanimated';
 import type { GapAnalysisItem } from '../hooks/usePackGapAnalysis';
 
@@ -281,22 +280,97 @@ export function GapSuggestionRow({
                 </View>
               </View>
 
-              {/* Right side: Swap + single morphing pill (no layout shift — fixed slot) */}
-              <View style={{ flexDirection: 'row', alignItems: 'center', gap: 8 }}>
-                <ScalePress
-                  onPress={onSwapPress}
-                  hitSlop={{ top: 8, bottom: 8, left: 8, right: 6 }}
-                >
-                  <Text style={{ fontSize: 13, fontWeight: '600', color: colors.grey }}>Swap</Text>
-                </ScalePress>
+              {/* Right side: base row always in flow; overlay morphs in on top */}
+              <View
+                style={{
+                  width: 120,
+                  minHeight: 34,
+                  alignItems: 'flex-end',
+                  justifyContent: 'center',
+                  position: 'relative',
+                }}
+              >
+                {/* Base row */}
+                <View style={{ flexDirection: 'row', alignItems: 'center', gap: 8 }}>
+                  <ScalePress
+                    onPress={onSwapPress}
+                    hitSlop={{ top: 8, bottom: 8, left: 8, right: 6 }}
+                  >
+                    <Text style={{ fontSize: 13, fontWeight: '600', color: colors.grey }}>
+                      Swap
+                    </Text>
+                  </ScalePress>
 
-                {/* Fixed-width slot reserves space so pill growth doesn't shift the row */}
-                <View style={{ width: 120, alignItems: 'flex-end', justifyContent: 'center' }}>
                   {selected ? (
                     <Animated.View
-                      key="pill"
-                      entering={ZoomIn.springify().damping(18).stiffness(220)}
-                      exiting={FadeOut.duration(150)}
+                      key="compact-pill"
+                      entering={FadeIn.duration(180)}
+                      exiting={FadeOut.duration(120)}
+                    >
+                      <ScalePress
+                        onPress={handleQtyPillPress}
+                        hitSlop={{ top: 8, bottom: 8, left: 4, right: 10 }}
+                      >
+                        <View
+                          style={{
+                            backgroundColor: colors.primary,
+                            borderRadius: 100,
+                            paddingHorizontal: 10,
+                            paddingVertical: 5,
+                            minWidth: 30,
+                            alignItems: 'center',
+                          }}
+                        >
+                          <Text
+                            style={{
+                              fontSize: 13,
+                              fontWeight: '700',
+                              color: '#fff',
+                              lineHeight: 16,
+                            }}
+                          >
+                            {quantity}
+                          </Text>
+                        </View>
+                      </ScalePress>
+                    </Animated.View>
+                  ) : (
+                    <Animated.View
+                      key="add"
+                      entering={FadeIn.duration(180)}
+                      exiting={FadeOut.duration(120)}
+                    >
+                      <ScalePress
+                        onPress={() => displayItem && handleAdd(displayItem)}
+                        hitSlop={{ top: 8, bottom: 8, left: 8, right: 10 }}
+                      >
+                        <Text style={{ fontSize: 13, fontWeight: '600', color: colors.primary }}>
+                          Add
+                        </Text>
+                      </ScalePress>
+                    </Animated.View>
+                  )}
+                </View>
+
+                {/* Container-transform overlay — no entering animation so controlsProgress
+                    is the sole driver of the expansion; exiting fades out to reveal base row */}
+                {selected && showControls && (
+                  <Animated.View
+                    key="expanded-pill"
+                    exiting={FadeOut.duration(180)}
+                    style={{
+                      position: 'absolute',
+                      left: 0,
+                      right: 0,
+                      top: 0,
+                      bottom: 0,
+                      justifyContent: 'center',
+                      alignItems: 'flex-end',
+                      zIndex: 10,
+                      backgroundColor: colors.background,
+                    }}
+                  >
+                    <Animated.View
                       style={[
                         {
                           flexDirection: 'row',
@@ -307,7 +381,7 @@ export function GapSuggestionRow({
                         pillPaddingStyle,
                       ]}
                     >
-                      {/* Minus — expands from left as controls open */}
+                      {/* Minus — grows from left outer edge inward */}
                       <Animated.View
                         style={[{ overflow: 'hidden', alignItems: 'flex-start' }, iconWrapStyle]}
                       >
@@ -338,7 +412,7 @@ export function GapSuggestionRow({
                         </Text>
                       </Pressable>
 
-                      {/* Plus — expands from right as controls open */}
+                      {/* Plus — grows from right outer edge inward */}
                       <Animated.View
                         style={[{ overflow: 'hidden', alignItems: 'flex-end' }, iconWrapStyle]}
                       >
@@ -350,23 +424,8 @@ export function GapSuggestionRow({
                         </Pressable>
                       </Animated.View>
                     </Animated.View>
-                  ) : (
-                    <Animated.View
-                      key="add"
-                      entering={FadeIn.duration(180)}
-                      exiting={FadeOut.duration(120)}
-                    >
-                      <ScalePress
-                        onPress={() => displayItem && handleAdd(displayItem)}
-                        hitSlop={{ top: 8, bottom: 8, left: 8, right: 10 }}
-                      >
-                        <Text style={{ fontSize: 13, fontWeight: '600', color: colors.primary }}>
-                          Add
-                        </Text>
-                      </ScalePress>
-                    </Animated.View>
-                  )}
-                </View>
+                  </Animated.View>
+                )}
               </View>
             </>
           ) : (

--- a/apps/expo/features/packs/components/GapSuggestionRow.tsx
+++ b/apps/expo/features/packs/components/GapSuggestionRow.tsx
@@ -149,15 +149,15 @@ export function GapSuggestionRow({
     });
   }, [showControls]);
 
-  // Icon slots grow from 0 → 28 and fade in after pill is half-open
+  // Icon slots grow from 0 → 36 and fade in after pill is half-open
   const iconWrapStyle = useAnimatedStyle(() => ({
-    width: interpolate(controlsProgress.value, [0, 1], [0, 28]),
+    width: interpolate(controlsProgress.value, [0, 1], [0, 36]),
     opacity: interpolate(controlsProgress.value, [0, 0.5, 1], [0, 0, 1]),
   }));
 
   // Pill padding breathes slightly wider when controls are open
   const pillPaddingStyle = useAnimatedStyle(() => ({
-    paddingHorizontal: interpolate(controlsProgress.value, [0, 1], [8, 10]),
+    paddingHorizontal: interpolate(controlsProgress.value, [0, 1], [10, 14]),
   }));
 
   useEffect(() => {
@@ -408,7 +408,7 @@ export function GapSuggestionRow({
                           onPress={handleDecrement}
                           hitSlop={{ top: 20, bottom: 20, left: 20, right: 8 }}
                         >
-                          <Icon name="minus" size={12} color="#fff" />
+                          <Icon name="minus" size={16} color="#fff" />
                         </Pressable>
                       </Animated.View>
 
@@ -419,12 +419,12 @@ export function GapSuggestionRow({
                       >
                         <Text
                           style={{
-                            fontSize: 13,
+                            fontSize: 16,
                             fontWeight: '700',
                             color: '#fff',
-                            minWidth: 16,
+                            minWidth: 20,
                             textAlign: 'center',
-                            lineHeight: 16,
+                            lineHeight: 20,
                           }}
                         >
                           {quantity}
@@ -439,7 +439,7 @@ export function GapSuggestionRow({
                           onPress={handleIncrement}
                           hitSlop={{ top: 20, bottom: 20, left: 8, right: 20 }}
                         >
-                          <Icon name="plus" size={12} color="#fff" />
+                          <Icon name="plus" size={16} color="#fff" />
                         </Pressable>
                       </Animated.View>
                     </Animated.View>


### PR DESCRIPTION
## Summary

- Enlarges the expanded quantity controls pill (icons 16px, icon slots 36px, font 16px, horizontal padding 10→14) — safe to make bigger since the expanded pill is an absolute overlay that doesn't affect layout
- Replaces the previous dual-fade swap (compact pill ↔ expanded overlay) with a container-transform animation: the overlay snaps in instantly and `controlsProgress` is the sole driver of the expansion, so there's no competing fade or spring bounce
- Compact qty pill retains its original small size; container width bumped 104→120 to fit the wider expanded pill without clipping
- Vertical padding on the expanded pill now also animates (5→8) alongside horizontal so the pill breathes in both axes during morph
- Exiting the controls (dismiss timer) uses `FadeOut` to smoothly reveal the compact pill underneath

## Test plan

- [ ] Tap **Add** on a gap suggestion — overlay should snap in and expand smoothly, no bounce or stagger
- [ ] With a qty pill visible, tap it — controls should morph open via the same expansion animation
- [ ] Tap −/+ to adjust quantity; dismiss timer should collapse controls back to compact pill with a fade
- [ ] Tap − down to 0 — item should deselect, revealing the Add button
- [ ] Verify no layout shift in the item row when controls open/close

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style & UI Improvements**
  * Enhanced expansion animation controls with improved layout spacing and timing
  * Increased icon and quantity text size for better visibility
  * Refined styling and layout in the expanded state interface

<!-- end of auto-generated comment: release notes by coderabbit.ai -->