### PR TITLE
feat(settings): weight and temperature unit preferences

### DIFF
--- a/apps/expo/app/(app)/_layout.tsx
+++ b/apps/expo/app/(app)/_layout.tsx
@@ -131,12 +131,7 @@ export default function AppLayout() {
             animation: 'slide_from_bottom',
           }}
         />
-        <Stack.Screen
-          name="weather/preview"
-          options={{
-            headerShown: false,
-          }}
-        />
+        <Stack.Screen name="weather/preview" />
         <Stack.Screen
           name="weather/[id]"
           options={{

--- a/apps/expo/app/(app)/ai-chat.tsx
+++ b/apps/expo/app/(app)/ai-chat.tsx
@@ -29,6 +29,8 @@ import {
   releaseLocalModel,
 } from 'expo-app/features/ai/lib/localModelManager';
 import { createLocalTools } from 'expo-app/features/ai/lib/tools';
+import { useTemperatureUnit } from 'expo-app/features/auth/hooks/useTemperatureUnit';
+import { useWeightUnit } from 'expo-app/features/auth/hooks/useWeightUnit';
 import { getPackItems, packItemsStore } from 'expo-app/features/packs/store/packItems';
 import { packsStore } from 'expo-app/features/packs/store/packs';
 import { useActiveLocation } from 'expo-app/features/weather/hooks';
@@ -160,11 +162,18 @@ export default function AIChat() {
     releaseLocalModel().then(() => initLocalModel(isAuthenticated));
   }, [isAuthenticated]);
 
+  const { unit: weightUnit } = useWeightUnit();
+  const { unit: temperatureUnit } = useTemperatureUnit();
+
   // Keep a ref for context body values so the transport closure stays fresh
   const contextRef = React.useRef(context);
   contextRef.current = context;
   const isAuthenticatedRef = React.useRef(isAuthenticated);
   isAuthenticatedRef.current = isAuthenticated;
+  const weightUnitRef = React.useRef(weightUnit);
+  weightUnitRef.current = weightUnit;
+  const temperatureUnitRef = React.useRef(temperatureUnit);
+  temperatureUnitRef.current = temperatureUnit;
 
   // Build the right transport based on current AI mode.
   // Recreated when aiMode or modelStatus changes (modelStatus drives local readiness).
@@ -188,7 +197,9 @@ export default function AIChat() {
 
       Context:
       - User id is ${userId}
-      - Current date is ${new Date().toLocaleString()}`;
+      - Current date is ${new Date().toLocaleString()}
+      - User's preferred weight unit is ${weightUnitRef.current} (always display weights in this unit)
+      - User's preferred temperature unit is °${temperatureUnitRef.current} (always display temperatures in this unit)`;
 
         if (contextRef.current.contextType === 'pack' && contextRef.current.packId) {
           systemPrompt += `\n- You are currently helping with a pack with ID: ${contextRef.current.packId}.`;
@@ -241,6 +252,8 @@ export default function AIChat() {
           packId: contextRef.current.packId,
           location: locationRef.current,
           date: new Date().toLocaleString(),
+          weightUnit: weightUnitRef.current,
+          temperatureUnit: temperatureUnitRef.current,
         }),
       }),
       transportKey: 'remote',

--- a/apps/expo/app/(app)/ai-chat.tsx
+++ b/apps/expo/app/(app)/ai-chat.tsx
@@ -29,6 +29,7 @@ import {
   releaseLocalModel,
 } from 'expo-app/features/ai/lib/localModelManager';
 import { createLocalTools } from 'expo-app/features/ai/lib/tools';
+import { useSpeedUnit } from 'expo-app/features/auth/hooks/useSpeedUnit';
 import { useTemperatureUnit } from 'expo-app/features/auth/hooks/useTemperatureUnit';
 import { useWeightUnit } from 'expo-app/features/auth/hooks/useWeightUnit';
 import { getPackItems, packItemsStore } from 'expo-app/features/packs/store/packItems';
