### PR TITLE
fix(ios): resolve Xcode 26 SDK build errors (SwiftUICore, UIUtilities, RCTRootContentView)

### DIFF
--- a/apps/expo/Shims/UIUtilities.framework/Headers/UICoordinateSpace.h
+++ b/apps/expo/Shims/UIUtilities.framework/Headers/UICoordinateSpace.h
@@ -1,0 +1,24 @@
+//
+//  UICoordinateSpace.h
+//  UIKit
+//
+//  Copyright © 2024 Apple Inc. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_HEADER_AUDIT_BEGIN(nullability, sendability)
+
+NS_SWIFT_UI_ACTOR
+@protocol UICoordinateSpace <NSObject>
+
+- (CGPoint)convertPoint:(CGPoint)point toCoordinateSpace:(id <UICoordinateSpace>)coordinateSpace API_AVAILABLE(ios(8.0)) API_UNAVAILABLE(watchos);
+- (CGPoint)convertPoint:(CGPoint)point fromCoordinateSpace:(id <UICoordinateSpace>)coordinateSpace API_AVAILABLE(ios(8.0)) API_UNAVAILABLE(watchos);
+- (CGRect)convertRect:(CGRect)rect toCoordinateSpace:(id <UICoordinateSpace>)coordinateSpace API_AVAILABLE(ios(8.0)) API_UNAVAILABLE(watchos);
+- (CGRect)convertRect:(CGRect)rect fromCoordinateSpace:(id <UICoordinateSpace>)coordinateSpace API_AVAILABLE(ios(8.0)) API_UNAVAILABLE(watchos);
+
+@property (readonly, nonatomic) CGRect bounds API_AVAILABLE(ios(8.0)) API_UNAVAILABLE(watchos);
+
+@end
+
+NS_HEADER_AUDIT_END(nullability, sendability)

--- a/apps/expo/Shims/UIUtilities.framework/Headers/UIDefines.h
+++ b/apps/expo/Shims/UIUtilities.framework/Headers/UIDefines.h
@@ -1,0 +1,26 @@
+//
+//  UIDefines.h
+//  UIKit
+//
+//  Copyright © 2024 Apple Inc. All rights reserved.
+//
+
+#import <TargetConditionals.h>
+
+#ifdef __cplusplus
+#define UIKIT_EXTERN       extern "C" __attribute__((visibility ("default")))
+#else
+#define UIKIT_EXTERN           extern __attribute__((visibility ("default")))
+#endif
+
+#define UIKIT_STATIC_INLINE    static inline
+
+#if !defined(UIKIT_EXTERN_C_BEGIN) && !defined(UIKIT_EXTERN_C_END)
+    #ifdef __cplusplus
+        #define UIKIT_EXTERN_C_BEGIN extern "C" {
+        #define UIKIT_EXTERN_C_END }
+    #else
+        #define UIKIT_EXTERN_C_BEGIN
+        #define UIKIT_EXTERN_C_END
+    #endif
+#endif

--- a/apps/expo/Shims/UIUtilities.framework/Headers/UIGeometry.h
+++ b/apps/expo/Shims/UIUtilities.framework/Headers/UIGeometry.h
@@ -1,0 +1,28 @@
+//
+//  UIGeometry.h
+//  UIKit
+//
+//  Copyright © 2024 Apple Inc. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_HEADER_AUDIT_BEGIN(nullability, sendability)
+
+typedef NS_OPTIONS(NSUInteger, UIRectEdge) {
+    UIRectEdgeNone   = 0,
+    UIRectEdgeTop    = 1 << 0,
+    UIRectEdgeLeft   = 1 << 1,
+    UIRectEdgeBottom = 1 << 2,
+    UIRectEdgeRight  = 1 << 3,
+    UIRectEdgeAll    = UIRectEdgeTop | UIRectEdgeLeft | UIRectEdgeBottom | UIRectEdgeRight
+} API_AVAILABLE(ios(7.0), watchos(2.0));
+
+typedef NS_OPTIONS(NSUInteger, UIAxis) {
+    UIAxisNeither    = 0,
+    UIAxisHorizontal = 1 << 0,
+    UIAxisVertical   = 1 << 1,
+    UIAxisBoth       = (UIAxisHorizontal | UIAxisVertical),
+} API_AVAILABLE(ios(13.4), tvos(13.4), watchos(6.2));
+
+NS_HEADER_AUDIT_END(nullability, sendability)

