### PR TITLE
fix(guards): use explicit .ts extensions to fix Node ESM resolution in app.config.ts

### DIFF
--- a/packages/guards/src/index.ts
+++ b/packages/guards/src/index.ts
@@ -44,7 +44,7 @@ export {
   setHas,
 } from 'ts-extras';
 
-export * from './assertions';
-export * from './enum';
-export * from './narrow';
-export * from './parse';
+export * from './assertions.ts';
+export * from './enum.ts';
+export * from './narrow.ts';
+export * from './parse.ts';

--- a/packages/guards/tsconfig.json
+++ b/packages/guards/tsconfig.json
@@ -1,4 +1,7 @@
 {
   "extends": "@packrat/typescript-config/base.json",
+  "compilerOptions": {
+    "allowImportingTsExtensions": true
+  },
   "include": ["src"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,7 @@
     "moduleResolution": "bundler",
     "noEmit": true,
     "noUncheckedIndexedAccess": true,
+    "allowImportingTsExtensions": true,
     "resolveJsonModule": true,
     "skipLibCheck": true,
     "strictNullChecks": true,


### PR DESCRIPTION
## Summary

- `packages/guards/src/index.ts` re-exported internal modules with extensionless relative imports (`./assertions`, `./enum`, etc.)
- Node 25's native TypeScript support can load `.ts` files but does **not** auto-try `.ts` extensions for bare relative imports — `./assertions` fails with `ERR_MODULE_NOT_FOUND`
- This broke `bun expo` / `expo start` because `app.config.ts` imports `isString` from `@packrat/guards`, and Expo evaluates configs via Node's ESM loader

## Changes

- `packages/guards/src/index.ts`: changed to explicit `.ts` extensions (`./assertions.ts`, etc.) — Node 25 TypeScript support resolves these correctly
- `packages/guards/tsconfig.json`: added `allowImportingTsExtensions: true` so `tsc --noEmit` accepts the `.ts` extension imports (valid since the package is source-only with `noEmit: true` in base config)
- `apps/expo/app.config.ts`: restored original `isString` import (no change from intent — reverts the broken intermediate state)

## Test plan

- [x] `bun expo` / `cd apps/expo && bun start` starts Metro without the `ERR_MODULE_NOT_FOUND` error
- [ ] `cd packages/guards && bun run check-types` passes with no errors
- [ ] Pre-push hooks pass (`no-raw-typeof`, circular deps, clean-checks)