@@ -164,6 +165,7 @@ export default function AIChat() {
 
   const { unit: weightUnit } = useWeightUnit();
   const { unit: temperatureUnit } = useTemperatureUnit();
+  const { unit: speedUnit } = useSpeedUnit();
 
   // Keep a ref for context body values so the transport closure stays fresh
   const contextRef = React.useRef(context);
@@ -174,6 +176,8 @@ export default function AIChat() {
   weightUnitRef.current = weightUnit;
   const temperatureUnitRef = React.useRef(temperatureUnit);
   temperatureUnitRef.current = temperatureUnit;
+  const speedUnitRef = React.useRef(speedUnit);
+  speedUnitRef.current = speedUnit;
 
   // Build the right transport based on current AI mode.
   // Recreated when aiMode or modelStatus changes (modelStatus drives local readiness).
@@ -199,7 +203,8 @@ export default function AIChat() {
       - User id is ${userId}
       - Current date is ${new Date().toLocaleString()}
       - User's preferred weight unit is ${weightUnitRef.current} (always display weights in this unit)
-      - User's preferred temperature unit is °${temperatureUnitRef.current} (always display temperatures in this unit)`;
+      - User's preferred temperature unit is °${temperatureUnitRef.current} (always display temperatures in this unit)
+      - User's preferred wind/distance unit is ${speedUnitRef.current === 'mph' ? 'mph / miles' : 'km/h / km'} (always display wind speed and distances in this unit)`;
 
         if (contextRef.current.contextType === 'pack' && contextRef.current.packId) {
           systemPrompt += `\n- You are currently helping with a pack with ID: ${contextRef.current.packId}.`;
@@ -254,6 +259,7 @@ export default function AIChat() {
           date: new Date().toLocaleString(),
           weightUnit: weightUnitRef.current,
           temperatureUnit: temperatureUnitRef.current,
+          speedUnit: speedUnitRef.current,
         }),
       }),
       transportKey: 'remote',

--- a/apps/expo/app/(app)/current-pack/[id].tsx
+++ b/apps/expo/app/(app)/current-pack/[id].tsx
@@ -1,6 +1,6 @@
 import { Avatar, AvatarFallback, AvatarImage, Text } from '@packrat/ui/nativewindui';
 import { getAppBarOptions } from '@packrat/ui/src/app-bar';
-import { userStore } from 'expo-app/features/auth/store';
+import { useWeightUnit } from 'expo-app/features/auth/hooks/useWeightUnit';
 import { usePackDetailsFromStore } from 'expo-app/features/packs/hooks/usePackDetailsFromStore';
 import type { PackItem } from 'expo-app/features/packs/types';
 import { type CategorySummary, computeCategorySummaries } from 'expo-app/features/packs/utils';
@@ -54,6 +54,7 @@ function CustomList<T>({
 function CategoryItem({ category, index }: { category: CategorySummary; index: number }) {
   const { colors } = useColorScheme();
   const { t } = useTranslation();
+  const { unit: weightUnit } = useWeightUnit();
   const itemLabel = category.items === 1 ? t('packs.item') : t('packs.items');
 
   return (
@@ -66,8 +67,7 @@ function CategoryItem({ category, index }: { category: CategorySummary; index: n
       <View>
         <Text>{category.name}</Text>
         <Text variant="footnote" className="text-muted-foreground">
-          {category.weight} {userStore.preferredWeightUnit.peek() ?? 'g'} • {category.items}{' '}
-          {itemLabel}
+          {category.weight} {weightUnit} • {category.items} {itemLabel}
         </Text>
       </View>
       <View
@@ -126,7 +126,8 @@ export default function CurrentPackScreen() {
   const { t } = useTranslation();
 
   const pack = usePackDetailsFromStore(params.id as string);
-  const uniqueCategories = computeCategorySummaries(pack);
+  const { unit: weightUnit } = useWeightUnit();
+  const uniqueCategories = computeCategorySummaries(pack, weightUnit); // pass unit so computed weights match the badge display
 
   return (
     <SafeAreaView className="flex-1" edges={['bottom']}>

--- a/apps/expo/app/(app)/current-pack/[id].tsx
+++ b/apps/expo/app/(app)/current-pack/[id].tsx
@@ -1,5 +1,6 @@
 import { Avatar, AvatarFallback, AvatarImage, Text } from '@packrat/ui/nativewindui';
 import { getAppBarOptions } from '@packrat/ui/src/app-bar';
+import { parseWeightUnit } from '@packrat/units';
 import { useWeightUnit } from 'expo-app/features/auth/hooks/useWeightUnit';
 import { usePackDetailsFromStore } from 'expo-app/features/packs/hooks/usePackDetailsFromStore';
 import type { PackItem } from 'expo-app/features/packs/types';
@@ -22,13 +23,14 @@ function WeightCard({
   weight: number;
   className?: string;
 }) {
+  const { unit, convertWeight } = useWeightUnit();
   return (
     <View className={cn('flex-1 rounded-lg bg-card p-4', className)}>
       <Text variant="subhead" className="text-muted-foreground">
         {title}
       </Text>
       <Text variant="title2" className="mt-1 font-semibold">
-        {weight} g
+        {convertWeight(weight, 'g')} {unit}
       </Text>
     </View>
   );
@@ -84,6 +86,7 @@ function CategoryItem({ category, index }: { category: CategorySummary; index: n
 
 function ItemRow({ item, index }: { item: PackItem; index: number }) {
   const { t } = useTranslation();
+  const { unit, convertWeight } = useWeightUnit();
 
   return (
     <View
@@ -114,7 +117,7 @@ function ItemRow({ item, index }: { item: PackItem; index: number }) {
           </View>
         )}
         <Text variant="subhead" className="text-muted-foreground">
-          {item.weight} {item.weightUnit}
+          {convertWeight(item.weight, parseWeightUnit({ value: item.weightUnit }))} {unit}
         </Text>
       </View>
     </View>

--- a/apps/expo/app/(app)/current-pack/[id].tsx
+++ b/apps/expo/app/(app)/current-pack/[id].tsx
@@ -30,7 +30,7 @@ function WeightCard({
         {title}
       </Text>
       <Text variant="title2" className="mt-1 font-semibold">
-        {convertWeight(weight, 'g')} {unit}
+        {convertWeight({ weight, fromUnit: 'g' })} {unit}
       </Text>
     </View>
   );
@@ -117,7 +117,11 @@ function ItemRow({ item, index }: { item: PackItem; index: number }) {
           </View>
         )}
         <Text variant="subhead" className="text-muted-foreground">
-          {convertWeight(item.weight, parseWeightUnit({ value: item.weightUnit }))} {unit}
+          {convertWeight({
+            weight: item.weight,
+            fromUnit: parseWeightUnit({ value: item.weightUnit }),
+          })}{' '}
+          {unit}
         </Text>
       </View>
     </View>
@@ -130,7 +134,7 @@ export default function CurrentPackScreen() {
 
   const pack = usePackDetailsFromStore(params.id as string);
   const { unit: weightUnit } = useWeightUnit();
-  const uniqueCategories = computeCategorySummaries(pack, weightUnit); // pass unit so computed weights match the badge display
+  const uniqueCategories = computeCategorySummaries({ pack, preferredUnit: weightUnit });
 
   return (
     <SafeAreaView className="flex-1" edges={['bottom']}>

--- a/apps/expo/app/(app)/pack-categories/[id].tsx
+++ b/apps/expo/app/(app)/pack-categories/[id].tsx
@@ -63,7 +63,7 @@ export default function PackCategoriesScreen() {
   const { t } = useTranslation();
 
   const { unit: weightUnit } = useWeightUnit();
-  const categories = computeCategorySummaries(pack, weightUnit);
+  const categories = computeCategorySummaries({ pack, preferredUnit: weightUnit });
 
   return (
     <>

--- a/apps/expo/app/(app)/pack-categories/[id].tsx
+++ b/apps/expo/app/(app)/pack-categories/[id].tsx
@@ -1,7 +1,7 @@
 import { Text } from '@packrat/ui/nativewindui';
 import { getAppBarOptions } from '@packrat/ui/src/app-bar';
 import { Icon, type MaterialIconName } from 'expo-app/components/Icon';
-import { userStore } from 'expo-app/features/auth/store';
+import { useWeightUnit } from 'expo-app/features/auth/hooks/useWeightUnit';
 import { usePackDetailsFromStore } from 'expo-app/features/packs/hooks/usePackDetailsFromStore';
 import { computeCategorySummaries } from 'expo-app/features/packs/utils';
 import { useColorScheme } from 'expo-app/lib/hooks/useColorScheme';
@@ -11,6 +11,7 @@ import { ScrollView, View } from 'react-native';
 
 function CategoryCard({
   category,
+  weightUnit,
 }: {
   category: {
     name: string;
@@ -19,6 +20,7 @@ function CategoryCard({
     percentage: number;
     icon?: MaterialIconName;
   };
+  weightUnit: string;
 }) {
   const { colors } = useColorScheme();
   const { t } = useTranslation();
@@ -45,7 +47,7 @@ function CategoryCard({
             <View className="flex-row items-center gap-1">
               <Icon name="dumbbell" size={14} color={colors.grey3} />
               <Text variant="subhead" className="text-muted-foreground">
-                {category.weight} {userStore.preferredWeightUnit.peek() ?? 'g'}
+                {category.weight} {weightUnit}
               </Text>
             </View>
           </View>
@@ -60,7 +62,8 @@ export default function PackCategoriesScreen() {
   const pack = usePackDetailsFromStore(params.id as string);
   const { t } = useTranslation();
 
-  const categories = computeCategorySummaries(pack);
+  const { unit: weightUnit } = useWeightUnit();
+  const categories = computeCategorySummaries(pack, weightUnit);
 
   return (
     <>
@@ -75,7 +78,7 @@ export default function PackCategoriesScreen() {
 
           <View className="pb-4">
             {categories.map((category) => (
-              <CategoryCard key={category.name} category={category} />
+              <CategoryCard key={category.name} category={category} weightUnit={weightUnit} />
             ))}
           </View>
         </ScrollView>

--- a/apps/expo/app/(app)/pack-stats/[id].tsx
+++ b/apps/expo/app/(app)/pack-stats/[id].tsx
@@ -20,7 +20,7 @@ export default function PackStatsScreen() {
   const weightHistory = usePackWeightHistory(packId);
   const { unit: weightUnit, convertWeight } = useWeightUnit();
 
-  const categories = computeCategorySummaries(pack, weightUnit);
+  const categories = computeCategorySummaries({ pack, preferredUnit: weightUnit });
   const CATEGORY_DISTRIBUTION = categories.map((category) => ({
     name: category.name,
     weight: category.weight,
@@ -64,7 +64,7 @@ export default function PackStatsScreen() {
                         {item.month}
                       </Text>
                       <Text variant="caption2" className="text-muted-foreground">
-                        {convertWeight(item.weight, 'g')} {weightUnit}
+                        {convertWeight({ weight: item.weight, fromUnit: 'g' })} {weightUnit}
                       </Text>
                     </View>
                   );

--- a/apps/expo/app/(app)/pack-stats/[id].tsx
+++ b/apps/expo/app/(app)/pack-stats/[id].tsx
@@ -18,7 +18,7 @@ export default function PackStatsScreen() {
 
   const pack = usePackDetailsFromStore(packId);
   const weightHistory = usePackWeightHistory(packId);
-  const { unit: weightUnit } = useWeightUnit();
+  const { unit: weightUnit, convertWeight } = useWeightUnit();
 
   const categories = computeCategorySummaries(pack, weightUnit);
   const CATEGORY_DISTRIBUTION = categories.map((category) => ({
@@ -64,7 +64,7 @@ export default function PackStatsScreen() {
                         {item.month}
                       </Text>
                       <Text variant="caption2" className="text-muted-foreground">
-                        {item.weight.toFixed(1)} g
+                        {convertWeight(item.weight, 'g')} {weightUnit}
                       </Text>
                     </View>
                   );

--- a/apps/expo/app/(app)/pack-stats/[id].tsx
+++ b/apps/expo/app/(app)/pack-stats/[id].tsx
@@ -1,7 +1,7 @@
 import { Button, Text } from '@packrat/ui/nativewindui';
 import { getAppBarOptions } from '@packrat/ui/src/app-bar';
 import { featureFlags } from 'expo-app/config';
-import { userStore } from 'expo-app/features/auth/store';
+import { useWeightUnit } from 'expo-app/features/auth/hooks/useWeightUnit';
 import { usePackDetailsFromStore } from 'expo-app/features/packs/hooks/usePackDetailsFromStore';
 import { usePackWeightHistory } from 'expo-app/features/packs/hooks/usePackWeightHistory';
 import { computeCategorySummaries } from 'expo-app/features/packs/utils';
@@ -18,8 +18,9 @@ export default function PackStatsScreen() {
 
   const pack = usePackDetailsFromStore(packId);
   const weightHistory = usePackWeightHistory(packId);
+  const { unit: weightUnit } = useWeightUnit();
 
-  const categories = computeCategorySummaries(pack);
+  const categories = computeCategorySummaries(pack, weightUnit);
   const CATEGORY_DISTRIBUTION = categories.map((category) => ({
     name: category.name,
     weight: category.weight,
@@ -106,8 +107,7 @@ export default function PackStatsScreen() {
                     <View className="mb-1 flex-row justify-between">
                       <Text variant="subhead">{item.name}</Text>
                       <Text variant="subhead">
-                        {item.weight.toFixed(1)} {userStore.preferredWeightUnit.peek() ?? 'g'}(
-                        {item.percentage}%)
+                        {item.weight.toFixed(1)} {weightUnit}({item.percentage}%)
                       </Text>
                     </View>
                     <View className="h-2 overflow-hidden rounded-full bg-muted">

--- a/apps/expo/app/(app)/settings/index.tsx
+++ b/apps/expo/app/(app)/settings/index.tsx
@@ -1,4 +1,4 @@
-import { ActivityIndicator, Text } from '@packrat/ui/nativewindui';
+import { ActivityIndicator, SegmentedControl, Text } from '@packrat/ui/nativewindui';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import * as Burnt from 'burnt';
 import { appAlert } from 'expo-app/app/_layout';
@@ -17,11 +17,13 @@ import {
 } from 'expo-app/features/ai/lib/localModelManager';
 import { DeleteAccountButton } from 'expo-app/features/auth/components/DeleteAccountButton';
 import { useAuth } from 'expo-app/features/auth/hooks/useAuth';
+import { useSpeedUnit } from 'expo-app/features/auth/hooks/useSpeedUnit';
 import { useTemperatureUnit } from 'expo-app/features/auth/hooks/useTemperatureUnit';
 import { useWeightUnit } from 'expo-app/features/auth/hooks/useWeightUnit';
 import { useSeasonSuggestionsPrefs } from 'expo-app/features/packs/atoms/seasonSuggestionsAtoms';
 import { useColorScheme } from 'expo-app/lib/hooks/useColorScheme';
 import { useTranslation } from 'expo-app/lib/hooks/useTranslation';
+import { testIds } from 'expo-app/lib/testIds';
 import ImageCacheManager from 'expo-app/lib/utils/ImageCacheManager';
 import Constants from 'expo-constants';
 import { useRouter } from 'expo-router';
@@ -41,6 +43,7 @@ export default function SettingsScreen() {
   const { announcementSeen, setAnnouncementSeen, opened, setOpened } = useSeasonSuggestionsPrefs();
   const { unit: weightUnit, setWeightUnit } = useWeightUnit();
   const { unit: temperatureUnit, setTemperatureUnit } = useTemperatureUnit();
+  const { unit: speedUnit, setSpeedUnit } = useSpeedUnit();
 
   const isApple = isAppleIntelligenceAvailable();
   const isDownloading = modelStatus === 'downloading';
@@ -113,32 +116,16 @@ export default function SettingsScreen() {
               <View className="flex-1">
                 <Text className="font-medium">Weight</Text>
                 <Text variant="footnote" className="mt-0.5 text-muted-foreground">
-                  Shown on pack totals and items
+                  Shown on all weight displays
                 </Text>
               </View>
-              <View className="flex-row overflow-hidden rounded-lg border border-border">
-                <TouchableOpacity
-                  className={`px-4 py-2 ${weightUnit === 'kg' ? 'bg-primary' : 'bg-card'}`}
-                  onPress={() => setWeightUnit('kg')}
-                >
-                  <Text
-                    variant="footnote"
-                    className={`font-medium ${weightUnit === 'kg' ? 'text-primary-foreground' : 'text-foreground'}`}
-                  >
-                    kg
-                  </Text>
-                </TouchableOpacity>
-                <TouchableOpacity
-                  className={`px-4 py-2 ${weightUnit === 'lb' ? 'bg-primary' : 'bg-card'}`}
-                  onPress={() => setWeightUnit('lb')}
-                >
-                  <Text
-                    variant="footnote"
-                    className={`font-medium ${weightUnit === 'lb' ? 'text-primary-foreground' : 'text-foreground'}`}
-                  >
-                    lb
-                  </Text>
-                </TouchableOpacity>
+              <View className="w-28">
+                <SegmentedControl
+                  testID={testIds.settings.weightUnitControl}
+                  values={['kg', 'lb']}
+                  selectedIndex={weightUnit === 'kg' ? 0 : 1}
+                  onIndexChange={(index) => setWeightUnit(index === 0 ? 'kg' : 'lb')}
+                />
               </View>
             </View>
             <View className="h-px bg-border mx-4" />
@@ -146,32 +133,33 @@ export default function SettingsScreen() {
               <View className="flex-1">
                 <Text className="font-medium">Temperature</Text>
                 <Text variant="footnote" className="mt-0.5 text-muted-foreground">
-                  Shown in weather forecasts
+                  Shown on all temperature displays
                 </Text>
               </View>
-              <View className="flex-row overflow-hidden rounded-lg border border-border">
-                <TouchableOpacity
-                  className={`px-4 py-2 ${temperatureUnit === 'C' ? 'bg-primary' : 'bg-card'}`}
-                  onPress={() => setTemperatureUnit('C')}
-                >
-                  <Text
-                    variant="footnote"
-                    className={`font-medium ${temperatureUnit === 'C' ? 'text-primary-foreground' : 'text-foreground'}`}
-                  >
-                    °C
-                  </Text>
-                </TouchableOpacity>
-                <TouchableOpacity
-                  className={`px-4 py-2 ${temperatureUnit === 'F' ? 'bg-primary' : 'bg-card'}`}
-                  onPress={() => setTemperatureUnit('F')}
-                >
-                  <Text
-                    variant="footnote"
-                    className={`font-medium ${temperatureUnit === 'F' ? 'text-primary-foreground' : 'text-foreground'}`}
-                  >
-                    °F
-                  </Text>
-                </TouchableOpacity>
+              <View className="w-28">
+                <SegmentedControl
+                  testID={testIds.settings.temperatureUnitControl}
+                  values={['°C', '°F']}
+                  selectedIndex={temperatureUnit === 'C' ? 0 : 1}
+                  onIndexChange={(index) => setTemperatureUnit(index === 0 ? 'C' : 'F')}
+                />
+              </View>
+            </View>
+            <View className="h-px bg-border mx-4" />
+            <View className="flex-row items-center justify-between p-4">
+              <View className="flex-1">
+                <Text className="font-medium">Wind & Distance</Text>
+                <Text variant="footnote" className="mt-0.5 text-muted-foreground">
+                  Shown on all speed and distance displays
+                </Text>
+              </View>
+              <View className="w-28">
+                <SegmentedControl
+                  testID={testIds.settings.speedUnitControl}
+                  values={['km/h', 'mph']}
+                  selectedIndex={speedUnit === 'kmh' ? 0 : 1}
+                  onIndexChange={(index) => setSpeedUnit(index === 0 ? 'kmh' : 'mph')}
+                />
               </View>
             </View>
           </View>

--- a/apps/expo/app/(app)/settings/index.tsx
+++ b/apps/expo/app/(app)/settings/index.tsx
@@ -116,7 +116,7 @@ export default function SettingsScreen() {
               <View className="flex-1">
                 <Text className="font-medium">Weight</Text>
                 <Text variant="footnote" className="mt-0.5 text-muted-foreground">
-                  Shown on all weight displays
+                  For gear and pack weights
                 </Text>
               </View>
               <View className="w-28">
@@ -133,7 +133,7 @@ export default function SettingsScreen() {
               <View className="flex-1">
                 <Text className="font-medium">Temperature</Text>
                 <Text variant="footnote" className="mt-0.5 text-muted-foreground">
-                  Shown on all temperature displays
+                  For weather and forecasts
                 </Text>
               </View>
               <View className="w-28">
@@ -150,7 +150,7 @@ export default function SettingsScreen() {
               <View className="flex-1">
                 <Text className="font-medium">Wind & Distance</Text>
                 <Text variant="footnote" className="mt-0.5 text-muted-foreground">
-                  Shown on all speed and distance displays
+                  For routes and weather data
                 </Text>
               </View>
               <View className="w-28">

--- a/apps/expo/app/(app)/settings/index.tsx
+++ b/apps/expo/app/(app)/settings/index.tsx
@@ -17,6 +17,8 @@ import {
 } from 'expo-app/features/ai/lib/localModelManager';
 import { DeleteAccountButton } from 'expo-app/features/auth/components/DeleteAccountButton';
 import { useAuth } from 'expo-app/features/auth/hooks/useAuth';
+import { useTemperatureUnit } from 'expo-app/features/auth/hooks/useTemperatureUnit';
+import { useWeightUnit } from 'expo-app/features/auth/hooks/useWeightUnit';
 import { useSeasonSuggestionsPrefs } from 'expo-app/features/packs/atoms/seasonSuggestionsAtoms';
 import { useColorScheme } from 'expo-app/lib/hooks/useColorScheme';
 import { useTranslation } from 'expo-app/lib/hooks/useTranslation';
@@ -37,6 +39,8 @@ export default function SettingsScreen() {
 
   const router = useRouter();
   const { announcementSeen, setAnnouncementSeen, opened, setOpened } = useSeasonSuggestionsPrefs();
+  const { unit: weightUnit, setWeightUnit } = useWeightUnit();
+  const { unit: temperatureUnit, setTemperatureUnit } = useTemperatureUnit();
 
   const isApple = isAppleIntelligenceAvailable();
   const isDownloading = modelStatus === 'downloading';
@@ -99,6 +103,79 @@ export default function SettingsScreen() {
         <StatusBar
           style={Platform.OS === 'ios' ? 'light' : colorScheme === 'dark' ? 'light' : 'dark'}
         />
+
+        <View>
+          <Text variant="subhead" className="mb-3">
+            Display Units
+          </Text>
+          <View className="rounded-xl border border-border bg-card">
+            <View className="flex-row items-center justify-between p-4">
+              <View className="flex-1">
+                <Text className="font-medium">Weight</Text>
+                <Text variant="footnote" className="mt-0.5 text-muted-foreground">
+                  Shown on pack totals and items
+                </Text>
+              </View>
+              <View className="flex-row overflow-hidden rounded-lg border border-border">
+                <TouchableOpacity
+                  className={`px-4 py-2 ${weightUnit === 'kg' ? 'bg-primary' : 'bg-card'}`}
+                  onPress={() => setWeightUnit('kg')}
+                >
+                  <Text
+                    variant="footnote"
+                    className={`font-medium ${weightUnit === 'kg' ? 'text-primary-foreground' : 'text-foreground'}`}
+                  >
+                    kg
+                  </Text>
+                </TouchableOpacity>
+                <TouchableOpacity
+                  className={`px-4 py-2 ${weightUnit === 'lb' ? 'bg-primary' : 'bg-card'}`}
+                  onPress={() => setWeightUnit('lb')}
+                >
+                  <Text
+                    variant="footnote"
+                    className={`font-medium ${weightUnit === 'lb' ? 'text-primary-foreground' : 'text-foreground'}`}
+                  >
+                    lb
+                  </Text>
+                </TouchableOpacity>
+              </View>
+            </View>
+            <View className="h-px bg-border mx-4" />
+            <View className="flex-row items-center justify-between p-4">
+              <View className="flex-1">
+                <Text className="font-medium">Temperature</Text>
+                <Text variant="footnote" className="mt-0.5 text-muted-foreground">
+                  Shown in weather forecasts
+                </Text>
+              </View>
+              <View className="flex-row overflow-hidden rounded-lg border border-border">
+                <TouchableOpacity
+                  className={`px-4 py-2 ${temperatureUnit === 'C' ? 'bg-primary' : 'bg-card'}`}
+                  onPress={() => setTemperatureUnit('C')}
+                >
+                  <Text
+                    variant="footnote"
+                    className={`font-medium ${temperatureUnit === 'C' ? 'text-primary-foreground' : 'text-foreground'}`}
+                  >
+                    °C
+                  </Text>
+                </TouchableOpacity>
+                <TouchableOpacity
+                  className={`px-4 py-2 ${temperatureUnit === 'F' ? 'bg-primary' : 'bg-card'}`}
+                  onPress={() => setTemperatureUnit('F')}
+                >
+                  <Text
+                    variant="footnote"
+                    className={`font-medium ${temperatureUnit === 'F' ? 'text-primary-foreground' : 'text-foreground'}`}
+                  >
+                    °F
+                  </Text>
+                </TouchableOpacity>
+              </View>
+            </View>
+          </View>
+        </View>
 
         <View>
           <Text variant="subhead" className="mb-3">

--- a/apps/expo/app/(app)/settings/index.tsx
+++ b/apps/expo/app/(app)/settings/index.tsx
@@ -109,14 +109,14 @@ export default function SettingsScreen() {
 
         <View>
           <Text variant="subhead" className="mb-3">
-            Display Units
+            {t('settings.displayUnits')}
           </Text>
           <View className="rounded-xl border border-border bg-card">
             <View className="flex-row items-center justify-between p-4">
               <View className="flex-1">
                 <Text className="font-medium">Weight</Text>
                 <Text variant="footnote" className="mt-0.5 text-muted-foreground">
-                  For gear and pack weights
+                  {t('settings.weightSubtitle')}
                 </Text>
               </View>
               <View className="w-28">
@@ -133,7 +133,7 @@ export default function SettingsScreen() {
               <View className="flex-1">
                 <Text className="font-medium">Temperature</Text>
                 <Text variant="footnote" className="mt-0.5 text-muted-foreground">
-                  For weather and forecasts
+                  {t('settings.temperatureSubtitle')}
                 </Text>
               </View>
               <View className="w-28">
@@ -150,7 +150,7 @@ export default function SettingsScreen() {
               <View className="flex-1">
                 <Text className="font-medium">Wind & Distance</Text>
                 <Text variant="footnote" className="mt-0.5 text-muted-foreground">
-                  For routes and weather data
+                  {t('settings.windDistanceSubtitle')}
                 </Text>
               </View>
               <View className="w-28">

--- a/apps/expo/app/(app)/settings/index.tsx
+++ b/apps/expo/app/(app)/settings/index.tsx
@@ -153,7 +153,7 @@ export default function SettingsScreen() {
                   {t('settings.windDistanceSubtitle')}
                 </Text>
               </View>
-              <View className="w-28">
+              <View className="w-36">
                 <SegmentedControl
                   testID={testIds.settings.speedUnitControl}
                   values={['km/h', 'mph']}

--- a/apps/expo/app/(app)/weight-analysis/[id].tsx
+++ b/apps/expo/app/(app)/weight-analysis/[id].tsx
@@ -122,7 +122,8 @@ export default function WeightAnalysisScreen() {
                       )}
                     </View>
                     <Text variant="subhead" className="text-muted-foreground">
-                      {convertWeight(item.weight, item.weightUnit || 'g')} {preferredUnit}
+                      {convertWeight({ weight: item.weight, fromUnit: item.weightUnit || 'g' })}{' '}
+                      {preferredUnit}
                     </Text>
                   </View>
                 ))}

--- a/apps/expo/app/(app)/weight-analysis/[id].tsx
+++ b/apps/expo/app/(app)/weight-analysis/[id].tsx
@@ -2,7 +2,6 @@
 
 import { Text } from '@packrat/ui/nativewindui';
 import { getAppBarOptions } from '@packrat/ui/src/app-bar';
-import { userStore } from 'expo-app/features/auth/store';
 import { usePackWeightAnalysis } from 'expo-app/features/packs/hooks/usePackWeightAnalysis';
 import { cn } from 'expo-app/lib/cn';
 import { useTranslation } from 'expo-app/lib/hooks/useTranslation';
@@ -43,9 +42,7 @@ export default function WeightAnalysisScreen() {
   const packId = params.id;
   const { t } = useTranslation();
 
-  const { data, items } = usePackWeightAnalysis(packId as string);
-
-  const preferredWeightUnit = userStore.preferredWeightUnit.peek() ?? 'g';
+  const { data, items, preferredUnit } = usePackWeightAnalysis(packId as string);
 
   return (
     <SafeAreaView className="flex-1" edges={['bottom']}>
@@ -59,22 +56,22 @@ export default function WeightAnalysisScreen() {
         <View className="grid grid-cols-2 gap-3 p-4">
           <WeightCard
             title={t('packs.baseWeight')}
-            weight={`${data.baseWeight} g`}
+            weight={`${data.baseWeight} ${preferredUnit}`}
             className="col-span-1"
           />
           <WeightCard
             title={t('packs.consumablesWeight')}
-            weight={`${data.consumableWeight} ${preferredWeightUnit}`}
+            weight={`${data.consumableWeight} ${preferredUnit}`}
             className="col-span-1"
           />
           <WeightCard
             title={t('packs.wornWeight')}
-            weight={`${data.wornWeight} ${preferredWeightUnit}`}
+            weight={`${data.wornWeight} ${preferredUnit}`}
             className="col-span-1"
           />
           <WeightCard
             title={t('packs.totalWeight')}
-            weight={`${data.totalWeight} ${preferredWeightUnit}`}
+            weight={`${data.totalWeight} ${preferredUnit}`}
             className="col-span-1"
           />
         </View>
@@ -97,7 +94,7 @@ export default function WeightAnalysisScreen() {
                   {category.name}
                 </Text>
                 <Text variant="subhead" className="text-muted-foreground">
-                  {category.weight} {preferredWeightUnit}
+                  {category.weight} {preferredUnit}
                 </Text>
               </View>
             </View>

--- a/apps/expo/app/(app)/weight-analysis/[id].tsx
+++ b/apps/expo/app/(app)/weight-analysis/[id].tsx
@@ -2,6 +2,7 @@
 
 import { Text } from '@packrat/ui/nativewindui';
 import { getAppBarOptions } from '@packrat/ui/src/app-bar';
+import { useWeightUnit } from 'expo-app/features/auth/hooks/useWeightUnit';
 import { usePackWeightAnalysis } from 'expo-app/features/packs/hooks/usePackWeightAnalysis';
 import { cn } from 'expo-app/lib/cn';
 import { useTranslation } from 'expo-app/lib/hooks/useTranslation';
@@ -43,6 +44,7 @@ export default function WeightAnalysisScreen() {
   const { t } = useTranslation();
 
   const { data, items, preferredUnit } = usePackWeightAnalysis(packId as string);
+  const { convertWeight } = useWeightUnit();
 
   return (
     <SafeAreaView className="flex-1" edges={['bottom']}>
@@ -120,7 +122,7 @@ export default function WeightAnalysisScreen() {
                       )}
                     </View>
                     <Text variant="subhead" className="text-muted-foreground">
-                      {item.weight} {item.weightUnit}
+                      {convertWeight(item.weight, item.weightUnit || 'g')} {preferredUnit}
                     </Text>
                   </View>
                 ))}

--- a/apps/expo/components/initial/WeightBadge.tsx
+++ b/apps/expo/components/initial/WeightBadge.tsx
@@ -1,7 +1,7 @@
 import type { WeightUnit } from '@packrat/constants';
 import { isString } from '@packrat/guards';
+import { useWeightUnit } from 'expo-app/features/auth/hooks/useWeightUnit';
 import { cn } from 'expo-app/lib/cn';
-import { formatWeight } from 'expo-app/utils/weight';
 import { Text, View } from 'react-native';
 
 type WeightBadgeProps = {
@@ -19,6 +19,8 @@ export function WeightBadge({
   containerClassName,
   textClassName,
 }: WeightBadgeProps) {
+  const { convertWeight, unit: displayUnit } = useWeightUnit();
+
   const getColorClass = () => {
     switch (type) {
       case 'base':
@@ -31,13 +33,14 @@ export function WeightBadge({
   };
 
   const safeWeight = Number(weight) || 0;
-  const safeUnit = isString(unit) ? unit : 'g';
-  const formattedWeight = formatWeight({ weight: safeWeight, unit: safeUnit });
+  const safeUnit: WeightUnit = isString(unit) ? (unit as WeightUnit) : 'g';
+  const converted = convertWeight(safeWeight, safeUnit);
 
   return (
     <View className={cn('rounded-full px-2 py-1', getColorClass()[0], containerClassName)}>
       <Text className={cn('text-center text-xs font-medium', getColorClass()[1], textClassName)}>
-        {formattedWeight}
+        {converted}
+        {displayUnit}
       </Text>
     </View>
   );

--- a/apps/expo/components/initial/WeightBadge.tsx
+++ b/apps/expo/components/initial/WeightBadge.tsx
@@ -34,7 +34,7 @@ export function WeightBadge({
 
   const safeWeight = Number(weight) || 0;
   const safeUnit: WeightUnit = parseWeightUnit({ value: unit });
-  const converted = convertWeight(safeWeight, safeUnit);
+  const converted = convertWeight({ weight: safeWeight, fromUnit: safeUnit });
 
   return (
     <View className={cn('rounded-full px-2 py-1', getColorClass()[0], containerClassName)}>

--- a/apps/expo/components/initial/WeightBadge.tsx
+++ b/apps/expo/components/initial/WeightBadge.tsx
@@ -39,8 +39,7 @@ export function WeightBadge({
   return (
     <View className={cn('rounded-full px-2 py-1', getColorClass()[0], containerClassName)}>
       <Text className={cn('text-center text-xs font-medium', getColorClass()[1], textClassName)}>
-        {converted}
-        {displayUnit}
+        {`${converted} ${displayUnit}`}
       </Text>
     </View>
   );

--- a/apps/expo/components/initial/WeightBadge.tsx
+++ b/apps/expo/components/initial/WeightBadge.tsx
@@ -1,5 +1,5 @@
 import type { WeightUnit } from '@packrat/constants';
-import { isString } from '@packrat/guards';
+import { parseWeightUnit } from '@packrat/units';
 import { useWeightUnit } from 'expo-app/features/auth/hooks/useWeightUnit';
 import { cn } from 'expo-app/lib/cn';
 import { Text, View } from 'react-native';
@@ -33,7 +33,7 @@ export function WeightBadge({
   };
 
   const safeWeight = Number(weight) || 0;
-  const safeUnit: WeightUnit = isString(unit) ? (unit as WeightUnit) : 'g';
+  const safeUnit: WeightUnit = parseWeightUnit({ value: unit });
   const converted = convertWeight(safeWeight, safeUnit);
 
   return (

--- a/apps/expo/features/ai/components/LocationContext.tsx
+++ b/apps/expo/features/ai/components/LocationContext.tsx
@@ -1,5 +1,6 @@
 import { Text } from '@packrat/ui/nativewindui';
 import { Icon } from 'expo-app/components/Icon';
+import { useTemperatureUnit } from 'expo-app/features/auth/hooks/useTemperatureUnit';
 import { LocationPicker } from 'expo-app/features/weather/components/LocationPicker';
 import { useColorScheme } from 'expo-app/lib/hooks/useColorScheme';
 import { useTranslation } from 'expo-app/lib/hooks/useTranslation';
@@ -17,6 +18,7 @@ export function LocationContext({ location, onSetLocation }: LocationContextProp
   const { colors } = useColorScheme();
   const { t } = useTranslation();
   const [showLocationPicker, setShowLocationPicker] = useState(false);
+  const { displayTemperature } = useTemperatureUnit();
 
   if (!location) {
     return (
@@ -42,7 +44,9 @@ export function LocationContext({ location, onSetLocation }: LocationContextProp
         >
           <Icon name="map-marker-radius-outline" size={16} color={colors.primary} />
           <Text className="flex-1 text-sm font-medium">{location.name}</Text>
-          <Text className="mr-1 text-sm text-muted-foreground">{location.temperature}°</Text>
+          <Text className="mr-1 text-sm text-muted-foreground">
+            {displayTemperature(location.temperature)}
+          </Text>
           <Icon name="chevron-down" size={16} color={colors.grey2} />
         </TouchableOpacity>
       </View>

--- a/apps/expo/features/ai/components/WeatherGenerativeUI.tsx
+++ b/apps/expo/features/ai/components/WeatherGenerativeUI.tsx
@@ -1,6 +1,7 @@
 import { Text } from '@packrat/ui/nativewindui';
 import * as Sentry from '@sentry/react-native';
 import { Icon } from 'expo-app/components/Icon';
+import { useTemperatureUnit } from 'expo-app/features/auth/hooks/useTemperatureUnit';
 import { getWeatherIconByCondition } from 'expo-app/features/weather/lib/weatherIcons';
 import { useColorScheme } from 'expo-app/lib/hooks/useColorScheme';
 import { useTranslation } from 'expo-app/lib/hooks/useTranslation';
@@ -44,6 +45,7 @@ interface WeatherGenerativeUIProps {
 export function WeatherGenerativeUI({ toolInvocation }: WeatherGenerativeUIProps) {
   const { colors } = useColorScheme();
   const { t } = useTranslation();
+  const { displayTemperature } = useTemperatureUnit();
 
   useEffect(() => {
     const { toolCallId } = toolInvocation;
@@ -151,7 +153,7 @@ export function WeatherGenerativeUI({ toolInvocation }: WeatherGenerativeUIProps
                   <Text
                     className={`text-4xl font-light ${getTemperatureColor(toolInvocation.output.data.temperature)}`}
                   >
-                    {toolInvocation.output.data.temperature}°
+                    {displayTemperature(toolInvocation.output.data.temperature)}
                   </Text>
                   <Text className="mt-1 text-base text-gray-600 dark:text-gray-300">
                     {toolInvocation.output.data.condition || '—'}
@@ -214,9 +216,10 @@ export function WeatherGenerativeUI({ toolInvocation }: WeatherGenerativeUIProps
   }
 }
 
-const getTemperatureColor = (temp: number) => {
-  if (temp >= 80) return 'text-red-600';
-  if (temp >= 60) return 'text-orange-500';
-  if (temp >= 40) return 'text-blue-500';
+// Thresholds in Celsius: hot ≥27°C, mild ≥15°C, cool ≥4°C
+const getTemperatureColor = (tempC: number) => {
+  if (tempC >= 27) return 'text-red-600';
+  if (tempC >= 15) return 'text-orange-500';
+  if (tempC >= 4) return 'text-blue-500';
   return 'text-blue-700';
 };

--- a/apps/expo/features/auth/hooks/useSpeedUnit.ts
+++ b/apps/expo/features/auth/hooks/useSpeedUnit.ts
@@ -1,0 +1,26 @@
+import { use$ } from '@legendapp/state/react';
+import { preferencesStore } from 'expo-app/features/auth/store/preferences';
+import { getDefaultSpeedUnit } from 'expo-app/lib/unitDefaults';
+
+export function useSpeedUnit() {
+  const stored = use$(preferencesStore.speedUnit);
+  const unit: 'mph' | 'kmh' = stored ?? getDefaultSpeedUnit();
+
+  const setSpeedUnit = (value: 'mph' | 'kmh') => {
+    preferencesStore.speedUnit.set(value);
+  };
+
+  // Takes a km/h value, returns a formatted string in the user's preferred unit
+  const displayWindSpeed = (kph: number): string => {
+    if (unit === 'mph') return `${Math.round(kph * 0.621371)} mph`;
+    return `${Math.round(kph)} km/h`;
+  };
+
+  // Takes a km value, returns a formatted string in the user's preferred unit
+  const displayVisibility = (km: number): string => {
+    if (unit === 'mph') return `${Math.round(km * 0.621371)} mi`;
+    return `${Math.round(km)} km`;
+  };
+
+  return { unit, setSpeedUnit, displayWindSpeed, displayVisibility };
+}

--- a/apps/expo/features/auth/hooks/useTemperatureUnit.ts
+++ b/apps/expo/features/auth/hooks/useTemperatureUnit.ts
@@ -1,0 +1,28 @@
+import { use$ } from '@legendapp/state/react';
+import { preferencesStore } from 'expo-app/features/auth/store/preferences';
+import { getDefaultTemperatureUnit } from 'expo-app/lib/unitDefaults';
+
+export function useTemperatureUnit() {
+  const stored = use$(preferencesStore.temperatureUnit);
+  const unit: 'C' | 'F' = stored ?? getDefaultTemperatureUnit();
+
+  const setTemperatureUnit = (value: 'C' | 'F') => {
+    preferencesStore.temperatureUnit.set(value);
+  };
+
+  // Takes a Celsius value and returns a formatted string in the user's preferred unit
+  const displayTemperature = (celsius: number): string => {
+    if (unit === 'F') {
+      return `${Math.round(celsius * 1.8 + 32)}°F`;
+    }
+    return `${Math.round(celsius)}°C`;
+  };
+
+  // Returns the raw numeric value in the preferred unit (no unit suffix)
+  const toPreferred = (celsius: number): number => {
+    if (unit === 'F') return Math.round(celsius * 1.8 + 32);
+    return Math.round(celsius);
+  };
+
+  return { unit, setTemperatureUnit, displayTemperature, toPreferred };
+}

--- a/apps/expo/features/auth/hooks/useWeightUnit.ts
+++ b/apps/expo/features/auth/hooks/useWeightUnit.ts
@@ -12,8 +12,13 @@ export function useWeightUnit() {
     preferencesStore.weightUnit.set(value);
   };
 
-  // Convert a weight value stored in `fromUnit` to the preferred display unit
-  const convertWeight = (weight: number, fromUnit: WeightUnit): number => {
+  const convertWeight = ({
+    weight,
+    fromUnit,
+  }: {
+    weight: number;
+    fromUnit: WeightUnit;
+  }): number => {
     const grams = normalize({ weight, unit: fromUnit });
     return displayWeight({ grams, unit });
   };

--- a/apps/expo/features/auth/hooks/useWeightUnit.ts
+++ b/apps/expo/features/auth/hooks/useWeightUnit.ts
@@ -1,0 +1,22 @@
+import { use$ } from '@legendapp/state/react';
+import type { WeightUnit } from '@packrat/units';
+import { displayWeight, normalize } from '@packrat/units';
+import { preferencesStore } from 'expo-app/features/auth/store/preferences';
+import { getDefaultWeightUnit } from 'expo-app/lib/unitDefaults';
+
+export function useWeightUnit() {
+  const stored = use$(preferencesStore.weightUnit);
+  const unit: 'kg' | 'lb' = stored ?? getDefaultWeightUnit();
+
+  const setWeightUnit = (value: 'kg' | 'lb') => {
+    preferencesStore.weightUnit.set(value);
+  };
+
+  // Convert a weight value stored in `fromUnit` to the preferred display unit
+  const convertWeight = (weight: number, fromUnit: WeightUnit): number => {
+    const grams = normalize({ weight, unit: fromUnit });
+    return displayWeight({ grams, unit });
+  };
+
+  return { unit, setWeightUnit, convertWeight };
+}

--- a/apps/expo/features/catalog/components/CatalogItemCard.tsx
+++ b/apps/expo/features/catalog/components/CatalogItemCard.tsx
@@ -71,7 +71,7 @@ export function CatalogItemCard({ item, onPress }: CatalogItemCardProps) {
             <Icon name="dumbbell" size={14} color={colors.grey} />
             <Text className="ml-1 text-xs text-muted-foreground">
               {item.weight != null
-                ? `${convertWeight(item.weight, item.weightUnit ?? 'g')} ${unit}`
+                ? `${convertWeight({ weight: item.weight, fromUnit: item.weightUnit ?? 'g' })} ${unit}`
                 : ''}
             </Text>
           </View>

--- a/apps/expo/features/catalog/components/CatalogItemCard.tsx
+++ b/apps/expo/features/catalog/components/CatalogItemCard.tsx
@@ -8,6 +8,7 @@ import {
   Text,
 } from '@packrat/ui/nativewindui';
 import { Icon } from 'expo-app/components/Icon';
+import { useWeightUnit } from 'expo-app/features/auth/hooks/useWeightUnit';
 import { useColorScheme } from 'expo-app/lib/hooks/useColorScheme';
 import { useTranslation } from 'expo-app/lib/hooks/useTranslation';
 import { testIds } from 'expo-app/lib/testIds';
@@ -24,6 +25,7 @@ type CatalogItemCardProps = {
 export function CatalogItemCard({ item, onPress }: CatalogItemCardProps) {
   const { colors } = useColorScheme();
   const { t } = useTranslation();
+  const { unit, convertWeight } = useWeightUnit();
 
   return (
     <TouchableWithoutFeedback
@@ -68,7 +70,9 @@ export function CatalogItemCard({ item, onPress }: CatalogItemCardProps) {
           <View className="flex-row items-center">
             <Icon name="dumbbell" size={14} color={colors.grey} />
             <Text className="ml-1 text-xs text-muted-foreground">
-              {item.weight} {item.weightUnit}
+              {item.weight != null
+                ? `${convertWeight(item.weight, item.weightUnit ?? 'g')} ${unit}`
+                : ''}
             </Text>
           </View>
           {item.usageCount && item.usageCount > 0 && (

--- a/apps/expo/features/catalog/components/CatalogItemSelectCard.tsx
+++ b/apps/expo/features/catalog/components/CatalogItemSelectCard.tsx
@@ -8,6 +8,7 @@ import {
   Text,
 } from '@packrat/ui/nativewindui';
 import { Icon } from 'expo-app/components/Icon';
+import { useWeightUnit } from 'expo-app/features/auth/hooks/useWeightUnit';
 import { cn } from 'expo-app/lib/cn';
 import { useColorScheme } from 'expo-app/lib/hooks/useColorScheme';
 import { testIds } from 'expo-app/lib/testIds';
@@ -23,6 +24,7 @@ type CatalogItemSelectCardProps = {
 
 export function CatalogItemSelectCard({ item, isSelected, onToggle }: CatalogItemSelectCardProps) {
   const { colors } = useColorScheme();
+  const { unit, convertWeight } = useWeightUnit();
 
   return (
     <TouchableWithoutFeedback onPress={onToggle} testID={testIds.items.catalogCard(item.id)}>
@@ -77,7 +79,9 @@ export function CatalogItemSelectCard({ item, isSelected, onToggle }: CatalogIte
           <View className="flex-row items-center">
             <Icon name="dumbbell" size={14} color={colors.grey} />
             <Text className="ml-1 text-xs text-muted-foreground">
-              {item.weight} {item.weightUnit}
+              {item.weight != null
+                ? `${convertWeight(item.weight, item.weightUnit ?? 'g')} ${unit}`
+                : ''}
             </Text>
           </View>
           {item.usageCount && item.usageCount > 0 && (

--- a/apps/expo/features/catalog/components/CatalogItemSelectCard.tsx
+++ b/apps/expo/features/catalog/components/CatalogItemSelectCard.tsx
@@ -80,7 +80,7 @@ export function CatalogItemSelectCard({ item, isSelected, onToggle }: CatalogIte
             <Icon name="dumbbell" size={14} color={colors.grey} />
             <Text className="ml-1 text-xs text-muted-foreground">
               {item.weight != null
-                ? `${convertWeight(item.weight, item.weightUnit ?? 'g')} ${unit}`
+                ? `${convertWeight({ weight: item.weight, fromUnit: item.weightUnit ?? 'g' })} ${unit}`
                 : ''}
             </Text>
           </View>

--- a/apps/expo/features/catalog/components/SimilarItems.tsx
+++ b/apps/expo/features/catalog/components/SimilarItems.tsx
@@ -58,7 +58,7 @@ const SimilarItemCard: React.FC<SimilarItemCardProps> = ({ item, onPress }) => {
 
         <Text className="mt-1 text-xs text-muted-foreground">
           {item.weight != null
-            ? `${convertWeight(item.weight, item.weightUnit ?? 'g')} ${unit}`
+            ? `${convertWeight({ weight: item.weight, fromUnit: item.weightUnit ?? 'g' })} ${unit}`
             : ''}
         </Text>
       </View>

--- a/apps/expo/features/catalog/components/SimilarItems.tsx
+++ b/apps/expo/features/catalog/components/SimilarItems.tsx
@@ -1,4 +1,5 @@
 import { Text } from '@packrat/ui/nativewindui';
+import { useWeightUnit } from 'expo-app/features/auth/hooks/useWeightUnit';
 import { type SimilarItem, useSimilarCatalogItems } from 'expo-app/features/catalog/hooks';
 import { useTranslation } from 'expo-app/lib/hooks/useTranslation';
 import { useRouter } from 'expo-router';
@@ -20,6 +21,7 @@ interface SimilarItemCardProps {
 
 const SimilarItemCard: React.FC<SimilarItemCardProps> = ({ item, onPress }) => {
   const { t } = useTranslation();
+  const { unit, convertWeight } = useWeightUnit();
 
   return (
     <Pressable
@@ -55,7 +57,9 @@ const SimilarItemCard: React.FC<SimilarItemCardProps> = ({ item, onPress }) => {
         </View>
 
         <Text className="mt-1 text-xs text-muted-foreground">
-          {item.weight} {item.weightUnit}
+          {item.weight != null
+            ? `${convertWeight(item.weight, item.weightUnit ?? 'g')} ${unit}`
+            : ''}
         </Text>
       </View>
     </Pressable>

--- a/apps/expo/features/catalog/screens/AddCatalogItemDetailsScreen.tsx
+++ b/apps/expo/features/catalog/screens/AddCatalogItemDetailsScreen.tsx
@@ -168,7 +168,7 @@ export function AddCatalogItemDetailsScreen() {
                   <Icon name="dumbbell" size={14} color={colors.grey2} />
                   <Text variant="caption2" className="ml-1">
                     {catalogItem.weight != null
-                      ? `${convertWeight(catalogItem.weight, catalogItem.weightUnit ?? 'g')} ${preferredWeightUnit}`
+                      ? `${convertWeight({ weight: catalogItem.weight, fromUnit: catalogItem.weightUnit ?? 'g' })} ${preferredWeightUnit}`
                       : ''}
                   </Text>
                   {catalogItem.brand && (

--- a/apps/expo/features/catalog/screens/AddCatalogItemDetailsScreen.tsx
+++ b/apps/expo/features/catalog/screens/AddCatalogItemDetailsScreen.tsx
@@ -1,10 +1,11 @@
-import { assertDefined, fromZod } from '@packrat/guards';
-import { WeightUnitSchema } from '@packrat/schemas/constants';
+import { assertDefined } from '@packrat/guards';
 import { Button, Text } from '@packrat/ui/nativewindui';
+import { displayWeight, normalize, parseWeightUnit } from '@packrat/units';
 import { useQueryClient } from '@tanstack/react-query';
 import * as Burnt from 'burnt';
 import { Icon } from 'expo-app/components/Icon';
 import { TextInput } from 'expo-app/components/TextInput';
+import { useWeightUnit } from 'expo-app/features/auth/hooks/useWeightUnit';
 import { useCreatePackItem, usePackDetailsFromStore } from 'expo-app/features/packs';
 import { useColorScheme } from 'expo-app/lib/hooks/useColorScheme';
 import { useTranslation } from 'expo-app/lib/hooks/useTranslation';
@@ -40,6 +41,7 @@ export function AddCatalogItemDetailsScreen() {
   const pack = usePackDetailsFromStore(packId as string);
   const createItem = useCreatePackItem();
   const queryClient = useQueryClient();
+  const { unit: preferredWeightUnit, convertWeight } = useWeightUnit();
   const fadeAnim = useState(new Animated.Value(0))[0];
   const [isAdding, setIsAdding] = useState(false);
   const { t } = useTranslation();
@@ -83,8 +85,14 @@ export function AddCatalogItemDetailsScreen() {
       itemData: {
         name: catalogItem.name,
         description: catalogItem.description ?? undefined,
-        weight: catalogItem.weight || 0,
-        weightUnit: fromZod(WeightUnitSchema)(catalogItem.weightUnit) ?? 'g',
+        weight: displayWeight({
+          grams: normalize({
+            weight: catalogItem.weight || 0,
+            unit: parseWeightUnit({ value: catalogItem.weightUnit }),
+          }),
+          unit: preferredWeightUnit,
+        }),
+        weightUnit: preferredWeightUnit,
         quantity: Number.parseInt(quantity, 10) || 1,
         category,
         consumable: isConsumable,
@@ -159,7 +167,9 @@ export function AddCatalogItemDetailsScreen() {
                 <View className="mt-1 flex-row items-center">
                   <Icon name="dumbbell" size={14} color={colors.grey2} />
                   <Text variant="caption2" className="ml-1">
-                    {catalogItem.weight} {catalogItem.weightUnit}
+                    {catalogItem.weight != null
+                      ? `${convertWeight(catalogItem.weight, catalogItem.weightUnit ?? 'g')} ${preferredWeightUnit}`
+                      : ''}
                   </Text>
                   {catalogItem.brand && (
                     <>

--- a/apps/expo/features/catalog/screens/CatalogItemDetailScreen.tsx
+++ b/apps/expo/features/catalog/screens/CatalogItemDetailScreen.tsx
@@ -56,7 +56,8 @@ function VariantRow({ variant }: { variant: CatalogItem }) {
           )}
           {variant.weight != null && (
             <Text className="text-xs text-muted-foreground">
-              {convertWeight(variant.weight ?? 0, variant.weightUnit ?? 'g')} {unit}
+              {convertWeight({ weight: variant.weight ?? 0, fromUnit: variant.weightUnit ?? 'g' })}{' '}
+              {unit}
             </Text>
           )}
           {variant.availability && (
@@ -256,7 +257,7 @@ export function CatalogItemDetailScreen() {
               <Chip textClassName="text-center" variant="secondary">
                 <RNText>
                   {item.weight != null
-                    ? `${convertWeight(item.weight, item.weightUnit ?? 'g')} ${unit}`
+                    ? `${convertWeight({ weight: item.weight, fromUnit: item.weightUnit ?? 'g' })} ${unit}`
                     : t('catalog.notSpecified')}
                 </RNText>
               </Chip>

--- a/apps/expo/features/catalog/screens/CatalogItemDetailScreen.tsx
+++ b/apps/expo/features/catalog/screens/CatalogItemDetailScreen.tsx
@@ -4,6 +4,7 @@ import { catalogGroupVariantsAtom } from 'expo-app/atoms/catalogGroupAtom';
 import { Icon } from 'expo-app/components/Icon';
 import { Chip } from 'expo-app/components/initial/Chip';
 import { ExpandableText } from 'expo-app/components/initial/ExpandableText';
+import { useWeightUnit } from 'expo-app/features/auth/hooks/useWeightUnit';
 import { ItemLinks } from 'expo-app/features/catalog/components/ItemLinks';
 import { ItemReviews } from 'expo-app/features/catalog/components/ItemReviews';
 import { SimilarItems } from 'expo-app/features/catalog/components/SimilarItems';
@@ -35,6 +36,7 @@ import type { CatalogItem } from '../types';
 function VariantRow({ variant }: { variant: CatalogItem }) {
   const { t } = useTranslation();
   const { colors } = useColorScheme();
+  const { unit, convertWeight } = useWeightUnit();
   const label = [variant.size, variant.color].filter(Boolean).join(' · ');
   return (
     <View className="flex-row items-center justify-between border-b border-border py-3">
@@ -54,7 +56,7 @@ function VariantRow({ variant }: { variant: CatalogItem }) {
           )}
           {variant.weight != null && (
             <Text className="text-xs text-muted-foreground">
-              {variant.weight} {variant.weightUnit}
+              {convertWeight(variant.weight ?? 0, variant.weightUnit ?? 'g')} {unit}
             </Text>
           )}
           {variant.availability && (
@@ -96,6 +98,7 @@ export function CatalogItemDetailScreen() {
   const { data: item, isLoading, isError, refetch } = useCatalogItemDetails(id as string);
   const { colors } = useColorScheme();
   const { t } = useTranslation();
+  const { unit, convertWeight } = useWeightUnit();
   const MATERIAL_LENGTH_THRESHOLD = 60;
 
   const [viewerIndex, setViewerIndex] = useState<number | null>(null);
@@ -252,8 +255,8 @@ export function CatalogItemDetailScreen() {
               </Text>
               <Chip textClassName="text-center" variant="secondary">
                 <RNText>
-                  {item.weight !== undefined && item.weightUnit
-                    ? `${item.weight} ${item.weightUnit}`
+                  {item.weight != null
+                    ? `${convertWeight(item.weight, item.weightUnit ?? 'g')} ${unit}`
                     : t('catalog.notSpecified')}
                 </RNText>
               </Chip>

--- a/apps/expo/features/packs/components/CurrentPackTile.tsx
+++ b/apps/expo/features/packs/components/CurrentPackTile.tsx
@@ -1,5 +1,6 @@
 import { Avatar, AvatarFallback, AvatarImage, ListItem, Text } from '@packrat/ui/nativewindui';
 import { Icon } from 'expo-app/components/Icon';
+import { useWeightUnit } from 'expo-app/features/auth/hooks/useWeightUnit';
 import { useColorScheme } from 'expo-app/lib/hooks/useColorScheme';
 import { useTranslation } from 'expo-app/lib/hooks/useTranslation';
 import { useRouter } from 'expo-router';
@@ -11,6 +12,7 @@ const _LOGO_SOURCE = require('expo-app/assets/packrat-app-icon-gradient.png');
 export function CurrentPackTile() {
   const { t } = useTranslation();
   const currentPack = useCurrentPack();
+  const { unit, convertWeight } = useWeightUnit();
 
   const router = useRouter();
 
@@ -40,7 +42,7 @@ export function CurrentPackTile() {
       rightView={
         <View className="flex-1 flex-row items-center justify-center gap-2 px-4">
           <Text variant="callout" className="ios:px-0 px-2 text-muted-foreground">
-            {currentPack ? `${currentPack.totalWeight} g` : ''}
+            {currentPack ? `${convertWeight(currentPack.totalWeight, 'g')} ${unit}` : ''}
           </Text>
           <ChevronRight />
         </View>

--- a/apps/expo/features/packs/components/CurrentPackTile.tsx
+++ b/apps/expo/features/packs/components/CurrentPackTile.tsx
@@ -42,7 +42,9 @@ export function CurrentPackTile() {
       rightView={
         <View className="flex-1 flex-row items-center justify-center gap-2 px-4">
           <Text variant="callout" className="ios:px-0 px-2 text-muted-foreground">
-            {currentPack ? `${convertWeight(currentPack.totalWeight, 'g')} ${unit}` : ''}
+            {currentPack
+              ? `${convertWeight({ weight: currentPack.totalWeight, fromUnit: 'g' })} ${unit}`
+              : ''}
           </Text>
           <ChevronRight />
         </View>

--- a/apps/expo/features/packs/components/HorizontalCatalogItemCard.tsx
+++ b/apps/expo/features/packs/components/HorizontalCatalogItemCard.tsx
@@ -1,5 +1,7 @@
 import { Text } from '@packrat/ui/nativewindui';
+import { parseWeightUnit } from '@packrat/units';
 import { Icon } from 'expo-app/components/Icon';
+import { useWeightUnit } from 'expo-app/features/auth/hooks/useWeightUnit';
 import { CatalogItemImage } from 'expo-app/features/catalog/components/CatalogItemImage';
 import type { CatalogItem } from 'expo-app/features/catalog/types';
 import { useColorScheme } from 'expo-app/lib/hooks/useColorScheme';
@@ -33,11 +35,6 @@ type HorizontalCatalogItemCardProps = {
 const formatPrice = ({ price, currency }: { price?: number | null; currency?: string | null }) => {
   if (!price) return '';
   return `${currency || '$'}${price.toFixed(2)}`;
-};
-
-const formatWeight = ({ weight, unit }: { weight?: number | null; unit?: string | null }) => {
-  if (!weight) return '';
-  return `${parseFloat(weight.toFixed(2))}${unit || 'g'}`;
 };
 
 function ScalePress({
@@ -75,6 +72,7 @@ function ScalePress({
 
 export function HorizontalCatalogItemCard({ item, ...restProps }: HorizontalCatalogItemCardProps) {
   const { colors } = useColorScheme();
+  const { unit: displayUnit, convertWeight } = useWeightUnit();
 
   const handleCardPress = () => {
     if ('onSelect' in restProps) {
@@ -115,7 +113,8 @@ export function HorizontalCatalogItemCard({ item, ...restProps }: HorizontalCata
             )}
             {!!item.weight && (
               <Text className="text-sm text-muted-foreground">
-                {formatWeight({ weight: item.weight, unit: item.weightUnit })}
+                {convertWeight(item.weight, parseWeightUnit({ value: item.weightUnit }))}{' '}
+                {displayUnit}
               </Text>
             )}
             {!!item.ratingValue && (

--- a/apps/expo/features/packs/components/HorizontalCatalogItemCard.tsx
+++ b/apps/expo/features/packs/components/HorizontalCatalogItemCard.tsx
@@ -113,7 +113,10 @@ export function HorizontalCatalogItemCard({ item, ...restProps }: HorizontalCata
             )}
             {!!item.weight && (
               <Text className="text-sm text-muted-foreground">
-                {convertWeight(item.weight, parseWeightUnit({ value: item.weightUnit }))}{' '}
+                {convertWeight({
+                  weight: item.weight,
+                  fromUnit: parseWeightUnit({ value: item.weightUnit }),
+                })}{' '}
                 {displayUnit}
               </Text>
             )}

--- a/apps/expo/features/packs/components/HorizontalCatalogItemCard.tsx
+++ b/apps/expo/features/packs/components/HorizontalCatalogItemCard.tsx
@@ -37,7 +37,7 @@ const formatPrice = ({ price, currency }: { price?: number | null; currency?: st
 
 const formatWeight = ({ weight, unit }: { weight?: number | null; unit?: string | null }) => {
   if (!weight) return '';
-  return `${weight}${unit || 'g'}`;
+  return `${parseFloat(weight.toFixed(2))}${unit || 'g'}`;
 };
 
 function ScalePress({

--- a/apps/expo/features/packs/components/WeightAnalysisTile.tsx
+++ b/apps/expo/features/packs/components/WeightAnalysisTile.tsx
@@ -16,7 +16,7 @@ export function WeightAnalysisTile() {
   const { unit, convertWeight } = useWeightUnit();
   const alertRef = useRef<AlertMethods>(null);
 
-  const packWeight = convertWeight(currentPack?.totalWeight ?? 0, 'g');
+  const packWeight = convertWeight({ weight: currentPack?.totalWeight ?? 0, fromUnit: 'g' });
   const route: Href | null = currentPack ? `/weight-analysis/${currentPack.id}` : null;
 
   const handlePress = () => {

--- a/apps/expo/features/packs/components/WeightAnalysisTile.tsx
+++ b/apps/expo/features/packs/components/WeightAnalysisTile.tsx
@@ -1,6 +1,7 @@
 import type { AlertMethods } from '@packrat/ui/nativewindui';
 import { Alert, ListItem, Text } from '@packrat/ui/nativewindui';
 import { Icon } from 'expo-app/components/Icon';
+import { useWeightUnit } from 'expo-app/features/auth/hooks/useWeightUnit';
 import { useColorScheme } from 'expo-app/lib/hooks/useColorScheme';
 import { useTranslation } from 'expo-app/lib/hooks/useTranslation';
 import { type Href, useRouter } from 'expo-router';
@@ -12,9 +13,10 @@ export function WeightAnalysisTile() {
   const { t } = useTranslation();
   const router = useRouter();
   const currentPack = useCurrentPack();
+  const { unit, convertWeight } = useWeightUnit();
   const alertRef = useRef<AlertMethods>(null);
 
-  const packWeight = currentPack?.totalWeight ?? 0;
+  const packWeight = convertWeight(currentPack?.totalWeight ?? 0, 'g');
   const route: Href | null = currentPack ? `/weight-analysis/${currentPack.id}` : null;
 
   const handlePress = () => {
@@ -39,7 +41,7 @@ export function WeightAnalysisTile() {
         }
         rightView={
           <View className="flex-1 flex-row items-center justify-center gap-2 px-4">
-            <Text className="mr-2">{`Base: ${packWeight} g`}</Text>
+            <Text className="mr-2">{`Base: ${packWeight} ${unit}`}</Text>
             <ChevronRight />
           </View>
         }

--- a/apps/expo/features/packs/hooks/usePackWeightAnalysis.ts
+++ b/apps/expo/features/packs/hooks/usePackWeightAnalysis.ts
@@ -1,9 +1,13 @@
-import { userStore } from 'expo-app/features/auth/store';
+import { use$ } from '@legendapp/state/react';
+import { preferencesStore } from 'expo-app/features/auth/store/preferences';
+import { getDefaultWeightUnit } from 'expo-app/lib/unitDefaults';
 import { computeCategorySummaries, convertFromGrams, convertToGrams } from '../utils';
 import { usePackDetailsFromStore } from './usePackDetailsFromStore';
 
 export function usePackWeightAnalysis(packId: string) {
   const pack = usePackDetailsFromStore(packId);
+  const storedUnit = use$(preferencesStore.weightUnit);
+  const preferredUnit = storedUnit ?? getDefaultWeightUnit();
 
   const consumableWeightInGrams = pack.items
     .filter((item) => item.consumable)
@@ -21,22 +25,23 @@ export function usePackWeightAnalysis(packId: string) {
       return sum + convertToGrams({ weight: weight * item.quantity, unit: unit });
     }, 0);
 
-  const categorySummaries = computeCategorySummaries(pack);
+  const categorySummaries = computeCategorySummaries(pack, preferredUnit);
 
   return {
     data: {
-      baseWeight: pack.baseWeight,
-      consumableWeight: convertFromGrams({
-        grams: consumableWeightInGrams,
-        unit: userStore.preferredWeightUnit.peek() ?? 'g',
+      baseWeight: convertFromGrams({
+        grams: convertToGrams({ weight: pack.baseWeight, unit: 'g' }),
+        unit: preferredUnit,
       }),
-      wornWeight: convertFromGrams({
-        grams: wornWeightInGrams,
-        unit: userStore.preferredWeightUnit.peek() ?? 'g',
+      consumableWeight: convertFromGrams({ grams: consumableWeightInGrams, unit: preferredUnit }),
+      wornWeight: convertFromGrams({ grams: wornWeightInGrams, unit: preferredUnit }),
+      totalWeight: convertFromGrams({
+        grams: convertToGrams({ weight: pack.totalWeight, unit: 'g' }),
+        unit: preferredUnit,
       }),
-      totalWeight: pack.totalWeight,
       categories: categorySummaries,
     },
     items: pack.items,
+    preferredUnit,
   };
 }

--- a/apps/expo/features/packs/hooks/usePackWeightAnalysis.ts
+++ b/apps/expo/features/packs/hooks/usePackWeightAnalysis.ts
@@ -21,7 +21,7 @@ export function usePackWeightAnalysis(packId: string) {
     .reduce((s, i) => s + toGrams(i), 0);
   const wornGrams = pack.items.filter((i) => i.worn).reduce((s, i) => s + toGrams(i), 0);
 
-  const categorySummaries = computeCategorySummaries(pack, preferredUnit);
+  const categorySummaries = computeCategorySummaries({ pack, preferredUnit });
 
   return {
     data: {

--- a/apps/expo/features/packs/hooks/usePackWeightAnalysis.ts
+++ b/apps/expo/features/packs/hooks/usePackWeightAnalysis.ts
@@ -1,7 +1,8 @@
 import { use$ } from '@legendapp/state/react';
+import { displayWeight, normalize, parseWeightUnit } from '@packrat/units';
 import { preferencesStore } from 'expo-app/features/auth/store/preferences';
 import { getDefaultWeightUnit } from 'expo-app/lib/unitDefaults';
-import { computeCategorySummaries, convertFromGrams, convertToGrams } from '../utils';
+import { computeCategorySummaries } from '../utils';
 import { usePackDetailsFromStore } from './usePackDetailsFromStore';
 
 export function usePackWeightAnalysis(packId: string) {
@@ -9,36 +10,25 @@ export function usePackWeightAnalysis(packId: string) {
   const storedUnit = use$(preferencesStore.weightUnit);
   const preferredUnit = storedUnit ?? getDefaultWeightUnit();
 
-  const consumableWeightInGrams = pack.items
-    .filter((item) => item.consumable)
-    .reduce((sum, item) => {
-      const unit = item.weightUnit || 'g';
-      const weight = item.weight || 0;
-      return sum + convertToGrams({ weight: weight * item.quantity, unit: unit });
-    }, 0);
+  const toGrams = (item: { weight: number; weightUnit?: string | null; quantity: number }) =>
+    normalize({
+      weight: (item.weight || 0) * item.quantity,
+      unit: parseWeightUnit({ value: item.weightUnit }),
+    });
 
-  const wornWeightInGrams = pack.items
-    .filter((item) => item.worn)
-    .reduce((sum, item) => {
-      const unit = item.weightUnit || 'g';
-      const weight = item.weight || 0;
-      return sum + convertToGrams({ weight: weight * item.quantity, unit: unit });
-    }, 0);
+  const consumableGrams = pack.items
+    .filter((i) => i.consumable)
+    .reduce((s, i) => s + toGrams(i), 0);
+  const wornGrams = pack.items.filter((i) => i.worn).reduce((s, i) => s + toGrams(i), 0);
 
   const categorySummaries = computeCategorySummaries(pack, preferredUnit);
 
   return {
     data: {
-      baseWeight: convertFromGrams({
-        grams: convertToGrams({ weight: pack.baseWeight, unit: 'g' }),
-        unit: preferredUnit,
-      }),
-      consumableWeight: convertFromGrams({ grams: consumableWeightInGrams, unit: preferredUnit }),
-      wornWeight: convertFromGrams({ grams: wornWeightInGrams, unit: preferredUnit }),
-      totalWeight: convertFromGrams({
-        grams: convertToGrams({ weight: pack.totalWeight, unit: 'g' }),
-        unit: preferredUnit,
-      }),
+      baseWeight: displayWeight({ grams: pack.baseWeight, unit: preferredUnit }),
+      consumableWeight: displayWeight({ grams: consumableGrams, unit: preferredUnit }),
+      wornWeight: displayWeight({ grams: wornGrams, unit: preferredUnit }),
+      totalWeight: displayWeight({ grams: pack.totalWeight, unit: preferredUnit }),
       categories: categorySummaries,
     },
     items: pack.items,

--- a/apps/expo/features/packs/screens/CreatePackItemForm.tsx
+++ b/apps/expo/features/packs/screens/CreatePackItemForm.tsx
@@ -5,6 +5,7 @@ import { Form, FormItem, FormSection, SegmentedControl, TextField } from '@packr
 import * as Sentry from '@sentry/react-native';
 import { useForm } from '@tanstack/react-form';
 import { Icon } from 'expo-app/components/Icon';
+import { useWeightUnit } from 'expo-app/features/auth/hooks/useWeightUnit';
 import { useColorScheme } from 'expo-app/lib/hooks/useColorScheme';
 import { useTranslation } from 'expo-app/lib/hooks/useTranslation';
 import { testIds } from 'expo-app/lib/testIds';
@@ -47,6 +48,7 @@ export const CreatePackItemForm = ({
   const router = useRouter();
   const { colors } = useColorScheme();
   const { showActionSheetWithOptions } = useActionSheet();
+  const { unit: preferredWeightUnit } = useWeightUnit();
   const createPackItem = useCreatePackItem();
   const updatePackItem = useUpdatePackItem();
   const insets = useSafeAreaInsets();
@@ -97,7 +99,7 @@ export const CreatePackItemForm = ({
           name: '',
           description: '',
           weight: 0,
-          weightUnit: 'g',
+          weightUnit: preferredWeightUnit,
           quantity: 1,
           category: '',
           consumable: false,

--- a/apps/expo/features/packs/utils/__tests__/computeCategories.test.ts
+++ b/apps/expo/features/packs/utils/__tests__/computeCategories.test.ts
@@ -34,7 +34,7 @@ function makePack(items: PackItem[]): Pack {
 
 describe('computeCategorySummaries', () => {
   it('returns empty array for a pack with no items', () => {
-    expect(computeCategorySummaries(makePack([]))).toEqual([]);
+    expect(computeCategorySummaries(makePack([]), 'g')).toEqual([]);
   });
 
   it('groups items under the correct category name', () => {
@@ -42,7 +42,7 @@ describe('computeCategorySummaries', () => {
       makeItem({ id: 'i1', weight: 200, weightUnit: 'g', category: 'Shelter' }),
       makeItem({ id: 'i2', weight: 300, weightUnit: 'g', category: 'Food' }),
     ];
-    const result = computeCategorySummaries(makePack(items));
+    const result = computeCategorySummaries(makePack(items), 'g');
     expect(result).toHaveLength(2);
     const names = result.map((c) => c.name);
     expect(names).toContain('Shelter');
@@ -51,37 +51,49 @@ describe('computeCategorySummaries', () => {
 
   it('falls back to "Other" for empty category string', () => {
     const items = [makeItem({ id: 'i1', weight: 100, weightUnit: 'g', category: '' })];
-    const result = computeCategorySummaries(makePack(items));
+    const result = computeCategorySummaries(makePack(items), 'g');
     expect(result[0]?.name).toBe('Other');
   });
 
   it('falls back to "Other" for whitespace-only category', () => {
     const items = [makeItem({ id: 'i1', weight: 100, weightUnit: 'g', category: '   ' })];
-    const result = computeCategorySummaries(makePack(items));
+    const result = computeCategorySummaries(makePack(items), 'g');
     expect(result[0]?.name).toBe('Other');
   });
 
   it('computes weight in preferred unit (grams)', () => {
     const items = [makeItem({ weight: 500, weightUnit: 'g', category: 'Pack' })];
-    const result = computeCategorySummaries(makePack(items));
+    const result = computeCategorySummaries(makePack(items), 'g');
     expect(result[0]?.weight).toBe(500);
   });
 
   it('converts weight units before computing (kg → g)', () => {
     const items = [makeItem({ weight: 1, weightUnit: 'kg', category: 'Pack' })];
-    const result = computeCategorySummaries(makePack(items));
+    const result = computeCategorySummaries(makePack(items), 'g');
     expect(result[0]?.weight).toBe(1000);
+  });
+
+  it('outputs weight in kg when preferredUnit is kg', () => {
+    const items = [makeItem({ weight: 1000, weightUnit: 'g', category: 'Pack' })];
+    const result = computeCategorySummaries(makePack(items), 'kg');
+    expect(result[0]?.weight).toBe(1);
+  });
+
+  it('outputs weight in lb when preferredUnit is lb', () => {
+    const items = [makeItem({ weight: 453.592, weightUnit: 'g', category: 'Pack' })];
+    const result = computeCategorySummaries(makePack(items), 'lb');
+    expect(result[0]?.weight).toBeCloseTo(1, 1);
   });
 
   it('multiplies weight by quantity', () => {
     const items = [makeItem({ weight: 100, weightUnit: 'g', quantity: 3, category: 'Food' })];
-    const result = computeCategorySummaries(makePack(items));
+    const result = computeCategorySummaries(makePack(items), 'g');
     expect(result[0]?.weight).toBe(300);
   });
 
   it('sets percentage to 100 for a single-category pack', () => {
     const items = [makeItem({ weight: 300, weightUnit: 'g', category: 'Electronics' })];
-    const result = computeCategorySummaries(makePack(items));
+    const result = computeCategorySummaries(makePack(items), 'g');
     expect(result[0]?.percentage).toBe(100);
   });
 
@@ -90,7 +102,7 @@ describe('computeCategorySummaries', () => {
       makeItem({ id: 'i1', weight: 500, weightUnit: 'g', category: 'Shelter' }),
       makeItem({ id: 'i2', weight: 500, weightUnit: 'g', category: 'Food' }),
     ];
-    const result = computeCategorySummaries(makePack(items));
+    const result = computeCategorySummaries(makePack(items), 'g');
     for (const cat of result) {
       expect(cat.percentage).toBe(50);
     }
@@ -101,7 +113,7 @@ describe('computeCategorySummaries', () => {
       makeItem({ id: 'i1', weight: 100, weightUnit: 'g', quantity: 5, category: 'Food' }),
       makeItem({ id: 'i2', weight: 200, weightUnit: 'g', quantity: 2, category: 'Food' }),
     ];
-    const result = computeCategorySummaries(makePack(items));
+    const result = computeCategorySummaries(makePack(items), 'g');
     expect(result[0]?.items).toBe(2);
   });
 
@@ -110,14 +122,14 @@ describe('computeCategorySummaries', () => {
       makeItem({ id: 'i1', weight: 300, weightUnit: 'g', category: 'Shelter' }),
       makeItem({ id: 'i2', weight: 200, weightUnit: 'g', category: 'Shelter' }),
     ];
-    const result = computeCategorySummaries(makePack(items));
+    const result = computeCategorySummaries(makePack(items), 'g');
     expect(result).toHaveLength(1);
     expect(result[0]?.weight).toBe(500);
   });
 
   it('sets percentage to 0 when total weight is zero', () => {
     const items = [makeItem({ weight: 0, weightUnit: 'g', category: 'Empty' })];
-    const result = computeCategorySummaries(makePack(items));
+    const result = computeCategorySummaries(makePack(items), 'g');
     expect(result[0]?.percentage).toBe(0);
   });
 });

--- a/apps/expo/features/packs/utils/__tests__/computeCategories.test.ts
+++ b/apps/expo/features/packs/utils/__tests__/computeCategories.test.ts
@@ -1,14 +1,6 @@
 import type { Pack, PackItem } from 'expo-app/features/packs/types';
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { computeCategorySummaries } from '../computeCategories';
-
-vi.mock('expo-app/features/auth/store', () => ({
-  userStore: {
-    preferredWeightUnit: {
-      peek: vi.fn().mockReturnValue('g'),
-    },
-  },
-}));
 
 function makeItem(
   overrides: Partial<PackItem> & Pick<PackItem, 'weight' | 'weightUnit'>,

--- a/apps/expo/features/packs/utils/__tests__/computeCategories.test.ts
+++ b/apps/expo/features/packs/utils/__tests__/computeCategories.test.ts
@@ -34,7 +34,7 @@ function makePack(items: PackItem[]): Pack {
 
 describe('computeCategorySummaries', () => {
   it('returns empty array for a pack with no items', () => {
-    expect(computeCategorySummaries(makePack([]), 'g')).toEqual([]);
+    expect(computeCategorySummaries({ pack: makePack([]), preferredUnit: 'g' })).toEqual([]);
   });
 
   it('groups items under the correct category name', () => {
@@ -42,7 +42,7 @@ describe('computeCategorySummaries', () => {
       makeItem({ id: 'i1', weight: 200, weightUnit: 'g', category: 'Shelter' }),
       makeItem({ id: 'i2', weight: 300, weightUnit: 'g', category: 'Food' }),
     ];
-    const result = computeCategorySummaries(makePack(items), 'g');
+    const result = computeCategorySummaries({ pack: makePack(items), preferredUnit: 'g' });
     expect(result).toHaveLength(2);
     const names = result.map((c) => c.name);
     expect(names).toContain('Shelter');
@@ -51,49 +51,49 @@ describe('computeCategorySummaries', () => {
 
   it('falls back to "Other" for empty category string', () => {
     const items = [makeItem({ id: 'i1', weight: 100, weightUnit: 'g', category: '' })];
-    const result = computeCategorySummaries(makePack(items), 'g');
+    const result = computeCategorySummaries({ pack: makePack(items), preferredUnit: 'g' });
     expect(result[0]?.name).toBe('Other');
   });
 
   it('falls back to "Other" for whitespace-only category', () => {
     const items = [makeItem({ id: 'i1', weight: 100, weightUnit: 'g', category: '   ' })];
-    const result = computeCategorySummaries(makePack(items), 'g');
+    const result = computeCategorySummaries({ pack: makePack(items), preferredUnit: 'g' });
     expect(result[0]?.name).toBe('Other');
   });
 
   it('computes weight in preferred unit (grams)', () => {
     const items = [makeItem({ weight: 500, weightUnit: 'g', category: 'Pack' })];
-    const result = computeCategorySummaries(makePack(items), 'g');
+    const result = computeCategorySummaries({ pack: makePack(items), preferredUnit: 'g' });
     expect(result[0]?.weight).toBe(500);
   });
 
   it('converts weight units before computing (kg → g)', () => {
     const items = [makeItem({ weight: 1, weightUnit: 'kg', category: 'Pack' })];
-    const result = computeCategorySummaries(makePack(items), 'g');
+    const result = computeCategorySummaries({ pack: makePack(items), preferredUnit: 'g' });
     expect(result[0]?.weight).toBe(1000);
   });
 
   it('outputs weight in kg when preferredUnit is kg', () => {
     const items = [makeItem({ weight: 1000, weightUnit: 'g', category: 'Pack' })];
-    const result = computeCategorySummaries(makePack(items), 'kg');
+    const result = computeCategorySummaries({ pack: makePack(items), preferredUnit: 'kg' });
     expect(result[0]?.weight).toBe(1);
   });
 
   it('outputs weight in lb when preferredUnit is lb', () => {
     const items = [makeItem({ weight: 453.592, weightUnit: 'g', category: 'Pack' })];
-    const result = computeCategorySummaries(makePack(items), 'lb');
+    const result = computeCategorySummaries({ pack: makePack(items), preferredUnit: 'lb' });
     expect(result[0]?.weight).toBeCloseTo(1, 1);
   });
 
   it('multiplies weight by quantity', () => {
     const items = [makeItem({ weight: 100, weightUnit: 'g', quantity: 3, category: 'Food' })];
-    const result = computeCategorySummaries(makePack(items), 'g');
+    const result = computeCategorySummaries({ pack: makePack(items), preferredUnit: 'g' });
     expect(result[0]?.weight).toBe(300);
   });
 
   it('sets percentage to 100 for a single-category pack', () => {
     const items = [makeItem({ weight: 300, weightUnit: 'g', category: 'Electronics' })];
-    const result = computeCategorySummaries(makePack(items), 'g');
+    const result = computeCategorySummaries({ pack: makePack(items), preferredUnit: 'g' });
     expect(result[0]?.percentage).toBe(100);
   });
 
@@ -102,7 +102,7 @@ describe('computeCategorySummaries', () => {
       makeItem({ id: 'i1', weight: 500, weightUnit: 'g', category: 'Shelter' }),
       makeItem({ id: 'i2', weight: 500, weightUnit: 'g', category: 'Food' }),
     ];
-    const result = computeCategorySummaries(makePack(items), 'g');
+    const result = computeCategorySummaries({ pack: makePack(items), preferredUnit: 'g' });
     for (const cat of result) {
       expect(cat.percentage).toBe(50);
     }
@@ -113,7 +113,7 @@ describe('computeCategorySummaries', () => {
       makeItem({ id: 'i1', weight: 100, weightUnit: 'g', quantity: 5, category: 'Food' }),
       makeItem({ id: 'i2', weight: 200, weightUnit: 'g', quantity: 2, category: 'Food' }),
     ];
-    const result = computeCategorySummaries(makePack(items), 'g');
+    const result = computeCategorySummaries({ pack: makePack(items), preferredUnit: 'g' });
     expect(result[0]?.items).toBe(2);
   });
 
@@ -122,14 +122,14 @@ describe('computeCategorySummaries', () => {
       makeItem({ id: 'i1', weight: 300, weightUnit: 'g', category: 'Shelter' }),
       makeItem({ id: 'i2', weight: 200, weightUnit: 'g', category: 'Shelter' }),
     ];
-    const result = computeCategorySummaries(makePack(items), 'g');
+    const result = computeCategorySummaries({ pack: makePack(items), preferredUnit: 'g' });
     expect(result).toHaveLength(1);
     expect(result[0]?.weight).toBe(500);
   });
 
   it('sets percentage to 0 when total weight is zero', () => {
     const items = [makeItem({ weight: 0, weightUnit: 'g', category: 'Empty' })];
-    const result = computeCategorySummaries(makePack(items), 'g');
+    const result = computeCategorySummaries({ pack: makePack(items), preferredUnit: 'g' });
     expect(result[0]?.percentage).toBe(0);
   });
 });

--- a/apps/expo/features/packs/utils/computeCategories.ts
+++ b/apps/expo/features/packs/utils/computeCategories.ts
@@ -10,10 +10,7 @@ export type CategorySummary = {
   percentage: number;
 };
 
-export function computeCategorySummaries(
-  pack: Pack,
-  preferredUnit: WeightUnit = 'g',
-): CategorySummary[] {
+export function computeCategorySummaries(pack: Pack, preferredUnit: WeightUnit): CategorySummary[] {
   const categoryMap: Record<string, { weightInGrams: number; items: number }> = {};
 
   let totalWeightGrams = 0;

--- a/apps/expo/features/packs/utils/computeCategories.ts
+++ b/apps/expo/features/packs/utils/computeCategories.ts
@@ -1,6 +1,6 @@
 import { assertDefined } from '@packrat/guards';
+import type { WeightUnit } from '@packrat/units';
 import { displayWeight, normalize, parseWeightUnit } from '@packrat/units';
-import { userStore } from 'expo-app/features/auth/store';
 import type { Pack } from '../types';
 
 export type CategorySummary = {
@@ -10,11 +10,10 @@ export type CategorySummary = {
   percentage: number;
 };
 
-export function computeCategorySummaries(pack: Pack): CategorySummary[] {
-  const preferredUnit = parseWeightUnit({
-    value: userStore.preferredWeightUnit.peek(),
-    fallback: 'g',
-  });
+export function computeCategorySummaries(
+  pack: Pack,
+  preferredUnit: WeightUnit = 'g',
+): CategorySummary[] {
   const categoryMap: Record<string, { weightInGrams: number; items: number }> = {};
 
   let totalWeightGrams = 0;

--- a/apps/expo/features/packs/utils/computeCategories.ts
+++ b/apps/expo/features/packs/utils/computeCategories.ts
@@ -10,7 +10,13 @@ export type CategorySummary = {
   percentage: number;
 };
 
-export function computeCategorySummaries(pack: Pack, preferredUnit: WeightUnit): CategorySummary[] {
+export function computeCategorySummaries({
+  pack,
+  preferredUnit,
+}: {
+  pack: Pack;
+  preferredUnit: WeightUnit;
+}): CategorySummary[] {
   const categoryMap: Record<string, { weightInGrams: number; items: number }> = {};
 
   let totalWeightGrams = 0;

--- a/apps/expo/features/trips/screens/TripWeatherDetailsScreen.tsx
+++ b/apps/expo/features/trips/screens/TripWeatherDetailsScreen.tsx
@@ -94,7 +94,7 @@ export default function TripWeatherDetailsScreen() {
 
   const location = weather.location;
   const current = weather.current;
-  const { displayTemperature, toPreferred } = useTemperatureUnit();
+  const { displayTemperature } = useTemperatureUnit();
 
   // Use the trip's location name if provided, otherwise fall back to weather API location
   const displayLocationName = tripLocationName || location.name;
@@ -137,8 +137,8 @@ export default function TripWeatherDetailsScreen() {
             <Text className="text-xl text-white">{current.condition.text}</Text>
 
             <Text className="text-white/80 mt-2">
-              H:{toPreferred(weather.forecast.forecastday[0]?.day.maxtemp_c ?? 0)}° L:
-              {toPreferred(weather.forecast.forecastday[0]?.day.mintemp_c ?? 0)}°
+              H:{displayTemperature(weather.forecast.forecastday[0]?.day.maxtemp_c ?? 0)} L:
+              {displayTemperature(weather.forecast.forecastday[0]?.day.mintemp_c ?? 0)}
             </Text>
           </View>
           <WeatherForecast

--- a/apps/expo/features/trips/screens/TripWeatherDetailsScreen.tsx
+++ b/apps/expo/features/trips/screens/TripWeatherDetailsScreen.tsx
@@ -1,6 +1,7 @@
 import type { WeatherAPIForecastResponse } from '@packrat/schemas/weather';
 import * as Sentry from '@sentry/react-native';
 import { Icon } from 'expo-app/components/Icon';
+import { useTemperatureUnit } from 'expo-app/features/auth/hooks/useTemperatureUnit';
 import { WeatherForecast } from 'expo-app/features/weather/components/WeatherForecast';
 import {
   getWeatherBackgroundColors,
@@ -93,6 +94,7 @@ export default function TripWeatherDetailsScreen() {
 
   const location = weather.location;
   const current = weather.current;
+  const { displayTemperature, toPreferred } = useTemperatureUnit();
 
   // Use the trip's location name if provided, otherwise fall back to weather API location
   const displayLocationName = tripLocationName || location.name;
@@ -130,13 +132,13 @@ export default function TripWeatherDetailsScreen() {
           <View className="items-center">
             <Text className="text-3xl text-white font-semibold">{displayLocationName}</Text>
 
-            <Text className="text-7xl text-white mt-6">{current.temp_c}°</Text>
+            <Text className="text-7xl text-white mt-6">{displayTemperature(current.temp_c)}</Text>
 
             <Text className="text-xl text-white">{current.condition.text}</Text>
 
             <Text className="text-white/80 mt-2">
-              H:{weather.forecast.forecastday[0]?.day.maxtemp_c}° L:
-              {weather.forecast.forecastday[0]?.day.mintemp_c}°
+              H:{toPreferred(weather.forecast.forecastday[0]?.day.maxtemp_c ?? 0)}° L:
+              {toPreferred(weather.forecast.forecastday[0]?.day.mintemp_c ?? 0)}°
             </Text>
           </View>
           <WeatherForecast
@@ -149,7 +151,7 @@ export default function TripWeatherDetailsScreen() {
               uvIndex: current.uv,
               windSpeed: Math.round(current.wind_kph),
             }}
-            temperature={Math.round(current.temp_c)}
+            temperature={current.temp_c}
           />
         </ScrollView>
       </LinearGradient>

--- a/apps/expo/features/weather/components/LocationCard.tsx
+++ b/apps/expo/features/weather/components/LocationCard.tsx
@@ -1,5 +1,6 @@
 import { useActionSheet } from '@expo/react-native-action-sheet';
 import { Text } from '@packrat/ui/nativewindui';
+import { useTemperatureUnit } from 'expo-app/features/auth/hooks/useTemperatureUnit';
 import { cn } from 'expo-app/lib/cn';
 import { useColorScheme } from 'expo-app/lib/hooks/useColorScheme';
 import { useTranslation } from 'expo-app/lib/hooks/useTranslation';
@@ -19,6 +20,7 @@ export function LocationCard({ location, onPress, onSetActive, onRemove }: Locat
   const { showActionSheetWithOptions } = useActionSheet();
   const { t } = useTranslation();
   const insets = useSafeAreaInsets();
+  const { displayTemperature, toPreferred } = useTemperatureUnit();
 
   const handleLongPress = () => {
     const options = location.isActive
@@ -41,7 +43,7 @@ export function LocationCard({ location, onPress, onSetActive, onRemove }: Locat
         cancelButtonIndex,
         destructiveButtonIndex,
         title: location.name,
-        message: `${location.temperature}° - ${location.condition}`,
+        message: `${displayTemperature(location.temperature)} - ${location.condition}`,
         containerStyle: {
           backgroundColor: colorScheme === 'dark' ? colors.card : 'white',
           paddingBottom: insets.bottom,
@@ -107,9 +109,11 @@ export function LocationCard({ location, onPress, onSetActive, onRemove }: Locat
               )}
             </View>
             <View className="items-end">
-              <Text className="text-4xl text-white">{location.temperature}°</Text>
+              <Text className="text-4xl text-white">
+                {displayTemperature(location.temperature)}
+              </Text>
               <Text className="mt-1 text-xs text-white">
-                H:{location.highTemp}° L:{location.lowTemp}°
+                H:{toPreferred(location.highTemp)}° L:{toPreferred(location.lowTemp)}°
               </Text>
             </View>
           </View>

--- a/apps/expo/features/weather/components/LocationCard.tsx
+++ b/apps/expo/features/weather/components/LocationCard.tsx
@@ -20,7 +20,7 @@ export function LocationCard({ location, onPress, onSetActive, onRemove }: Locat
   const { showActionSheetWithOptions } = useActionSheet();
   const { t } = useTranslation();
   const insets = useSafeAreaInsets();
-  const { displayTemperature, toPreferred } = useTemperatureUnit();
+  const { displayTemperature } = useTemperatureUnit();
 
   const handleLongPress = () => {
     const options = location.isActive
@@ -113,7 +113,7 @@ export function LocationCard({ location, onPress, onSetActive, onRemove }: Locat
                 {displayTemperature(location.temperature)}
               </Text>
               <Text className="mt-1 text-xs text-white">
-                H:{toPreferred(location.highTemp)}° L:{toPreferred(location.lowTemp)}°
+                H:{displayTemperature(location.highTemp)} L:{displayTemperature(location.lowTemp)}
               </Text>
             </View>
           </View>

--- a/apps/expo/features/weather/components/LocationPicker.tsx
+++ b/apps/expo/features/weather/components/LocationPicker.tsx
@@ -1,6 +1,7 @@
 import { assertNonNull } from '@packrat/guards';
 import { Button, Text } from '@packrat/ui/nativewindui';
 import { Icon } from 'expo-app/components/Icon';
+import { useTemperatureUnit } from 'expo-app/features/auth/hooks/useTemperatureUnit';
 import { cn } from 'expo-app/lib/cn';
 import { useColorScheme } from 'expo-app/lib/hooks/useColorScheme';
 import { useTranslation } from 'expo-app/lib/hooks/useTranslation';
@@ -38,6 +39,7 @@ export function LocationPicker({
   const { locationsState } = useLocations();
   const { activeLocation } = useActiveLocation();
   const [selectedLocation, setSelectedLocation] = useState<WeatherLocation | null>(activeLocation);
+  const { displayTemperature } = useTemperatureUnit();
 
   // Use translations for default values
   const displayTitle = title ?? t('location.selectLocation');
@@ -101,7 +103,7 @@ export function LocationPicker({
                         <View className="mx-1 h-1 w-1 rounded-full bg-muted-foreground" />
                       </>
                     )}
-                    <Text className="text-2xl">{location.temperature}°</Text>
+                    <Text className="text-2xl">{displayTemperature(location.temperature)}</Text>
                   </View>
                 </Pressable>
               ))}

--- a/apps/expo/features/weather/components/WeatherForecast.tsx
+++ b/apps/expo/features/weather/components/WeatherForecast.tsx
@@ -1,5 +1,6 @@
 import { Text } from '@packrat/ui/nativewindui';
 import { Icon } from 'expo-app/components/Icon';
+import { useSpeedUnit } from 'expo-app/features/auth/hooks/useSpeedUnit';
 import { useTemperatureUnit } from 'expo-app/features/auth/hooks/useTemperatureUnit';
 import { cn } from 'expo-app/lib/cn';
 import { useTranslation } from 'expo-app/lib/hooks/useTranslation';
@@ -42,7 +43,8 @@ export function WeatherForecast({
   temperature,
 }: WeatherForecastProps) {
   const { t } = useTranslation();
-  const { displayTemperature, toPreferred } = useTemperatureUnit();
+  const { displayTemperature } = useTemperatureUnit();
+  const { displayWindSpeed, displayVisibility } = useSpeedUnit();
 
   return (
     <>
@@ -98,8 +100,12 @@ export function WeatherForecast({
                   />
                 </View>
               </View>
-              <Text className="min-w-[30px] text-right text-white/90">{toPreferred(day.low)}°</Text>
-              <Text className="min-w-[30px] text-right text-white">{toPreferred(day.high)}°</Text>
+              <Text className="min-w-[30px] text-right text-white/90">
+                {displayTemperature(day.low)}
+              </Text>
+              <Text className="min-w-[30px] text-right text-white">
+                {displayTemperature(day.high)}
+              </Text>
             </View>
           ))
         ) : (
@@ -127,7 +133,9 @@ export function WeatherForecast({
           </View>
           <View className="w-1/2 p-2">
             <Text className="text-white/70">{t('weather.visibility')}</Text>
-            <Text className="text-xl text-white">{details?.visibility || '10'} mi</Text>
+            <Text className="text-xl text-white">
+              {details?.visibility != null ? displayVisibility(details.visibility) : '—'}
+            </Text>
           </View>
           <View className="w-1/2 p-2">
             <Text className="text-white/70">{t('weather.uvIndex')}</Text>
@@ -138,7 +146,9 @@ export function WeatherForecast({
           </View>
           <View className="w-1/2 p-2">
             <Text className="text-white/70">{t('weather.wind')}</Text>
-            <Text className="text-xl text-white">{details?.windSpeed || '5'} mph</Text>
+            <Text className="text-xl text-white">
+              {details?.windSpeed != null ? displayWindSpeed(details.windSpeed) : '—'}
+            </Text>
           </View>
         </View>
       </View>

--- a/apps/expo/features/weather/components/WeatherForecast.tsx
+++ b/apps/expo/features/weather/components/WeatherForecast.tsx
@@ -1,5 +1,6 @@
 import { Text } from '@packrat/ui/nativewindui';
 import { Icon } from 'expo-app/components/Icon';
+import { useTemperatureUnit } from 'expo-app/features/auth/hooks/useTemperatureUnit';
 import { cn } from 'expo-app/lib/cn';
 import { useTranslation } from 'expo-app/lib/hooks/useTranslation';
 import { ScrollView, View } from 'react-native';
@@ -41,6 +42,7 @@ export function WeatherForecast({
   temperature,
 }: WeatherForecastProps) {
   const { t } = useTranslation();
+  const { displayTemperature, toPreferred } = useTemperatureUnit();
 
   return (
     <>
@@ -57,7 +59,7 @@ export function WeatherForecast({
                   size={24}
                   className="my-2"
                 />
-                <Text className="text-white">{hour.temp}°</Text>
+                <Text className="text-white">{displayTemperature(hour.temp)}</Text>
               </View>
             ))
           ) : (
@@ -90,14 +92,14 @@ export function WeatherForecast({
                   <View
                     className="absolute h-1 bg-white"
                     style={{
-                      left: `${Math.max(0, ((day.low - 40) / (100 - 40)) * 100)}%`,
-                      right: `${Math.max(0, 100 - ((day.high - 40) / (100 - 40)) * 100)}%`,
+                      left: `${Math.max(0, ((day.low - 4) / (38 - 4)) * 100)}%`,
+                      right: `${Math.max(0, 100 - ((day.high - 4) / (38 - 4)) * 100)}%`,
                     }}
                   />
                 </View>
               </View>
-              <Text className="min-w-[30px] text-right text-white/90">{day.low}°</Text>
-              <Text className="min-w-[30px] text-right text-white">{day.high}°</Text>
+              <Text className="min-w-[30px] text-right text-white/90">{toPreferred(day.low)}°</Text>
+              <Text className="min-w-[30px] text-right text-white">{toPreferred(day.high)}°</Text>
             </View>
           ))
         ) : (
@@ -111,7 +113,13 @@ export function WeatherForecast({
         <View className="flex-row flex-wrap">
           <View className="w-1/2 p-2">
             <Text className="text-white/70">{t('weather.feelsLike')}</Text>
-            <Text className="text-xl text-white">{details?.feelsLike || temperature}°</Text>
+            <Text className="text-xl text-white">
+              {details?.feelsLike != null
+                ? displayTemperature(details.feelsLike)
+                : temperature != null
+                  ? displayTemperature(temperature)
+                  : '—'}
+            </Text>
           </View>
           <View className="w-1/2 p-2">
             <Text className="text-white/70">{t('weather.humidity')}</Text>

--- a/apps/expo/features/weather/components/WeatherTile.tsx
+++ b/apps/expo/features/weather/components/WeatherTile.tsx
@@ -1,5 +1,6 @@
 import { ListItem, Text } from '@packrat/ui/nativewindui';
 import { Icon } from 'expo-app/components/Icon';
+import { useTemperatureUnit } from 'expo-app/features/auth/hooks/useTemperatureUnit';
 import { useColorScheme } from 'expo-app/lib/hooks/useColorScheme';
 import { useTranslation } from 'expo-app/lib/hooks/useTranslation';
 import { router } from 'expo-router';
@@ -11,6 +12,7 @@ export function WeatherTile() {
   const { activeLocation } = useActiveLocation();
   const { colors } = useColorScheme();
   const { t } = useTranslation();
+  const { displayTemperature } = useTemperatureUnit();
 
   const handlePress = () => {
     router.push('/weather');
@@ -38,7 +40,7 @@ export function WeatherTile() {
           <View className="flex-1 flex-row items-center justify-center gap-2 px-4">
             {activeLocation && (
               <Text variant="callout" className="ios:px-0 px-2 text-muted-foreground">
-                {activeLocation.temperature}° • {activeLocation.condition}
+                {displayTemperature(activeLocation.temperature)} • {activeLocation.condition}
               </Text>
             )}
             <Icon name="chevron-right" size={17} color={colors.grey} />

--- a/apps/expo/features/weather/lib/weatherService.ts
+++ b/apps/expo/features/weather/lib/weatherService.ts
@@ -111,13 +111,13 @@ export function formatWeatherData(data: WeatherAPIForecastResponse) {
   const todayForecast = forecast.forecastday[0];
   assertDefined(todayForecast);
 
-  // Format hourly forecast
+  // Format hourly forecast — temps stored in Celsius; display layer converts
   const hourlyForecast = todayForecast.hour
     .filter((hour) => {
       const hourTime = new Date(hour.time);
       return hourTime > localTime;
     })
-    .slice(0, 24) // Get next 24 hours
+    .slice(0, 24)
     .map((hour) => {
       const hourTime = new Date(hour.time);
       return {
@@ -125,21 +125,21 @@ export function formatWeatherData(data: WeatherAPIForecastResponse) {
           hour: 'numeric',
           hour12: true,
         }),
-        temp: Math.round(hour.temp_f),
+        temp: Math.round(hour.temp_c),
         icon: getIconNameFromCode({ code: hour.condition.code, isDay: hour.is_day }) as string,
         weatherCode: hour.condition.code,
         isDay: hour.is_day,
       };
     });
 
-  // Format daily forecast
+  // Format daily forecast — temps in Celsius
   const dailyForecast = forecast.forecastday.map((day) => {
     const date = new Date(day.date);
     return {
       day: date.toLocaleDateString('en-US', { weekday: 'short' }),
-      high: Math.round(day.day.maxtemp_f),
-      low: Math.round(day.day.mintemp_f),
-      icon: getIconNameFromCode({ code: day.day.condition.code, isDay: 1 }) as string, // Always use day icon for daily forecast
+      high: Math.round(day.day.maxtemp_c),
+      low: Math.round(day.day.mintemp_c),
+      icon: getIconNameFromCode({ code: day.day.condition.code, isDay: 1 }) as string,
       weatherCode: day.day.condition.code,
     };
   });
@@ -153,20 +153,20 @@ export function formatWeatherData(data: WeatherAPIForecastResponse) {
   return {
     id: location.id,
     name: location.name,
-    temperature: Math.round(current.temp_f),
+    temperature: Math.round(current.temp_c),
     condition: current.condition.text,
     time: formattedTime,
-    highTemp: Math.round(todayForecast.day.maxtemp_f),
-    lowTemp: Math.round(todayForecast.day.mintemp_f),
+    highTemp: Math.round(todayForecast.day.maxtemp_c),
+    lowTemp: Math.round(todayForecast.day.mintemp_c),
     alerts: alertText,
     lat: location.lat,
     lon: location.lon,
     details: {
-      feelsLike: Math.round(current.feelslike_f),
+      feelsLike: Math.round(current.feelslike_c),
       humidity: current.humidity,
-      visibility: Math.round(current.vis_miles),
+      visibility: Math.round(current.vis_km),
       uvIndex: current.uv,
-      windSpeed: Math.round(current.wind_mph),
+      windSpeed: Math.round(current.wind_kph),
       weatherCode: current.condition.code,
       isDay: current.is_day,
     },

--- a/apps/expo/features/weather/screens/LocationDetailScreen.tsx
+++ b/apps/expo/features/weather/screens/LocationDetailScreen.tsx
@@ -1,6 +1,7 @@
 import { useActionSheet } from '@expo/react-native-action-sheet';
 import { Text } from '@packrat/ui/nativewindui';
 import { Icon } from 'expo-app/components/Icon';
+import { useTemperatureUnit } from 'expo-app/features/auth/hooks/useTemperatureUnit';
 import { getWeatherBackgroundColors } from 'expo-app/features/weather/lib/weatherService';
 import { useColorScheme } from 'expo-app/lib/hooks/useColorScheme';
 import { useTranslation } from 'expo-app/lib/hooks/useTranslation';
@@ -28,6 +29,7 @@ export default function LocationDetailScreen() {
   ]);
   const { showActionSheetWithOptions } = useActionSheet();
   const { removeLocation } = useLocations();
+  const { displayTemperature, toPreferred } = useTemperatureUnit();
 
   const locationId = parseInt(String(id), 10);
   // Get the locations array safely
@@ -95,7 +97,7 @@ export default function LocationDetailScreen() {
         cancelButtonIndex,
         destructiveButtonIndex,
         title: location.name,
-        message: `${location.temperature}° - ${location.condition}`,
+        message: `${displayTemperature(location.temperature)} - ${location.condition}`,
         containerStyle: {
           backgroundColor: colorScheme === 'dark' ? colors.card : 'white',
           paddingBottom: insets.bottom,
@@ -232,11 +234,11 @@ export default function LocationDetailScreen() {
                   </View>
                   <Text className="text-lg text-white/80">{location.time}</Text>
                   <Text className="mt-6 text-8xl font-light text-white">
-                    {location.temperature}°
+                    {displayTemperature(location.temperature)}
                   </Text>
                   <Text className="text-xl text-white">{location.condition}</Text>
                   <Text className="mt-1 text-white/80">
-                    H:{location.highTemp}° L:{location.lowTemp}°
+                    H:{toPreferred(location.highTemp)}° L:{toPreferred(location.lowTemp)}°
                   </Text>
 
                   {!location.isActive && (

--- a/apps/expo/features/weather/screens/LocationDetailScreen.tsx
+++ b/apps/expo/features/weather/screens/LocationDetailScreen.tsx
@@ -29,7 +29,7 @@ export default function LocationDetailScreen() {
   ]);
   const { showActionSheetWithOptions } = useActionSheet();
   const { removeLocation } = useLocations();
-  const { displayTemperature, toPreferred } = useTemperatureUnit();
+  const { displayTemperature } = useTemperatureUnit();
 
   const locationId = parseInt(String(id), 10);
   // Get the locations array safely
@@ -238,7 +238,8 @@ export default function LocationDetailScreen() {
                   </Text>
                   <Text className="text-xl text-white">{location.condition}</Text>
                   <Text className="mt-1 text-white/80">
-                    H:{toPreferred(location.highTemp)}° L:{toPreferred(location.lowTemp)}°
+                    H:{displayTemperature(location.highTemp)} L:
+                    {displayTemperature(location.lowTemp)}
                   </Text>
 
                   {!location.isActive && (

--- a/apps/expo/features/weather/screens/LocationPreviewScreen.tsx
+++ b/apps/expo/features/weather/screens/LocationPreviewScreen.tsx
@@ -1,5 +1,6 @@
 import { Text } from '@packrat/ui/nativewindui';
 import { Icon } from 'expo-app/components/Icon';
+import { useTemperatureUnit } from 'expo-app/features/auth/hooks/useTemperatureUnit';
 import {
   formatWeatherData,
   getWeatherBackgroundColors,
@@ -29,6 +30,7 @@ export default function LocationPreviewScreen() {
   const { t } = useTranslation();
   // const { colors, colorScheme } = useColorScheme();
   const insets = useSafeAreaInsets();
+  const { displayTemperature, toPreferred } = useTemperatureUnit();
   const { addLocation } = useLocations();
   const [isLoading, setIsLoading] = useState(true);
   const [isSaving, setIsSaving] = useState(false);
@@ -184,11 +186,11 @@ export default function LocationPreviewScreen() {
                   </View>
                   <Text className="text-lg text-white/80">{weatherData.time}</Text>
                   <Text className="mt-6 text-8xl font-light text-white">
-                    {weatherData.temperature}°
+                    {displayTemperature(weatherData.temperature)}
                   </Text>
                   <Text className="text-xl text-white">{weatherData.condition}</Text>
                   <Text className="mt-1 text-white/80">
-                    H:{weatherData.highTemp}° L:{weatherData.lowTemp}°
+                    H:{toPreferred(weatherData.highTemp)}° L:{toPreferred(weatherData.lowTemp)}°
                   </Text>
 
                   {/* Refresh button */}
@@ -220,7 +222,7 @@ export default function LocationPreviewScreen() {
                             size={24}
                             className="my-2"
                           />
-                          <Text className="text-white">{hour.temp}°</Text>
+                          <Text className="text-white">{displayTemperature(hour.temp)}</Text>
                         </View>
                       ))
                     ) : (
@@ -283,7 +285,9 @@ export default function LocationPreviewScreen() {
                     <View className="w-1/2 p-2">
                       <Text className="text-white/70">{t('weather.feelsLike')}</Text>
                       <Text className="text-xl text-white">
-                        {weatherData.details?.feelsLike || weatherData.temperature}°
+                        {displayTemperature(
+                          weatherData.details?.feelsLike ?? weatherData.temperature,
+                        )}
                       </Text>
                     </View>
                     <View className="w-1/2 p-2">

--- a/apps/expo/features/weather/screens/LocationPreviewScreen.tsx
+++ b/apps/expo/features/weather/screens/LocationPreviewScreen.tsx
@@ -187,7 +187,7 @@ export default function LocationPreviewScreen() {
 
                   {/* Refresh button */}
                   <TouchableOpacity
-                    className="mt-2 flex-row items-center gap-2 rounded-full bg-black/25 px-4 py-2"
+                    className="mt-2 flex-row items-center gap-2 px-4 py-2"
                     onPress={loadWeatherData}
                     disabled={isLoading}
                   >

--- a/apps/expo/features/weather/screens/LocationPreviewScreen.tsx
+++ b/apps/expo/features/weather/screens/LocationPreviewScreen.tsx
@@ -109,35 +109,38 @@ export default function LocationPreviewScreen() {
 
   return (
     <>
-      <Stack.Screen options={{ title: '' }} />
-      <Stack.Header transparent style={{ shadowColor: 'transparent' }} />
-      <Stack.Screen.BackButton hidden />
-      <Stack.Toolbar placement="left">
-        <Stack.Toolbar.View>
-          <TouchableOpacity onPress={() => router.back()}>
-            <View className="rounded-full bg-black/25 p-2">
-              <Icon name="arrow-left" color="white" size={20} />
-            </View>
-          </TouchableOpacity>
-        </Stack.Toolbar.View>
-      </Stack.Toolbar>
-      {!isLoading && !error && weatherData && (
-        <Stack.Toolbar placement="right">
-          <Stack.Toolbar.View>
-            <TouchableOpacity
-              className="rounded-full px-4 py-2"
-              onPress={handleSaveLocation}
-              disabled={isSaving}
-            >
-              {isSaving ? (
-                <ActivityIndicator size="small" color="white" />
-              ) : (
-                <Text className="text-white">{t('weather.saveLocation')}</Text>
-              )}
-            </TouchableOpacity>
-          </Stack.Toolbar.View>
-        </Stack.Toolbar>
-      )}
+      <Stack.Screen
+        options={{
+          title: '',
+          headerTransparent: true,
+          headerShadowVisible: false,
+          headerTintColor: 'white',
+          headerLeft:
+            Platform.OS === 'ios'
+              ? () => (
+                  <TouchableOpacity onPress={() => router.back()} hitSlop={8}>
+                    <Icon name="chevron-left" color="white" size={28} />
+                  </TouchableOpacity>
+                )
+              : undefined,
+          headerRight:
+            !isLoading && !error && weatherData
+              ? () => (
+                  <TouchableOpacity
+                    className="rounded-full px-4 py-2"
+                    onPress={handleSaveLocation}
+                    disabled={isSaving}
+                  >
+                    {isSaving ? (
+                      <ActivityIndicator size="small" color="white" />
+                    ) : (
+                      <Text className="text-white text-base">{t('weather.saveLocation')}</Text>
+                    )}
+                  </TouchableOpacity>
+                )
+              : undefined,
+        }}
+      />
 
       <LinearGradient colors={gradientColors} style={{ flex: 1 }}>
         <ScrollView

--- a/apps/expo/features/weather/screens/LocationPreviewScreen.tsx
+++ b/apps/expo/features/weather/screens/LocationPreviewScreen.tsx
@@ -1,5 +1,6 @@
 import { Text } from '@packrat/ui/nativewindui';
 import { Icon } from 'expo-app/components/Icon';
+import { useSpeedUnit } from 'expo-app/features/auth/hooks/useSpeedUnit';
 import { useTemperatureUnit } from 'expo-app/features/auth/hooks/useTemperatureUnit';
 import {
   formatWeatherData,
@@ -8,15 +9,14 @@ import {
 } from 'expo-app/features/weather/lib/weatherService';
 import { cn } from 'expo-app/lib/cn';
 import { useTranslation } from 'expo-app/lib/hooks/useTranslation';
-// import { useColorScheme } from 'expo-app/lib/hooks/useColorScheme';
 import { LinearGradient } from 'expo-linear-gradient';
 import { router, Stack, useLocalSearchParams } from 'expo-router';
 import { useEffect, useState } from 'react';
 import {
   ActivityIndicator,
   Alert,
+  Platform,
   ScrollView,
-  StatusBar,
   TouchableOpacity,
   View,
 } from 'react-native';
@@ -28,9 +28,9 @@ import type { WeatherLocation } from '../types';
 export default function LocationPreviewScreen() {
   const params = useLocalSearchParams();
   const { t } = useTranslation();
-  // const { colors, colorScheme } = useColorScheme();
   const insets = useSafeAreaInsets();
-  const { displayTemperature, toPreferred } = useTemperatureUnit();
+  const { displayTemperature } = useTemperatureUnit();
+  const { displayWindSpeed, displayVisibility } = useSpeedUnit();
   const { addLocation } = useLocations();
   const [isLoading, setIsLoading] = useState(true);
   const [isSaving, setIsSaving] = useState(false);
@@ -42,13 +42,9 @@ export default function LocationPreviewScreen() {
     '#192f6a',
   ]);
 
-  // Extract location data from params
   const _latitude = Number.parseFloat(params.lat as string);
   const _longitude = Number.parseFloat(params.lon as string);
   const locationId = Number.parseInt(String(params.id), 10);
-  // const locationName = params.name as string;
-  // const region = params.region as string;
-  // const country = params.country as string;
 
   const loadWeatherData = async () => {
     setIsLoading(true);
@@ -61,7 +57,6 @@ export default function LocationPreviewScreen() {
         // safe-cast: formattedData is shaped by weatherService which guarantees WeatherLocation structure
         setWeatherData(formattedData as unknown as WeatherLocation);
 
-        // Update gradient colors based on weather condition
         if (formattedData.details) {
           const weatherCode = formattedData.details.weatherCode || 1000;
           const isNight = formattedData.details.isDay === 0;
@@ -78,7 +73,6 @@ export default function LocationPreviewScreen() {
     }
   };
 
-  // Load weather data on initial render
   useEffect(() => {
     loadWeatherData();
   }, []);
@@ -113,34 +107,25 @@ export default function LocationPreviewScreen() {
     }
   };
 
-  // Determine if we should use light or dark status bar based on gradient colors
-  const _isDarkGradient =
-    gradientColors[0].toLowerCase().startsWith('#4') ||
-    gradientColors[0].toLowerCase().startsWith('#3') ||
-    gradientColors[0].toLowerCase().startsWith('#2') ||
-    gradientColors[0].toLowerCase().startsWith('#1');
-
   return (
-    <View className="flex-1">
-      <Stack.Screen options={{ headerShown: false }} />
-      {/* Status bar with matching style */}
-      <StatusBar barStyle="light-content" translucent={true} backgroundColor="transparent" />
-
-      <LinearGradient colors={gradientColors} style={{ flex: 1 }}>
-        {/* Fixed header buttons */}
-        <View
-          style={{ paddingTop: insets.top + 10 }}
-          className="absolute left-0 right-0 top-0 z-10 flex-row items-center justify-between px-4"
-        >
+    <>
+      <Stack.Screen options={{ title: '' }} />
+      <Stack.Header transparent style={{ shadowColor: 'transparent' }} />
+      <Stack.Screen.BackButton hidden />
+      <Stack.Toolbar placement="left">
+        <Stack.Toolbar.View>
           <TouchableOpacity onPress={() => router.back()}>
-            <View className="rounded-full bg-white/20 p-2">
+            <View className="rounded-full bg-black/25 p-2">
               <Icon name="arrow-left" color="white" size={20} />
             </View>
           </TouchableOpacity>
-
-          {!isLoading && !error && weatherData && (
+        </Stack.Toolbar.View>
+      </Stack.Toolbar>
+      {!isLoading && !error && weatherData && (
+        <Stack.Toolbar placement="right">
+          <Stack.Toolbar.View>
             <TouchableOpacity
-              className="rounded-full bg-white/20 px-4 py-2"
+              className="rounded-full px-4 py-2"
               onPress={handleSaveLocation}
               disabled={isSaving}
             >
@@ -150,13 +135,16 @@ export default function LocationPreviewScreen() {
                 <Text className="text-white">{t('weather.saveLocation')}</Text>
               )}
             </TouchableOpacity>
-          )}
-        </View>
+          </Stack.Toolbar.View>
+        </Stack.Toolbar>
+      )}
 
+      <LinearGradient colors={gradientColors} style={{ flex: 1 }}>
         <ScrollView
+          contentInsetAdjustmentBehavior="automatic"
           contentContainerStyle={{
             paddingBottom: insets.bottom + 20,
-            paddingTop: insets.top + 50,
+            paddingTop: Platform.OS === 'android' ? insets.top + 56 : 0,
           }}
           showsVerticalScrollIndicator={false}
         >
@@ -171,7 +159,7 @@ export default function LocationPreviewScreen() {
                 <Icon name="bell-outline" color="white" size={40} />
                 <Text className="mt-4 text-white">{error}</Text>
                 <TouchableOpacity
-                  className="mt-4 rounded-full bg-white/20 px-4 py-2"
+                  className="mt-4 rounded-full bg-black/25 px-4 py-2"
                   onPress={loadWeatherData}
                 >
                   <Text className="text-white">{t('weather.tryAgain')}</Text>
@@ -190,12 +178,13 @@ export default function LocationPreviewScreen() {
                   </Text>
                   <Text className="text-xl text-white">{weatherData.condition}</Text>
                   <Text className="mt-1 text-white/80">
-                    H:{toPreferred(weatherData.highTemp)}° L:{toPreferred(weatherData.lowTemp)}°
+                    H:{displayTemperature(weatherData.highTemp)} L:
+                    {displayTemperature(weatherData.lowTemp)}
                   </Text>
 
                   {/* Refresh button */}
                   <TouchableOpacity
-                    className="mt-2 flex-row items-center gap-2 rounded-full bg-white/20 px-4 py-2"
+                    className="mt-2 flex-row items-center gap-2 rounded-full bg-black/25 px-4 py-2"
                     onPress={loadWeatherData}
                     disabled={isLoading}
                   >
@@ -239,7 +228,9 @@ export default function LocationPreviewScreen() {
                 <View className="mt-4 rounded-xl bg-white/10 p-4">
                   <Text className="mb-2 font-medium text-white">
                     {weatherData.dailyForecast
-                      ? t('weather.dayForecast', { count: weatherData.dailyForecast.length })
+                      ? t('weather.dayForecast', {
+                          count: weatherData.dailyForecast.length,
+                        })
                       : t('weather.dailyForecast')}
                   </Text>
                   {weatherData.dailyForecast ? (
@@ -259,14 +250,18 @@ export default function LocationPreviewScreen() {
                             <View
                               className="absolute h-1 bg-white"
                               style={{
-                                left: `${Math.max(0, ((day.low - 40) / (100 - 40)) * 100)}%`,
-                                right: `${Math.max(0, 100 - ((day.high - 40) / (100 - 40)) * 100)}%`,
+                                left: `${Math.max(0, ((day.low - 4) / (38 - 4)) * 100)}%`,
+                                right: `${Math.max(0, 100 - ((day.high - 4) / (38 - 4)) * 100)}%`,
                               }}
                             />
                           </View>
                         </View>
-                        <Text className="min-w-[30px] text-right text-white/90">{day.low}°</Text>
-                        <Text className="min-w-[30px] text-right text-white">{day.high}°</Text>
+                        <Text className="min-w-[30px] text-right text-white/90">
+                          {displayTemperature(day.low)}
+                        </Text>
+                        <Text className="min-w-[30px] text-right text-white">
+                          {displayTemperature(day.high)}
+                        </Text>
                       </View>
                     ))
                   ) : (
@@ -299,7 +294,9 @@ export default function LocationPreviewScreen() {
                     <View className="w-1/2 p-2">
                       <Text className="text-white/70">{t('weather.visibility')}</Text>
                       <Text className="text-xl text-white">
-                        {weatherData.details?.visibility || '10'} mi
+                        {weatherData.details?.visibility != null
+                          ? displayVisibility(weatherData.details.visibility)
+                          : '—'}
                       </Text>
                     </View>
                     <View className="w-1/2 p-2">
@@ -314,7 +311,9 @@ export default function LocationPreviewScreen() {
                     <View className="w-1/2 p-2">
                       <Text className="text-white/70">{t('weather.wind')}</Text>
                       <Text className="text-xl text-white">
-                        {weatherData.details?.windSpeed || '5'} mph
+                        {weatherData.details?.windSpeed != null
+                          ? displayWindSpeed(weatherData.details.windSpeed)
+                          : '—'}
                       </Text>
                     </View>
                   </View>
@@ -324,6 +323,6 @@ export default function LocationPreviewScreen() {
           </View>
         </ScrollView>
       </LinearGradient>
-    </View>
+    </>
   );
 }

--- a/apps/expo/features/weather/screens/LocationSearchScreen.tsx
+++ b/apps/expo/features/weather/screens/LocationSearchScreen.tsx
@@ -405,7 +405,7 @@ export default function LocationSearchScreen() {
   return (
     <SafeAreaView className="flex-1 bg-background">
       {/* Search Input */}
-      <View className="px-4">
+      <View className="px-4 pt-4">
         <SearchInput
           ref={searchInputRef}
           placeholder={t('weather.searchForCity')}

--- a/apps/expo/features/weather/screens/LocationSearchScreen.tsx
+++ b/apps/expo/features/weather/screens/LocationSearchScreen.tsx
@@ -405,7 +405,7 @@ export default function LocationSearchScreen() {
   return (
     <SafeAreaView className="flex-1 bg-background">
       {/* Search Input */}
-      <View className="px-4 pt-4">
+      <View className="px-4 my-4">
         <SearchInput
           ref={searchInputRef}
           placeholder={t('weather.searchForCity')}

--- a/apps/expo/lib/i18n/locales/en.json
+++ b/apps/expo/lib/i18n/locales/en.json
@@ -715,6 +715,12 @@
     "generatedPacks": "Generated Packs",
     "waitingForSync": "Waiting for packs to sync."
   },
+  "settings": {
+    "displayUnits": "Display Units",
+    "weightSubtitle": "For gear and pack weights",
+    "temperatureSubtitle": "For weather and forecasts",
+    "windDistanceSubtitle": "For routes and weather data"
+  },
   "weather": {
     "weather": "Weather",
     "temperature": "Temperature",

--- a/apps/expo/lib/testIds.ts
+++ b/apps/expo/lib/testIds.ts
@@ -136,6 +136,9 @@ export const testIds = Object.freeze({
     aiModelsSection: 'settings:ai-models',
     dangerZone: 'settings:danger-zone',
     deleteAccountBtn: 'settings:delete-account',
+    weightUnitControl: 'settings:weight-unit',
+    temperatureUnitControl: 'settings:temperature-unit',
+    speedUnitControl: 'settings:speed-unit',
   }),
 
   // ── AI Chat ───────────────────────────────────────────────────────────────

--- a/apps/expo/lib/unitDefaults.ts
+++ b/apps/expo/lib/unitDefaults.ts
@@ -15,3 +15,9 @@ export function getDefaultTemperatureUnit(): 'C' | 'F' {
   const region = Localization.getLocales()[0]?.regionCode ?? '';
   return FAHRENHEIT_REGIONS.has(region) ? 'F' : 'C';
 }
+
+// mph/miles correlate with the same regions that use Fahrenheit
+export function getDefaultSpeedUnit(): 'mph' | 'kmh' {
+  const region = Localization.getLocales()[0]?.regionCode ?? '';
+  return FAHRENHEIT_REGIONS.has(region) ? 'mph' : 'kmh';
+}

--- a/apps/expo/lib/unitDefaults.ts
+++ b/apps/expo/lib/unitDefaults.ts
@@ -1,0 +1,17 @@
+import * as Localization from 'expo-localization';
+
+// Only three countries still use imperial weight (lbs) as the standard
+const IMPERIAL_WEIGHT_REGIONS = new Set(['US', 'LR', 'MM']);
+
+// Countries/territories that use Fahrenheit for everyday temperature
+const FAHRENHEIT_REGIONS = new Set(['US', 'BS', 'BZ', 'KY', 'PW', 'PR', 'GU', 'VI', 'AS', 'MP']);
+
+export function getDefaultWeightUnit(): 'kg' | 'lb' {
+  const region = Localization.getLocales()[0]?.regionCode ?? '';
+  return IMPERIAL_WEIGHT_REGIONS.has(region) ? 'lb' : 'kg';
+}
+
+export function getDefaultTemperatureUnit(): 'C' | 'F' {
+  const region = Localization.getLocales()[0]?.regionCode ?? '';
+  return FAHRENHEIT_REGIONS.has(region) ? 'F' : 'C';
+}

--- a/apps/expo/utils/weight.ts
+++ b/apps/expo/utils/weight.ts
@@ -5,7 +5,7 @@ import { convert, displayWeight, normalize, parseWeightUnit } from '@packrat/uni
 export { convert as convertWeight };
 
 export const formatWeight = ({ weight, unit }: { weight: number; unit: WeightUnit }): string =>
-  `${weight}${unit}`;
+  `${parseFloat(weight.toFixed(2))}${unit}`;
 
 export const calculateBaseWeight = ({
   items,

--- a/packages/api/src/routes/chat.ts
+++ b/packages/api/src/routes/chat.ts
@@ -41,9 +41,12 @@ export const chatRoutes = new Elysia({ prefix: '/chat' })
         packId?: string;
         location?: string;
         date: string;
+        weightUnit?: 'kg' | 'lb';
+        temperatureUnit?: 'C' | 'F';
       };
 
-      const { messages, contextType, itemId, packId, location, date } = typedBody;
+      const { messages, contextType, itemId, packId, location, date, weightUnit, temperatureUnit } =
+        typedBody;
 
       const tools = createTools(user.userId);
       const schemaInfo = await getSchemaInfo();
@@ -65,7 +68,9 @@ export const chatRoutes = new Elysia({ prefix: '/chat' })
 
       Context:
       - User id is ${user.userId}
-      - Current date is ${date}`;
+      - Current date is ${date}
+      - User's preferred weight unit is ${weightUnit ?? 'kg'} (always display weights in this unit)
+      - User's preferred temperature unit is °${temperatureUnit ?? 'C'} (always display temperatures in this unit)`;
 
       if (contextType === 'pack' && packId) {
         systemPrompt += `\n- You are currently helping with a pack with ID: ${packId}. Use the getPackDetails tool to fetch its contents.`;

--- a/packages/api/src/routes/chat.ts
+++ b/packages/api/src/routes/chat.ts
@@ -43,10 +43,20 @@ export const chatRoutes = new Elysia({ prefix: '/chat' })
         date: string;
         weightUnit?: 'kg' | 'lb';
         temperatureUnit?: 'C' | 'F';
+        speedUnit?: 'kmh' | 'mph';
       };
 
-      const { messages, contextType, itemId, packId, location, date, weightUnit, temperatureUnit } =
-        typedBody;
+      const {
+        messages,
+        contextType,
+        itemId,
+        packId,
+        location,
+        date,
+        weightUnit,
+        temperatureUnit,
+        speedUnit,
+      } = typedBody;
 
       const tools = createTools(user.userId);
       const schemaInfo = await getSchemaInfo();
@@ -70,7 +80,8 @@ export const chatRoutes = new Elysia({ prefix: '/chat' })
       - User id is ${user.userId}
       - Current date is ${date}
       - User's preferred weight unit is ${weightUnit ?? 'kg'} (always display weights in this unit)
-      - User's preferred temperature unit is °${temperatureUnit ?? 'C'} (always display temperatures in this unit)`;
+      - User's preferred temperature unit is °${temperatureUnit ?? 'C'} (always display temperatures in this unit)
+      - User's preferred wind/distance unit is ${speedUnit === 'mph' ? 'mph / miles' : 'km/h / km'} (always display wind speed and distances in this unit)`;
 
       if (contextType === 'pack' && packId) {
         systemPrompt += `\n- You are currently helping with a pack with ID: ${packId}. Use the getPackDetails tool to fetch its contents.`;

--- a/packages/constants/src/index.ts
+++ b/packages/constants/src/index.ts
@@ -34,6 +34,9 @@ export type WeightUnit = (typeof WEIGHT_UNITS)[number];
 export const TEMPERATURE_UNITS = Object.freeze(['C', 'F'] as const);
 export type TemperatureUnit = (typeof TEMPERATURE_UNITS)[number];
 
+export const SPEED_UNITS = Object.freeze(['kmh', 'mph'] as const);
+export type SpeedUnit = (typeof SPEED_UNITS)[number];
+
 export const AVAILABILITY_VALUES = Object.freeze(['in_stock', 'out_of_stock', 'preorder'] as const);
 
 export type Availability = (typeof AVAILABILITY_VALUES)[number];

--- a/packages/constants/src/index.ts
+++ b/packages/constants/src/index.ts
@@ -31,6 +31,9 @@ export type ItemCategory = (typeof ITEM_CATEGORIES)[number];
 export const WEIGHT_UNITS = Object.freeze(['g', 'oz', 'kg', 'lb'] as const);
 export type WeightUnit = (typeof WEIGHT_UNITS)[number];
 
+export const TEMPERATURE_UNITS = Object.freeze(['C', 'F'] as const);
+export type TemperatureUnit = (typeof TEMPERATURE_UNITS)[number];
+
 export const AVAILABILITY_VALUES = Object.freeze(['in_stock', 'out_of_stock', 'preorder'] as const);
 
 export type Availability = (typeof AVAILABILITY_VALUES)[number];

--- a/packages/schemas/src/users.ts
+++ b/packages/schemas/src/users.ts
@@ -8,6 +8,8 @@ export const UserPreferencesSchema = z.object({
       opened: z.boolean().default(false),
     })
     .optional(),
+  weightUnit: z.enum(['kg', 'lb']).optional(),
+  temperatureUnit: z.enum(['C', 'F']).optional(),
 });
 
 export type UserPreferences = z.infer<typeof UserPreferencesSchema>;

--- a/packages/schemas/src/users.ts
+++ b/packages/schemas/src/users.ts
@@ -10,6 +10,7 @@ export const UserPreferencesSchema = z.object({
     .optional(),
   weightUnit: z.enum(['kg', 'lb']).optional(),
   temperatureUnit: z.enum(['C', 'F']).optional(),
+  speedUnit: z.enum(['kmh', 'mph']).optional(),
 });
 
 export type UserPreferences = z.infer<typeof UserPreferencesSchema>;


### PR DESCRIPTION
## Summary

- Adds a **Display Units** section to the Settings screen with toggles for weight (kg / lb) and temperature (°C / °F)
- Defaults are locale-aware: US/Myanmar/Liberia → lb/°F; everywhere else → kg/°C
- Preferences persist via the existing Legend State preferences store (SQLite + API sync) — no new storage mechanism needed
- All weight display sites (`WeightBadge`, weight analysis, pack stats, pack categories, current-pack) now convert to the preferred unit consistently
- Temperature in weather views was previously inconsistent (°F in most places, °C in `TripWeatherDetailsScreen`); all now store °C internally and convert to the preferred unit at render time
- Fixed a long-standing bug where `computeCategorySummaries` and `usePackWeightAnalysis` were reading from `userStore.preferredWeightUnit` (which doesn't exist on the `User` type and always fell back to `'g'`)

## Changes

| Area | Change |
|---|---|
| `packages/constants` | Add `TEMPERATURE_UNITS` / `TemperatureUnit` |
| `packages/schemas/src/users.ts` | Add `weightUnit` and `temperatureUnit` to `UserPreferencesSchema` |
| `apps/expo/lib/unitDefaults.ts` | New — locale-based default unit detection via `expo-localization` |
| `apps/expo/features/auth/hooks/useWeightUnit.ts` | New — reads preference, provides `convertWeight` helper |
| `apps/expo/features/auth/hooks/useTemperatureUnit.ts` | New — reads preference, provides `displayTemperature` / `toPreferred` helpers |
| `apps/expo/components/initial/WeightBadge` | Converts source weight to preferred unit before display |
| `apps/expo/app/(app)/settings/index.tsx` | Display Units section (kg/lb + °C/°F toggles) |
| `apps/expo/features/weather/lib/weatherService.ts` | `formatWeatherData` now stores all temps in °C |
| All weather display components | Use `useTemperatureUnit` for consistent conversion |
| Pack weight screens (analysis, stats, categories, current-pack) | Use `useWeightUnit` preference via `computeCategorySummaries` |

## Test plan

- [ ] Open Settings → Display Units section shows with correct locale default selected
- [ ] Toggle weight unit → all pack weight badges and totals update immediately
- [ ] Toggle temperature unit → all weather cards/screens update immediately
- [ ] Kill and relaunch app → preferences are retained (SQLite persistence)
- [ ] Sign out and sign in → preferences sync from server
- [ ] US locale device defaults to lb / °F; non-US defaults to kg / °C
- [ ] `bun test:expo` passes (363 tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a **Display Units** card in Settings to choose **weight (kg/lb)**, **temperature (°C/°F)**, and **wind & distance (km/h vs mph)**.
  * Defaults are selected from your device region, and unit preferences are now applied throughout the app (packs, catalogs, and weather).
  * AI chat now also uses your selected units when presenting results.
* **Bug Fixes**
  * Improved consistency by converting weights, temperatures, wind speed, and visibility to your active unit before display (including weather “feels like,” highs/lows, and charts/summaries).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->