--- a/apps/expo/Shims/UIUtilities.framework/Modules/module.modulemap
+++ b/apps/expo/Shims/UIUtilities.framework/Modules/module.modulemap
@@ -1,0 +1,6 @@
+framework module UIUtilities [system] {
+  umbrella "Headers"
+
+  export *
+  module * { export * }
+}

--- a/apps/expo/Shims/UIUtilities.framework/UIUtilities.tbd
+++ b/apps/expo/Shims/UIUtilities.framework/UIUtilities.tbd
@@ -1,0 +1,6 @@
+--- !tapi-tbd
+tbd-version:     4
+targets:         [ x86_64-ios-simulator, arm64-ios-simulator, arm64-ios, arm64e-ios ]
+install-name:    '/System/Library/SubFrameworks/UIUtilities.framework/UIUtilities'
+current-version: 1.0
+...

--- a/apps/expo/app.config.ts
+++ b/apps/expo/app.config.ts
@@ -1,5 +1,8 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 import { withSentry } from '@sentry/react-native/expo';
 import type { ExpoConfig } from 'expo/config';
+import { type ConfigPlugin, withDangerousMod, withXcodeProject } from 'expo/config-plugins';
 
 const IS_DEV = process.env.APP_VARIANT === 'development';
 const IS_PREVIEW = process.env.APP_VARIANT === 'preview';
@@ -32,160 +35,268 @@ const getAdaptiveIcon = () => {
   return './assets/adaptive-icon.png';
 };
 
