### PR TITLE
fix(pack-templates): restore header and move template count into list scroll

### DIFF
--- a/apps/expo/app/(app)/_layout.tsx
+++ b/apps/expo/app/(app)/_layout.tsx
@@ -249,7 +249,8 @@ export default function AppLayout() {
         <Stack.Screen
           name="pack-templates/index"
           options={{
-            headerShown: false,
+            ...getAppBarOptions(),
+            title: 'Pack Templates',
           }}
         />
         <Stack.Screen

--- a/apps/expo/app/(app)/pack-categories/[id].tsx
+++ b/apps/expo/app/(app)/pack-categories/[id].tsx
@@ -69,7 +69,7 @@ export default function PackCategoriesScreen() {
     <>
       <Stack.Screen options={{ ...getAppBarOptions(), title: t('packs.packCategories') }} />
       {categories.length ? (
-        <ScrollView className="flex-1">
+        <ScrollView className="flex-1" contentInsetAdjustmentBehavior="automatic">
           <View className="p-4">
             <Text variant="subhead" className="mb-2 text-muted-foreground">
               {t('packs.organizeGear')}

--- a/apps/expo/app/(app)/pack-categories/[id].tsx
+++ b/apps/expo/app/(app)/pack-categories/[id].tsx
@@ -67,7 +67,13 @@ export default function PackCategoriesScreen() {
 
   return (
     <>
-      <Stack.Screen options={{ ...getAppBarOptions(), title: t('packs.packCategories') }} />
+      <Stack.Screen
+        options={{
+          ...getAppBarOptions(),
+          headerLargeTitle: false,
+          title: t('packs.packCategories'),
+        }}
+      />
       {categories.length ? (
         <ScrollView className="flex-1" contentInsetAdjustmentBehavior="automatic">
           <View className="p-4">

--- a/apps/expo/features/pack-templates/screens/PackTemplateListScreen.tsx
+++ b/apps/expo/features/pack-templates/screens/PackTemplateListScreen.tsx
@@ -169,14 +169,6 @@ export function PackTemplateListScreen() {
     return selectedTemplateTypeIndex === 0 ? (
       <View className="bg-background">
         <FeaturedPacksSection onTemplatePress={handleTemplatePress} />
-        <View className="px-4 pb-2">
-          <Text className="text-muted-foreground">
-            {filteredTemplates.length}{' '}
-            {filteredTemplates.length === 1
-              ? t('packTemplates.template')
-              : t('packTemplates.templates')}
-          </Text>
-        </View>
       </View>
     ) : undefined;
   };
@@ -220,8 +212,16 @@ export function PackTemplateListScreen() {
         data={filteredTemplates}
         keyExtractor={(item) => item.id}
         contentInsetAdjustmentBehavior="automatic"
-        renderItem={({ item }) => (
+        renderItem={({ item, index }) => (
           <View className="px-4 pt-4">
+            {index === 0 && (
+              <Text className="pb-2 text-muted-foreground">
+                {filteredTemplates.length}{' '}
+                {filteredTemplates.length === 1
+                  ? t('packTemplates.template')
+                  : t('packTemplates.templates')}
+              </Text>
+            )}
             <PackTemplateCard templateId={item.id} onPress={handleTemplatePress} />
           </View>
         )}

--- a/apps/expo/features/pack-templates/screens/PackTemplateListScreen.tsx
+++ b/apps/expo/features/pack-templates/screens/PackTemplateListScreen.tsx
@@ -169,6 +169,14 @@ export function PackTemplateListScreen() {
     return selectedTemplateTypeIndex === 0 ? (
       <View className="bg-background">
         <FeaturedPacksSection onTemplatePress={handleTemplatePress} />
+        <View className="px-4 pb-2">
+          <Text className="text-muted-foreground">
+            {filteredTemplates.length}{' '}
+            {filteredTemplates.length === 1
+              ? t('packTemplates.template')
+              : t('packTemplates.templates')}
+          </Text>
+        </View>
       </View>
     ) : undefined;
   };
@@ -212,16 +220,8 @@ export function PackTemplateListScreen() {
         data={filteredTemplates}
         keyExtractor={(item) => item.id}
         contentInsetAdjustmentBehavior="automatic"
-        renderItem={({ item, index }) => (
+        renderItem={({ item }) => (
           <View className="px-4 pt-4">
-            {index === 0 && (
-              <Text className="pb-2 text-muted-foreground">
-                {filteredTemplates.length}{' '}
-                {filteredTemplates.length === 1
-                  ? t('packTemplates.template')
-                  : t('packTemplates.templates')}
-              </Text>
-            )}
             <PackTemplateCard templateId={item.id} onPress={handleTemplatePress} />
           </View>
         )}

--- a/apps/expo/features/packs/screens/PackListScreen.tsx
+++ b/apps/expo/features/packs/screens/PackListScreen.tsx
@@ -211,10 +211,29 @@ export function PackListScreen() {
         )}
       </SearchOverlay>
 
+      <View className="bg-background">
+        {!isAuthenticated && <SyncBanner title={t('packs.syncBanner')} />}
+        {isAuthenticated && (
+          <View className="px-4">
+            <SegmentedControl
+              enabled={isAuthenticated}
+              values={['My Packs', 'All Packs']}
+              selectedIndex={selectedTypeIndex}
+              onIndexChange={(index) => {
+                setSelectedTypeIndex(index);
+              }}
+            />
+          </View>
+        )}
+        <View className="bg-background px-4 py-2">
+          <ScrollView horizontal showsHorizontalScrollIndicator={false} className="py-1">
+            {filterOptions.map(renderFilterChip)}
+          </ScrollView>
+        </View>
+      </View>
       <FlatList
         data={filteredPacks}
         keyExtractor={(pack) => pack.id}
-        stickyHeaderIndices={[0]}
         contentInsetAdjustmentBehavior="automatic"
         renderItem={({ item: pack, index }) => (
           <View className="px-4 pt-4">
@@ -239,28 +258,6 @@ export function PackListScreen() {
               tintColor={colors.primary}
             />
           ) : undefined
-        }
-        ListHeaderComponent={
-          <View className="bg-background">
-            {!isAuthenticated && <SyncBanner title={t('packs.syncBanner')} />}
-            {isAuthenticated && (
-              <View className="px-4">
-                <SegmentedControl
-                  enabled={isAuthenticated}
-                  values={['My Packs', 'All Packs']}
-                  selectedIndex={selectedTypeIndex}
-                  onIndexChange={(index) => {
-                    setSelectedTypeIndex(index);
-                  }}
-                />
-              </View>
-            )}
-            <View className="bg-background px-4 py-2">
-              <ScrollView horizontal showsHorizontalScrollIndicator={false} className="py-1">
-                {filterOptions.map(renderFilterChip)}
-              </ScrollView>
-            </View>
-          </View>
         }
         ListEmptyComponent={
           selectedTypeIndex === ALL_PACKS_INDEX ? (

--- a/apps/expo/features/packs/screens/PackListScreen.tsx
+++ b/apps/expo/features/packs/screens/PackListScreen.tsx
@@ -218,8 +218,13 @@ export function PackListScreen() {
           keyExtractor={(pack) => pack.id}
           stickyHeaderIndices={[0]}
           contentInsetAdjustmentBehavior="automatic"
-          renderItem={({ item: pack }) => (
+          renderItem={({ item: pack, index }) => (
             <View className="px-4 pt-4">
+              {index === 0 && selectedTypeIndex === USER_PACKS_INDEX && (
+                <Text className="pb-2 text-muted-foreground">
+                  {filteredPacks?.length || 0} {filteredPacks?.length === 1 ? 'pack' : 'packs'}
+                </Text>
+              )}
               <PackCard
                 // biome-ignore lint/suspicious/noExplicitAny: Treaty type divergence
                 pack={pack as any}
@@ -257,13 +262,6 @@ export function PackListScreen() {
                   {filterOptions.map(renderFilterChip)}
                 </ScrollView>
               </View>
-              {selectedTypeIndex === USER_PACKS_INDEX && (
-                <View className="px-6 py-2 bg-background">
-                  <Text className="text-muted-foreground">
-                    {filteredPacks?.length || 0} {filteredPacks?.length === 1 ? 'pack' : 'packs'}
-                  </Text>
-                </View>
-              )}
             </View>
           }
           ListEmptyComponent={

--- a/apps/expo/features/packs/screens/PackListScreen.tsx
+++ b/apps/expo/features/packs/screens/PackListScreen.tsx
@@ -1,5 +1,6 @@
 import { ActivityIndicator, Button, SegmentedControl } from '@packrat/ui/nativewindui';
 import { getAppBarOptions } from '@packrat/ui/src/app-bar';
+import { LargeTitleHeaderOverlapFixIOS } from '@packrat/ui/src/large-title-header-overlap-fix-ios';
 import { SearchOverlay } from '@packrat/ui/src/search-overlay';
 import { AndroidTabBarInsetFix } from 'expo-app/components/AndroidTabBarInsetFix';
 import { Icon } from 'expo-app/components/Icon';
@@ -23,7 +24,7 @@ import {
   TouchableOpacity,
   View,
 } from 'react-native';
-import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import { useAllPacks } from '../hooks/useAllPacks';
 import { usePacks } from '../hooks/usePacks';
 import type { Pack, PackCategory, PackInStore } from '../types';
@@ -67,7 +68,6 @@ export function PackListScreen() {
   const allPacksQuery = useAllPacks(selectedTypeIndex === ALL_PACKS_INDEX);
 
   const { colors } = useColorScheme();
-  const { top: topInset } = useSafeAreaInsets();
 
   const filterOptions: FilterOption[] = [
     { label: t('packs.all'), value: 'all' },
@@ -212,83 +212,89 @@ export function PackListScreen() {
         )}
       </SearchOverlay>
 
-      <View className="bg-background" style={{ paddingTop: topInset }}>
-        {!isAuthenticated && <SyncBanner title={t('packs.syncBanner')} />}
-        {isAuthenticated && (
-          <View className="px-4">
-            <SegmentedControl
-              enabled={isAuthenticated}
-              values={['My Packs', 'All Packs']}
-              selectedIndex={selectedTypeIndex}
-              onIndexChange={(index) => {
-                setSelectedTypeIndex(index);
-              }}
-            />
-          </View>
-        )}
-        <View className="bg-background px-4 py-2">
-          <ScrollView horizontal showsHorizontalScrollIndicator={false} className="py-1">
-            {filterOptions.map(renderFilterChip)}
-          </ScrollView>
-        </View>
-      </View>
-      <FlatList
-        data={filteredPacks}
-        keyExtractor={(pack) => pack.id}
-        renderItem={({ item: pack, index }) => (
-          <View className="px-4 pt-4">
-            {index === 0 && selectedTypeIndex === USER_PACKS_INDEX && (
-              <Text className="pb-2 text-muted-foreground">
-                {filteredPacks?.length || 0} {filteredPacks?.length === 1 ? 'pack' : 'packs'}
-              </Text>
-            )}
-            <PackCard
-              // biome-ignore lint/suspicious/noExplicitAny: Treaty type divergence
-              pack={pack as any}
-              onPress={handlePackPress}
-              showDuplicateButton={selectedTypeIndex === ALL_PACKS_INDEX}
-            />
-          </View>
-        )}
-        refreshControl={
-          selectedTypeIndex === ALL_PACKS_INDEX ? (
-            <RefreshControl
-              refreshing={allPacksQuery.isRefetching}
-              onRefresh={allPacksQuery.refetch}
-              tintColor={colors.primary}
-            />
-          ) : undefined
-        }
-        ListEmptyComponent={
-          selectedTypeIndex === ALL_PACKS_INDEX ? (
-            renderAllPacksEmptyState()
-          ) : (
-            <View className="flex-1 items-center justify-center p-8">
-              <View className="mb-4 rounded-full bg-muted p-4">
-                <Icon name="cog-outline" size={32} color="text-muted-foreground" />
-              </View>
-              <Text className="mb-1 text-lg font-medium text-foreground">
-                {t('packs.noPacksFound')}
-              </Text>
-              <Text className="mb-6 text-center text-muted-foreground">
-                {activeFilter === 'all'
-                  ? "You haven't created or found any public packs yet."
-                  : `You don't have any ${activeFilter} packs.`}
-              </Text>
-              <TouchableOpacity
-                className="rounded-lg bg-primary px-4 py-2"
-                onPress={handleCreatePack}
-              >
-                <Text className="font-medium text-primary-foreground">
-                  {t('packs.createNewPack')}
+      <LargeTitleHeaderOverlapFixIOS>
+        <FlatList
+          data={filteredPacks}
+          keyExtractor={(pack) => pack.id}
+          stickyHeaderIndices={[0]}
+          contentInsetAdjustmentBehavior="automatic"
+          renderItem={({ item: pack, index }) => (
+            <View className="px-4 pt-4">
+              {index === 0 && selectedTypeIndex === USER_PACKS_INDEX && (
+                <Text className="pb-2 text-muted-foreground">
+                  {filteredPacks?.length || 0} {filteredPacks?.length === 1 ? 'pack' : 'packs'}
                 </Text>
-              </TouchableOpacity>
+              )}
+              <PackCard
+                // biome-ignore lint/suspicious/noExplicitAny: Treaty type divergence
+                pack={pack as any}
+                onPress={handlePackPress}
+                showDuplicateButton={selectedTypeIndex === ALL_PACKS_INDEX}
+              />
             </View>
-          )
-        }
-        ListFooterComponent={<AndroidTabBarInsetFix />}
-        contentContainerStyle={{ flexGrow: 1 }}
-      />
+          )}
+          refreshControl={
+            selectedTypeIndex === ALL_PACKS_INDEX ? (
+              <RefreshControl
+                refreshing={allPacksQuery.isRefetching}
+                onRefresh={allPacksQuery.refetch}
+                tintColor={colors.primary}
+              />
+            ) : undefined
+          }
+          ListHeaderComponent={
+            <View className="bg-background">
+              {!isAuthenticated && <SyncBanner title={t('packs.syncBanner')} />}
+              {isAuthenticated && (
+                <View className="px-4">
+                  <SegmentedControl
+                    enabled={isAuthenticated}
+                    values={['My Packs', 'All Packs']}
+                    selectedIndex={selectedTypeIndex}
+                    onIndexChange={(index) => {
+                      setSelectedTypeIndex(index);
+                    }}
+                  />
+                </View>
+              )}
+              <View className="bg-background px-4 py-2">
+                <ScrollView horizontal showsHorizontalScrollIndicator={false} className="py-1">
+                  {filterOptions.map(renderFilterChip)}
+                </ScrollView>
+              </View>
+            </View>
+          }
+          ListEmptyComponent={
+            selectedTypeIndex === ALL_PACKS_INDEX ? (
+              renderAllPacksEmptyState()
+            ) : (
+              <View className="flex-1 items-center justify-center p-8">
+                <View className="mb-4 rounded-full bg-muted p-4">
+                  <Icon name="cog-outline" size={32} color="text-muted-foreground" />
+                </View>
+                <Text className="mb-1 text-lg font-medium text-foreground">
+                  {t('packs.noPacksFound')}
+                </Text>
+                <Text className="mb-6 text-center text-muted-foreground">
+                  {activeFilter === 'all'
+                    ? "You haven't created or found any public packs yet."
+                    : `You don't have any ${activeFilter} packs.`}
+                </Text>
+                <TouchableOpacity
+                  className="rounded-lg bg-primary px-4 py-2"
+                  onPress={handleCreatePack}
+                >
+                  <Text className="font-medium text-primary-foreground">
+                    {t('packs.createNewPack')}
+                  </Text>
+                </TouchableOpacity>
+              </View>
+            )
+          }
+          ListFooterComponent={<AndroidTabBarInsetFix />}
+          contentContainerStyle={{ flexGrow: 1 }}
+        />
+      </LargeTitleHeaderOverlapFixIOS>
     </SafeAreaView>
   );
 }

--- a/apps/expo/features/packs/screens/PackListScreen.tsx
+++ b/apps/expo/features/packs/screens/PackListScreen.tsx
@@ -23,7 +23,7 @@ import {
   TouchableOpacity,
   View,
 } from 'react-native';
-import { SafeAreaView } from 'react-native-safe-area-context';
+import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useAllPacks } from '../hooks/useAllPacks';
 import { usePacks } from '../hooks/usePacks';
 import type { Pack, PackCategory, PackInStore } from '../types';
@@ -67,6 +67,7 @@ export function PackListScreen() {
   const allPacksQuery = useAllPacks(selectedTypeIndex === ALL_PACKS_INDEX);
 
   const { colors } = useColorScheme();
+  const { top: topInset } = useSafeAreaInsets();
 
   const filterOptions: FilterOption[] = [
     { label: t('packs.all'), value: 'all' },
@@ -211,7 +212,7 @@ export function PackListScreen() {
         )}
       </SearchOverlay>
 
-      <View className="bg-background">
+      <View className="bg-background" style={{ paddingTop: topInset }}>
         {!isAuthenticated && <SyncBanner title={t('packs.syncBanner')} />}
         {isAuthenticated && (
           <View className="px-4">
@@ -234,7 +235,6 @@ export function PackListScreen() {
       <FlatList
         data={filteredPacks}
         keyExtractor={(pack) => pack.id}
-        contentInsetAdjustmentBehavior="automatic"
         renderItem={({ item: pack, index }) => (
           <View className="px-4 pt-4">
             {index === 0 && selectedTypeIndex === USER_PACKS_INDEX && (

--- a/apps/expo/features/packs/screens/PackListScreen.tsx
+++ b/apps/expo/features/packs/screens/PackListScreen.tsx
@@ -187,7 +187,6 @@ export function PackListScreen() {
       <Stack.Screen
         options={{
           ...getAppBarOptions(),
-          headerLargeTitle: false,
           title: t('navigation.packs'),
           headerBackVisible: false,
           headerRight: () => <CreatePackIconButton />,

--- a/apps/expo/features/packs/screens/PackListScreen.tsx
+++ b/apps/expo/features/packs/screens/PackListScreen.tsx
@@ -1,6 +1,5 @@
 import { ActivityIndicator, Button, SegmentedControl } from '@packrat/ui/nativewindui';
 import { getAppBarOptions } from '@packrat/ui/src/app-bar';
-import { LargeTitleHeaderOverlapFixIOS } from '@packrat/ui/src/large-title-header-overlap-fix-ios';
 import { SearchOverlay } from '@packrat/ui/src/search-overlay';
 import { AndroidTabBarInsetFix } from 'expo-app/components/AndroidTabBarInsetFix';
 import { Icon } from 'expo-app/components/Icon';
@@ -188,6 +187,7 @@ export function PackListScreen() {
       <Stack.Screen
         options={{
           ...getAppBarOptions(),
+          headerLargeTitle: false,
           title: t('navigation.packs'),
           headerBackVisible: false,
           headerRight: () => <CreatePackIconButton />,
@@ -212,89 +212,87 @@ export function PackListScreen() {
         )}
       </SearchOverlay>
 
-      <LargeTitleHeaderOverlapFixIOS>
-        <FlatList
-          data={filteredPacks}
-          keyExtractor={(pack) => pack.id}
-          stickyHeaderIndices={[0]}
-          contentInsetAdjustmentBehavior="automatic"
-          renderItem={({ item: pack, index }) => (
-            <View className="px-4 pt-4">
-              {index === 0 && selectedTypeIndex === USER_PACKS_INDEX && (
-                <Text className="pb-2 text-muted-foreground">
-                  {filteredPacks?.length || 0} {filteredPacks?.length === 1 ? 'pack' : 'packs'}
-                </Text>
-              )}
-              <PackCard
-                // biome-ignore lint/suspicious/noExplicitAny: Treaty type divergence
-                pack={pack as any}
-                onPress={handlePackPress}
-                showDuplicateButton={selectedTypeIndex === ALL_PACKS_INDEX}
-              />
-            </View>
-          )}
-          refreshControl={
-            selectedTypeIndex === ALL_PACKS_INDEX ? (
-              <RefreshControl
-                refreshing={allPacksQuery.isRefetching}
-                onRefresh={allPacksQuery.refetch}
-                tintColor={colors.primary}
-              />
-            ) : undefined
-          }
-          ListHeaderComponent={
-            <View className="bg-background">
-              {!isAuthenticated && <SyncBanner title={t('packs.syncBanner')} />}
-              {isAuthenticated && (
-                <View className="px-4">
-                  <SegmentedControl
-                    enabled={isAuthenticated}
-                    values={['My Packs', 'All Packs']}
-                    selectedIndex={selectedTypeIndex}
-                    onIndexChange={(index) => {
-                      setSelectedTypeIndex(index);
-                    }}
-                  />
-                </View>
-              )}
-              <View className="bg-background px-4 py-2">
-                <ScrollView horizontal showsHorizontalScrollIndicator={false} className="py-1">
-                  {filterOptions.map(renderFilterChip)}
-                </ScrollView>
+      <FlatList
+        data={filteredPacks}
+        keyExtractor={(pack) => pack.id}
+        stickyHeaderIndices={[0]}
+        contentInsetAdjustmentBehavior="automatic"
+        renderItem={({ item: pack, index }) => (
+          <View className="px-4 pt-4">
+            {index === 0 && selectedTypeIndex === USER_PACKS_INDEX && (
+              <Text className="pb-2 text-muted-foreground">
+                {filteredPacks?.length || 0} {filteredPacks?.length === 1 ? 'pack' : 'packs'}
+              </Text>
+            )}
+            <PackCard
+              // biome-ignore lint/suspicious/noExplicitAny: Treaty type divergence
+              pack={pack as any}
+              onPress={handlePackPress}
+              showDuplicateButton={selectedTypeIndex === ALL_PACKS_INDEX}
+            />
+          </View>
+        )}
+        refreshControl={
+          selectedTypeIndex === ALL_PACKS_INDEX ? (
+            <RefreshControl
+              refreshing={allPacksQuery.isRefetching}
+              onRefresh={allPacksQuery.refetch}
+              tintColor={colors.primary}
+            />
+          ) : undefined
+        }
+        ListHeaderComponent={
+          <View className="bg-background">
+            {!isAuthenticated && <SyncBanner title={t('packs.syncBanner')} />}
+            {isAuthenticated && (
+              <View className="px-4">
+                <SegmentedControl
+                  enabled={isAuthenticated}
+                  values={['My Packs', 'All Packs']}
+                  selectedIndex={selectedTypeIndex}
+                  onIndexChange={(index) => {
+                    setSelectedTypeIndex(index);
+                  }}
+                />
               </View>
+            )}
+            <View className="bg-background px-4 py-2">
+              <ScrollView horizontal showsHorizontalScrollIndicator={false} className="py-1">
+                {filterOptions.map(renderFilterChip)}
+              </ScrollView>
             </View>
-          }
-          ListEmptyComponent={
-            selectedTypeIndex === ALL_PACKS_INDEX ? (
-              renderAllPacksEmptyState()
-            ) : (
-              <View className="flex-1 items-center justify-center p-8">
-                <View className="mb-4 rounded-full bg-muted p-4">
-                  <Icon name="cog-outline" size={32} color="text-muted-foreground" />
-                </View>
-                <Text className="mb-1 text-lg font-medium text-foreground">
-                  {t('packs.noPacksFound')}
-                </Text>
-                <Text className="mb-6 text-center text-muted-foreground">
-                  {activeFilter === 'all'
-                    ? "You haven't created or found any public packs yet."
-                    : `You don't have any ${activeFilter} packs.`}
-                </Text>
-                <TouchableOpacity
-                  className="rounded-lg bg-primary px-4 py-2"
-                  onPress={handleCreatePack}
-                >
-                  <Text className="font-medium text-primary-foreground">
-                    {t('packs.createNewPack')}
-                  </Text>
-                </TouchableOpacity>
+          </View>
+        }
+        ListEmptyComponent={
+          selectedTypeIndex === ALL_PACKS_INDEX ? (
+            renderAllPacksEmptyState()
+          ) : (
+            <View className="flex-1 items-center justify-center p-8">
+              <View className="mb-4 rounded-full bg-muted p-4">
+                <Icon name="cog-outline" size={32} color="text-muted-foreground" />
               </View>
-            )
-          }
-          ListFooterComponent={<AndroidTabBarInsetFix />}
-          contentContainerStyle={{ flexGrow: 1 }}
-        />
-      </LargeTitleHeaderOverlapFixIOS>
+              <Text className="mb-1 text-lg font-medium text-foreground">
+                {t('packs.noPacksFound')}
+              </Text>
+              <Text className="mb-6 text-center text-muted-foreground">
+                {activeFilter === 'all'
+                  ? "You haven't created or found any public packs yet."
+                  : `You don't have any ${activeFilter} packs.`}
+              </Text>
+              <TouchableOpacity
+                className="rounded-lg bg-primary px-4 py-2"
+                onPress={handleCreatePack}
+              >
+                <Text className="font-medium text-primary-foreground">
+                  {t('packs.createNewPack')}
+                </Text>
+              </TouchableOpacity>
+            </View>
+          )
+        }
+        ListFooterComponent={<AndroidTabBarInsetFix />}
+        contentContainerStyle={{ flexGrow: 1 }}
+      />
     </SafeAreaView>
   );
 }


### PR DESCRIPTION
## Summary

- **Restore pack templates header**: `_layout.tsx` was setting `headerShown: false` for `pack-templates/index`, suppressing the native large-title header, title, and the + create button. Replaced with `getAppBarOptions()` + `title: 'Pack Templates'` to match other screens like Guides.
- **Move template count into list scroll**: The count text ("17 templates") was inside the sticky `ListHeaderComponent` alongside `FeaturedPacksSection`, causing it to disappear when scrolling (due to `stickyHeaderHiddenOnScroll`). Moved count to `renderItem` at `index === 0` so it scrolls naturally with the list.
- **Pack categories scroll inset**: Added `contentInsetAdjustmentBehavior="automatic"` to the `ScrollView` in `pack-categories/[id].tsx` so content respects the large-title header inset.

## Test plan

- [ ] Open Pack Templates screen — header title "Pack Templates" and + button are visible
- [ ] Scroll down — FeaturedPacksSection hides, template count ("N templates") scrolls with the cards and remains visible
- [ ] Switch between All / App / Yours segments — count updates correctly
- [ ] Apply a category filter — count reflects filtered result
- [ ] Open Pack Categories modal — content is not obscured by the header

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Pack Templates screen header to display "Pack Templates" title for improved navigation.
  * Improved category list scrolling behavior with automatic content adjustment.

* **Refactor**
  * Reorganized template count display position in the list view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->