### PR TITLE
fix(catalog): clamp brand to one line and widen quick-access cards

### DIFF
--- a/apps/expo/features/catalog/components/CatalogBrowserModal.tsx
+++ b/apps/expo/features/catalog/components/CatalogBrowserModal.tsx
@@ -85,7 +85,7 @@ function QuickAccessSection({
         contentContainerStyle={{ gap: 8 }}
       >
         {items.map((item) => (
-          <View key={item.id} style={{ width: 288 }}>
+          <View key={item.id} style={{ width: 320 }}>
             <HorizontalCatalogItemCard
               item={item}
               selected={selectedItems.has(item.id)}

--- a/apps/expo/features/packs/components/HorizontalCatalogItemCard.tsx
+++ b/apps/expo/features/packs/components/HorizontalCatalogItemCard.tsx
@@ -103,7 +103,11 @@ export function HorizontalCatalogItemCard({ item, ...restProps }: HorizontalCata
           <Text className="font-medium text-foreground" numberOfLines={1}>
             {item.name}
           </Text>
-          {item.brand && <Text className="text-sm text-muted-foreground">{item.brand}</Text>}
+          {item.brand && (
+            <Text className="text-sm text-muted-foreground" numberOfLines={1}>
+              {item.brand}
+            </Text>
+          )}
 
           <View className="mt-2 flex-row flex-wrap items-center gap-x-4 gap-y-1">
             {!!item.price && (


### PR DESCRIPTION
## Summary

- Adds `numberOfLines={1}` to the brand text in `HorizontalCatalogItemCard` so it never wraps to a second line in the recently-used and popular-items sections
- Title (`item.name`) already had `numberOfLines={1}` — no change needed there
- Increases the horizontal card width from `288` → `320` in `CatalogBrowserModal` to give the single-line title more readable space in the horizontal scroll

## Files changed

- `apps/expo/features/packs/components/HorizontalCatalogItemCard.tsx` — brand text clamped to 1 line
- `apps/expo/features/catalog/components/CatalogBrowserModal.tsx` — card width 288 → 320

## Test plan

- [ ] Open the catalog browser modal and verify the recently-used section shows brand names on a single line without wrapping
- [ ] Verify popular items section behaves the same
- [ ] Confirm item names (titles) are also clamped to one line and truncated with ellipsis when long
- [ ] Check cards are wider and text has more horizontal room

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted spacing in quick access items within the catalog browser for improved layout.
  * Enhanced brand name display in catalog item cards with single-line text truncation to prevent overflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->