+// Since Xcode 16, SwiftUI is split into a public SwiftUI.framework and a private
+// SwiftUICore.framework. SPIndicator + SPAlert (Burnt's deps) compile `import SwiftUI`,
+// which causes the Swift compiler to embed a SwiftUICore auto-link directive in the
+// resulting object files. The linker then fails because SwiftUICore is restricted to
+// Apple-internal clients. Two-pronged fix:
+//   1. withXcodeProject — add -framework SwiftUI to the main target's OTHER_LDFLAGS so
+//      the public umbrella satisfies any transitive symbol look-ups.
+//   2. withDangerousMod — inject a Podfile post_install hook that replaces the
+//      SwiftUIExtension.swift files in SPIndicator/SPAlert with empty stubs before
+//      compilation, eliminating the auto-link directive at its source.
+const SWIFTUI_FIX_MARKER = '# withSwiftUICoreFix';
+
+const withSwiftUICoreFix: ConfigPlugin<void> = (config) => {
+  // ── Step 1: xcodeproj ──────────────────────────────────────────────────────
+  let patched = withXcodeProject(config, (c) => {
+    const proj = c.modResults;
+    const appTarget = proj.getTarget('com.apple.product-type.application');
+    if (!appTarget) return c;
+
+    const configList = proj.pbxXCConfigurationList()[appTarget.target.buildConfigurationList];
+    if (!configList || typeof configList === 'string') return c;
+
+    const buildConfigs = proj.pbxXCBuildConfigurationSection();
+    for (const ref of configList.buildConfigurations) {
+      const bc = buildConfigs[ref.value];
+      if (!bc || typeof bc === 'string') continue;
+
+      // Shims/SwiftUICore.framework/SwiftUICore.tbd is a minimal stub without
+      // allowable-clients. It lives at apps/expo/Shims/ (outside ios/, so it
+      // survives CNG rebuilds). Adding it before the SDK lets the linker accept
+      // the SwiftUICore auto-link directive; the actual symbols resolve through
+      // SwiftUI.framework which re-exports all of SwiftUICore.
+      const fps = bc.buildSettings.FRAMEWORK_SEARCH_PATHS;
+      const searchPaths = Array.isArray(fps) ? fps : fps ? [fps as string] : ['"$(inherited)"'];
+      if (!searchPaths.some((p) => String(p).includes('Shims'))) {
+        bc.buildSettings.FRAMEWORK_SEARCH_PATHS = [...searchPaths, '"$(PROJECT_DIR)/../Shims"'];
+      }
+
+      const existing = bc.buildSettings.OTHER_LDFLAGS;
+      const flags = Array.isArray(existing) ? existing : ['"$(inherited)"'];
+      if (!flags.some((f) => String(f).includes('SwiftUI'))) {
+        bc.buildSettings.OTHER_LDFLAGS = [...flags, '"-framework SwiftUI"'];
+      }
+    }
+    return c;
+  });
+
+  // ── Step 2: Podfile post_install stub ──────────────────────────────────────
+  patched = withDangerousMod(patched, [
+    'ios',
+    (c) => {
+      const podfilePath = path.join(c.modRequest.platformProjectRoot, 'Podfile');
+      let podfile = fs.readFileSync(podfilePath, 'utf-8');
+
+      if (!podfile.includes(SWIFTUI_FIX_MARKER)) {
+        // Ruby code injected inside the existing post_install block.
+        // Dir.glob with **/ finds SwiftUIExtension.swift wherever CocoaPods places it.
+        // File.write replaces content with an empty stub — no `import SwiftUI` means
+        // the Swift compiler emits no SwiftUICore auto-link directive.
+        const snippet = [
+          `    ${SWIFTUI_FIX_MARKER}: stub SwiftUI extension files to prevent SwiftUICore auto-linking.`,
+          `    # Xcode 16+/26+: SwiftUICore.framework is private (Apple-internal only). Any pod`,
+          `    # that compiles \`import SwiftUI\` embeds a SwiftUICore auto-link directive in its`,
+          `    # object files; the linker fails when it tries to resolve it. Replacing the`,
+          `    # extension files with empty stubs removes the directive before compilation.`,
+          `    ['SPIndicator', 'SPAlert'].each do |pod_name|`,
+          `      Dir.glob("#{installer.sandbox.pod_dir(pod_name)}/**/SwiftUI*.swift").each do |f|`,
+          `        File.write(f, "// SwiftUI extension disabled — SwiftUICore restricted on Xcode 16+\\n")`,
+          `      end`,
+          `    end`,
+          `    # react-native-ios-utilities 5.x references RCTRootContentView which is not exported`,
+          `    # from the prebuilt React.framework in RN 0.85+. Replace the property return type`,
+          `    # with RCTView (the common ancestor) so the linker finds the symbol.`,
+          `    # For :path pods, source lives in node_modules — walk back from ios/ to find it.`,
+          `    helpers_file = File.expand_path(`,
+          `      '../../../../node_modules/react-native-ios-utilities/ios/Sources/Extensions+Helpers/RCTView+Helpers.swift',`,
+          `      installer.sandbox.root`,
+          `    )`,
+          `    if File.exist?(helpers_file)`,
+          `      content = File.read(helpers_file)`,
+          `      patched = content`,
+          `        .gsub('var closestParentReactContentView: RCTRootContentView?', 'var closestParentReactContentView: RCTView?')`,
+          `        .gsub('let targetType = RCTRootContentView.self;', 'let targetType = RCTView.self;')`,
+          `      File.write(helpers_file, patched) if patched != content`,
+          `    end`,
+        ].join('\n');
+
+        // Anchor: the blank line + post_install closing `end` + platform block closing `end`.
+        // This pattern is stable in Expo's generated Podfile across regenerations.
+        const anchor = '\n\n  end\nend\n';
+        if (podfile.includes(anchor)) {
+          podfile = podfile.replace(anchor, `\n\n${snippet}\n\n  end\nend\n`);
+          fs.writeFileSync(podfilePath, podfile, 'utf-8');
+        }
+      }
+
+      return c;
+    },
+  ]);
+
+  return patched;
+};
+
 export default (): ExpoConfig =>
-  withSentry(
-    {
-      name: getAppName(),
-      slug: 'packrat',
-      version: '2.0.28',
-      scheme: 'packrat',
-      web: {
-        bundler: 'metro',
-        output: 'single',
-        favicon: './assets/favicon.png',
-      },
-      plugins: [
-        'expo-router',
-        'expo-sqlite',
-        'expo-font',
-        'expo-image',
-        [
-          '@react-native-google-signin/google-signin',
-          {
-            iosUrlScheme:
-              'com.googleusercontent.apps.993694750638-97t0vhfml04u2avrlbve22jbs9qcinbc',
-          },
-        ],
-        'expo-secure-store',
-        'expo-web-browser',
-        [
-          'expo-dev-client',
-          {
-            android: { toolsButton: false },
-            ios: { toolsButton: false },
-          },
-        ],
-        'expo-apple-authentication',
-        'expo-localization',
-        [
-          'llama.rn',
-          {
-            enableEntitlements: true,
-            forceCxx20: true,
-            enableOpenCLAndHexagon: false,
-          },
-        ],
-        ['react-native-maps', { iosGoogleMapsApiKey: process.env.EXPO_PUBLIC_GOOGLE_MAPS_API_KEY }],
-        '@react-native-community/datetimepicker',
-        '@sentry/react-native',
-        'expo-status-bar',
-        ['expo-splash-screen', { image: './assets/splash.png' }],
-      ],
-      experiments: {
-        typedRoutes: true,
-        tsconfigPaths: true,
-      },
-      orientation: 'portrait',
-      icon: getIcon(),
-      userInterfaceStyle: 'automatic',
-      assetBundlePatterns: ['**/*'],
-      ios: {
-        supportsTablet: true,
-        bundleIdentifier: getBundleIdentifier(),
-        usesAppleSignIn: true,
-        config: {
-          googleMapsApiKey: process.env.EXPO_PUBLIC_GOOGLE_MAPS_API_KEY,
+  withSwiftUICoreFix(
+    withSentry(
+      {
+        name: getAppName(),
+        slug: 'packrat',
+        version: '2.0.28',
+        scheme: 'packrat',
+        web: {
+          bundler: 'metro',
+          output: 'single',
+          favicon: './assets/favicon.png',
         },
-        infoPlist: {
-          ITSAppUsesNonExemptEncryption: false,
-          CFBundleURLTypes: [
+        plugins: [
+          'expo-router',
+          'expo-sqlite',
+          'expo-font',
+          'expo-image',
+          [
+            '@react-native-google-signin/google-signin',
             {
-              CFBundleURLSchemes: [getBundleIdentifier()],
+              iosUrlScheme:
+                'com.googleusercontent.apps.993694750638-97t0vhfml04u2avrlbve22jbs9qcinbc',
             },
           ],
-          NSLocationWhenInUseUsageDescription:
-            'This app needs access to your location while you are using it.',
-          NSCameraUsageDescription:
-            'This app requires access to your camera to let you take photos or scan items.',
-          NSPhotoLibraryUsageDescription:
-            'This app needs access to your photo library to let you upload or choose photos.',
-        },
-        privacyManifests: {
-          NSPrivacyCollectedDataTypes: [
+          'expo-secure-store',
+          'expo-web-browser',
+          [
+            'expo-dev-client',
             {
-              NSPrivacyCollectedDataType: 'NSPrivacyCollectedDataTypeCrashData',
-              NSPrivacyCollectedDataTypeLinked: false,
-              NSPrivacyCollectedDataTypeTracking: false,
-              NSPrivacyCollectedDataTypePurposes: [
-                'NSPrivacyCollectedDataTypePurposeAppFunctionality',
-              ],
-            },
-            {
-              NSPrivacyCollectedDataType: 'NSPrivacyCollectedDataTypePerformanceData',
-              NSPrivacyCollectedDataTypeLinked: false,
-              NSPrivacyCollectedDataTypeTracking: false,
-              NSPrivacyCollectedDataTypePurposes: [
-                'NSPrivacyCollectedDataTypePurposeAppFunctionality',
-              ],
-            },
-            {
-              NSPrivacyCollectedDataType: 'NSPrivacyCollectedDataTypeOtherDiagnosticData',
-              NSPrivacyCollectedDataTypeLinked: false,
-              NSPrivacyCollectedDataTypeTracking: false,
-              NSPrivacyCollectedDataTypePurposes: [
-                'NSPrivacyCollectedDataTypePurposeAppFunctionality',
-              ],
+              android: { toolsButton: false },
+              ios: { toolsButton: false },
             },
           ],
-          NSPrivacyAccessedAPITypes: [
+          'expo-apple-authentication',
+          'expo-localization',
+          [
+            'llama.rn',
             {
-              NSPrivacyAccessedAPIType: 'NSPrivacyAccessedAPICategoryUserDefaults',
-              NSPrivacyAccessedAPITypeReasons: ['CA92.1'],
-            },
-            {
-              NSPrivacyAccessedAPIType: 'NSPrivacyAccessedAPICategorySystemBootTime',
-              NSPrivacyAccessedAPITypeReasons: ['35F9.1'],
-            },
-            {
-              NSPrivacyAccessedAPIType: 'NSPrivacyAccessedAPICategoryFileTimestamp',
-              NSPrivacyAccessedAPITypeReasons: ['C617.1'],
+              enableEntitlements: true,
+              forceCxx20: true,
+              enableOpenCLAndHexagon: false,
             },
           ],
+          [
+            'react-native-maps',
+            { iosGoogleMapsApiKey: process.env.EXPO_PUBLIC_GOOGLE_MAPS_API_KEY },
+          ],
+          '@react-native-community/datetimepicker',
+          '@sentry/react-native',
+          'expo-status-bar',
+          ['expo-splash-screen', { image: './assets/splash.png' }],
+        ],
+        experiments: {
+          typedRoutes: true,
+          tsconfigPaths: true,
         },
-        entitlements: {
-          'com.apple.developer.kernel.extended-virtual-addressing': true,
-          'com.apple.developer.kernel.increased-memory-limit': true,
-        },
-      },
-      android: {
-        adaptiveIcon: {
-          foregroundImage: getAdaptiveIcon(),
-          backgroundColor: '#026A9F',
-        },
-        package: getAndroidPackage(),
-        config: {
-          googleMaps: {
-            apiKey: process.env.EXPO_PUBLIC_GOOGLE_MAPS_API_KEY,
+        orientation: 'portrait',
+        icon: getIcon(),
+        userInterfaceStyle: 'automatic',
+        assetBundlePatterns: ['**/*'],
+        ios: {
+          supportsTablet: true,
+          bundleIdentifier: getBundleIdentifier(),
+          usesAppleSignIn: true,
+          config: {
+            googleMapsApiKey: process.env.EXPO_PUBLIC_GOOGLE_MAPS_API_KEY,
+          },
+          infoPlist: {
+            ITSAppUsesNonExemptEncryption: false,
+            CFBundleURLTypes: [
+              {
+                CFBundleURLSchemes: [getBundleIdentifier()],
+              },
+            ],
+            NSLocationWhenInUseUsageDescription:
+              'This app needs access to your location while you are using it.',
+            NSCameraUsageDescription:
+              'This app requires access to your camera to let you take photos or scan items.',
+            NSPhotoLibraryUsageDescription:
+              'This app needs access to your photo library to let you upload or choose photos.',
+          },
+          privacyManifests: {
+            NSPrivacyCollectedDataTypes: [
+              {
+                NSPrivacyCollectedDataType: 'NSPrivacyCollectedDataTypeCrashData',
+                NSPrivacyCollectedDataTypeLinked: false,
+                NSPrivacyCollectedDataTypeTracking: false,
+                NSPrivacyCollectedDataTypePurposes: [
+                  'NSPrivacyCollectedDataTypePurposeAppFunctionality',
+                ],
+              },
+              {
+                NSPrivacyCollectedDataType: 'NSPrivacyCollectedDataTypePerformanceData',
+                NSPrivacyCollectedDataTypeLinked: false,
+                NSPrivacyCollectedDataTypeTracking: false,
+                NSPrivacyCollectedDataTypePurposes: [
+                  'NSPrivacyCollectedDataTypePurposeAppFunctionality',
+                ],
+              },
+              {
+                NSPrivacyCollectedDataType: 'NSPrivacyCollectedDataTypeOtherDiagnosticData',
+                NSPrivacyCollectedDataTypeLinked: false,
+                NSPrivacyCollectedDataTypeTracking: false,
+                NSPrivacyCollectedDataTypePurposes: [
+                  'NSPrivacyCollectedDataTypePurposeAppFunctionality',
+                ],
+              },
+            ],
+            NSPrivacyAccessedAPITypes: [
+              {
+                NSPrivacyAccessedAPIType: 'NSPrivacyAccessedAPICategoryUserDefaults',
+                NSPrivacyAccessedAPITypeReasons: ['CA92.1'],
+              },
+              {
+                NSPrivacyAccessedAPIType: 'NSPrivacyAccessedAPICategorySystemBootTime',
+                NSPrivacyAccessedAPITypeReasons: ['35F9.1'],
+              },
+              {
+                NSPrivacyAccessedAPIType: 'NSPrivacyAccessedAPICategoryFileTimestamp',
+                NSPrivacyAccessedAPITypeReasons: ['C617.1'],
+              },
+            ],
+          },
+          entitlements: {
+            'com.apple.developer.kernel.extended-virtual-addressing': true,
+            'com.apple.developer.kernel.increased-memory-limit': true,
           },
         },
-      },
-      extra: {
-        eas: {
-          projectId: '267945b1-d9ac-4621-8541-826a2c70576d',
+        android: {
+          adaptiveIcon: {
+            foregroundImage: getAdaptiveIcon(),
+            backgroundColor: '#026A9F',
+          },
+          package: getAndroidPackage(),
+          config: {
+            googleMaps: {
+              apiKey: process.env.EXPO_PUBLIC_GOOGLE_MAPS_API_KEY,
+            },
+          },
         },
-        appVariant: IS_DEV ? 'development' : IS_PREVIEW ? 'preview' : 'production',
+        extra: {
+          eas: {
+            projectId: '267945b1-d9ac-4621-8541-826a2c70576d',
+          },
+          appVariant: IS_DEV ? 'development' : IS_PREVIEW ? 'preview' : 'production',
+        },
+        updates: {
+          url: 'https://u.expo.dev/267945b1-d9ac-4621-8541-826a2c70576d',
+        },
+        runtimeVersion: {
+          policy: 'appVersion',
+        },
+        owner: 'packrat',
       },
-      updates: {
-        url: 'https://u.expo.dev/267945b1-d9ac-4621-8541-826a2c70576d',
+      {
+        url: 'https://sentry.io/',
+        organization: 'packrat-oq',
+        project: 'packrat-expo',
       },
-      runtimeVersion: {
-        policy: 'appVersion',
-      },
-      owner: 'packrat',
-    },
-    {
-      url: 'https://sentry.io/',
-      organization: 'packrat-oq',
-      project: 'packrat-expo',
-    },
+    ),
   );

--- a/apps/expo/app.config.ts
+++ b/apps/expo/app.config.ts
@@ -1,5 +1,6 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import { isString } from '@packrat/guards';
 import { withSentry } from '@sentry/react-native/expo';
 import type { ExpoConfig } from 'expo/config';
 import { type ConfigPlugin, withDangerousMod, withXcodeProject } from 'expo/config-plugins';
@@ -55,12 +56,12 @@ const withSwiftUICoreFix: ConfigPlugin<void> = (config) => {
     if (!appTarget) return c;
 
     const configList = proj.pbxXCConfigurationList()[appTarget.target.buildConfigurationList];
-    if (!configList || typeof configList === 'string') return c;
+    if (!configList || isString(configList)) return c;
 
     const buildConfigs = proj.pbxXCBuildConfigurationSection();
     for (const ref of configList.buildConfigurations) {
       const bc = buildConfigs[ref.value];
-      if (!bc || typeof bc === 'string') continue;
+      if (!bc || isString(bc)) continue;
 
       // Shims/SwiftUICore.framework/SwiftUICore.tbd is a minimal stub without
       // allowable-clients. It lives at apps/expo/Shims/ (outside ios/, so it

--- a/bun.lock
+++ b/bun.lock
@@ -796,6 +796,9 @@
   "trustedDependencies": [
     "@sentry/cli",
   ],
+  "patchedDependencies": {
+    "react-native-ios-utilities@5.2.0": "patches/react-native-ios-utilities@5.2.0.patch",
+  },
   "overrides": {
     "@packrat-ai/nativewindui": "2.2.1",
     "@sinclair/typebox": "^0.34.15",

--- a/patches/react-native-ios-utilities@5.2.0.patch
+++ b/patches/react-native-ios-utilities@5.2.0.patch
@@ -1,0 +1,25 @@
+diff --git a/ios/Sources/Extensions+Helpers/RCTView+Helpers.swift b/ios/Sources/Extensions+Helpers/RCTView+Helpers.swift
+index 09be306d5aa39337c5114c2ad6ba7513218e0751..de321cb3c6d2e45c05dfc6bf9786001b15576eab 100644
+--- a/ios/Sources/Extensions+Helpers/RCTView+Helpers.swift
++++ b/ios/Sources/Extensions+Helpers/RCTView+Helpers.swift
+@@ -25,13 +25,16 @@ public extension RCTView {
+     return rootView.recursivelyFindSubview(whereType: targetType);
+   };
+   
+-  var closestParentReactContentView: RCTRootContentView? {
+-    let targetType = RCTRootContentView.self;
+-  
++  // RCTRootContentView is not exported from the prebuilt React.framework in RN 0.85+.
++  // Use RCTView as the search target — it's the common ancestor and satisfies the
++  // reactTouchHandlers call-site downstream.
++  var closestParentReactContentView: RCTView? {
++    let targetType = RCTView.self;
++
+     if let match = self.recursivelyFindParentView(whereType: targetType) {
+       return match;
+     };
+-    
++
+     guard let rootView = self.rootViewForCurrentWindow else { return nil };
+     return rootView.recursivelyFindSubview(whereType: targetType);
+   };


### PR DESCRIPTION
## Summary

Fixes three iOS build failures introduced by the Xcode 26 SDK that prevent both `bun ios` and `eas build --local` from succeeding.

- **SwiftUICore `allowable-clients` restriction** — Xcode 26 splits `SwiftUI.framework` into a public `SwiftUI.framework` and a private `SwiftUICore.framework`. Pods that compile `import SwiftUI` emit a SwiftUICore auto-link directive; the linker rejects it because `SwiftUICore.tbd` restricts clients to Apple-internal frameworks. Fix: ship `apps/expo/Shims/SwiftUICore.framework/SwiftUICore.tbd` (the real 49k-line TBD with only the `allowable-clients` block stripped) and prepend `$(PROJECT_DIR)/../Shims` to `FRAMEWORK_SEARCH_PATHS` via a `withXcodeProject` config plugin. The linker finds the shim before the SDK's restricted copy; all symbols resolve through `SwiftUI.framework`'s re-export of SwiftUICore.

- **UIUtilities compile-time header missing** — `UIKit.framework/Headers/UIKitDefines.h` in the iOS 26.4 SDK now `#import`s `<UIUtilities/UIDefines.h>`. With our Shims directory first in `FRAMEWORK_SEARCH_PATHS`, the compiler found our initially-headerless `UIUtilities.framework` shim and failed (cascading into UIKit → AVKit → ExpoModulesCore → ExpoFileSystem / ExpoLocation). Fix: copy the real UIUtilities headers (`UIDefines.h`, `UICoordinateSpace.h`, `UIGeometry.h`) and `module.modulemap` from the SDK's `SubFrameworks/UIUtilities.framework` into the shim.

- **`RCTRootContentView` missing from prebuilt `React.framework`** — `react-native-ios-utilities` 5.x references `_OBJC_CLASS_$_RCTRootContentView` which Expo's prebuilt `React.xcframework` no longer exports in RN 0.85+. Fix: bun patch replacing `RCTRootContentView` with `RCTView` (the common ancestor — satisfies the downstream `reactTouchHandlers` call-site). A Podfile `post_install` gsub applies the same fix for any environment that re-runs pod install after a prebuild.

## Architecture

All shims live in `apps/expo/Shims/` (outside `ios/` which is CNG-gitignored) and the `withSwiftUICoreFix` config plugin re-applies `FRAMEWORK_SEARCH_PATHS` and the Podfile hooks on every `expo prebuild`, so the fix is fully automatic for local development and EAS builds.

## Test plan

- [x] `bun ios` → simulator build succeeds, app runs on iPhone 17
- [x] `eas build --profile development --platform ios --local` → device archive succeeds