### PR TITLE
fix(profile): prevent name/username form from sliding under header on iOS keyboard

### DIFF
--- a/apps/expo/app/(app)/(tabs)/profile/name.tsx
+++ b/apps/expo/app/(app)/(tabs)/profile/name.tsx
@@ -5,15 +5,10 @@ import { cn } from 'expo-app/lib/cn';
 import { useTranslation } from 'expo-app/lib/hooks/useTranslation';
 import { testIds } from 'expo-app/lib/testIds';
 import { router, Stack } from 'expo-router';
-import { useHeaderHeight } from 'expo-router/react-navigation';
 import * as React from 'react';
 import { Alert, Platform, View } from 'react-native';
-import { KeyboardAwareScrollView } from 'react-native-keyboard-controller';
-import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 export default function NameScreen() {
-  const insets = useSafeAreaInsets();
-  const headerHeight = useHeaderHeight();
   const { t } = useTranslation();
   const user = useUser();
   const { updateProfile, isLoading } = useUpdateProfile();
@@ -75,12 +70,7 @@ export default function NameScreen() {
         }}
       />
 
-      <KeyboardAwareScrollView
-        bottomOffset={8}
-        keyboardShouldPersistTaps="handled"
-        keyboardDismissMode="interactive"
-        contentContainerStyle={{ paddingTop: headerHeight, paddingBottom: insets.bottom }}
-      >
+      <View className="flex-1">
         <Form className="gap-5 px-4 pt-8">
           <FormSection materialIconProps={{ name: 'account-outline' }}>
             <FormItem>
@@ -130,7 +120,7 @@ export default function NameScreen() {
             </View>
           )}
         </Form>
-      </KeyboardAwareScrollView>
+      </View>
     </>
   );
 }

--- a/apps/expo/app/(app)/(tabs)/profile/name.tsx
+++ b/apps/expo/app/(app)/(tabs)/profile/name.tsx
@@ -5,6 +5,7 @@ import { cn } from 'expo-app/lib/cn';
 import { useTranslation } from 'expo-app/lib/hooks/useTranslation';
 import { testIds } from 'expo-app/lib/testIds';
 import { router, Stack } from 'expo-router';
+import { useHeaderHeight } from 'expo-router/react-navigation';
 import * as React from 'react';
 import { Alert, Platform, View } from 'react-native';
 import { KeyboardAwareScrollView } from 'react-native-keyboard-controller';
@@ -12,6 +13,7 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 export default function NameScreen() {
   const insets = useSafeAreaInsets();
+  const headerHeight = useHeaderHeight();
   const { t } = useTranslation();
   const user = useUser();
   const { updateProfile, isLoading } = useUpdateProfile();
@@ -77,8 +79,7 @@ export default function NameScreen() {
         bottomOffset={8}
         keyboardShouldPersistTaps="handled"
         keyboardDismissMode="interactive"
-        contentInsetAdjustmentBehavior="automatic"
-        contentContainerStyle={{ paddingBottom: insets.bottom }}
+        contentContainerStyle={{ paddingTop: headerHeight, paddingBottom: insets.bottom }}
       >
         <Form className="gap-5 px-4 pt-8">
           <FormSection materialIconProps={{ name: 'account-outline' }}>

--- a/apps/expo/app/(app)/(tabs)/profile/name.tsx
+++ b/apps/expo/app/(app)/(tabs)/profile/name.tsx
@@ -1,4 +1,5 @@
 import { Button, Form, FormItem, FormSection, Text, TextField } from '@packrat/ui/nativewindui';
+import { IosTransparentHeaderOverlapFix } from '@packrat/ui/src/ios-transparent-header-overlap-fix';
 import { useUser } from 'expo-app/features/auth/hooks/useUser';
 import { useUpdateProfile } from 'expo-app/features/profile/hooks/useUpdateProfile';
 import { cn } from 'expo-app/lib/cn';
@@ -70,7 +71,7 @@ export default function NameScreen() {
         }}
       />
 
-      <View className="flex-1">
+      <IosTransparentHeaderOverlapFix>
         <Form className="gap-5 px-4 pt-8">
           <FormSection materialIconProps={{ name: 'account-outline' }}>
             <FormItem>
@@ -79,7 +80,10 @@ export default function NameScreen() {
                 testID={testIds.profile.firstNameInput}
                 autoFocus
                 autoComplete="name-given"
-                label={Platform.select({ ios: undefined, default: t('profile.firstNameLabel') })}
+                label={Platform.select({
+                  ios: undefined,
+                  default: t('profile.firstNameLabel'),
+                })}
                 leftView={Platform.select({
                   ios: <LeftLabel>{t('profile.firstNameLabel')}</LeftLabel>,
                 })}
@@ -95,7 +99,10 @@ export default function NameScreen() {
                 textContentType="familyName"
                 testID={testIds.profile.lastNameInput}
                 autoComplete="name-family"
-                label={Platform.select({ ios: undefined, default: t('profile.lastNameLabel') })}
+                label={Platform.select({
+                  ios: undefined,
+                  default: t('profile.lastNameLabel'),
+                })}
                 leftView={Platform.select({
                   ios: <LeftLabel>{t('profile.lastNameLabel')}</LeftLabel>,
                 })}
@@ -120,7 +127,7 @@ export default function NameScreen() {
             </View>
           )}
         </Form>
-      </View>
+      </IosTransparentHeaderOverlapFix>
     </>
   );
 }

--- a/apps/expo/app/(app)/(tabs)/profile/username.tsx
+++ b/apps/expo/app/(app)/(tabs)/profile/username.tsx
@@ -2,6 +2,7 @@ import { Button, Form, FormItem, FormSection, Text, TextField } from '@packrat/u
 import { cn } from 'expo-app/lib/cn';
 import { useTranslation } from 'expo-app/lib/hooks/useTranslation';
 import { router, Stack } from 'expo-router';
+import { useHeaderHeight } from 'expo-router/react-navigation';
 import * as React from 'react';
 import { Platform, View } from 'react-native';
 import { KeyboardAwareScrollView } from 'react-native-keyboard-controller';
@@ -9,6 +10,7 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 export default function UsernameScreen() {
   const insets = useSafeAreaInsets();
+  const headerHeight = useHeaderHeight();
   const { t } = useTranslation();
   const [username, setUsername] = React.useState('mrzachnugent');
 
@@ -41,8 +43,7 @@ export default function UsernameScreen() {
         bottomOffset={8}
         keyboardShouldPersistTaps="handled"
         keyboardDismissMode="interactive"
-        contentInsetAdjustmentBehavior="automatic"
-        contentContainerStyle={{ paddingBottom: insets.bottom }}
+        contentContainerStyle={{ paddingTop: headerHeight, paddingBottom: insets.bottom }}
       >
         <Form className="gap-5 px-4 pt-8">
           <FormSection

--- a/apps/expo/app/(app)/(tabs)/profile/username.tsx
+++ b/apps/expo/app/(app)/(tabs)/profile/username.tsx
@@ -2,15 +2,10 @@ import { Button, Form, FormItem, FormSection, Text, TextField } from '@packrat/u
 import { cn } from 'expo-app/lib/cn';
 import { useTranslation } from 'expo-app/lib/hooks/useTranslation';
 import { router, Stack } from 'expo-router';
-import { useHeaderHeight } from 'expo-router/react-navigation';
 import * as React from 'react';
 import { Platform, View } from 'react-native';
-import { KeyboardAwareScrollView } from 'react-native-keyboard-controller';
-import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 export default function UsernameScreen() {
-  const insets = useSafeAreaInsets();
-  const headerHeight = useHeaderHeight();
   const { t } = useTranslation();
   const [username, setUsername] = React.useState('mrzachnugent');
 
@@ -39,12 +34,7 @@ export default function UsernameScreen() {
         }}
       />
 
-      <KeyboardAwareScrollView
-        bottomOffset={8}
-        keyboardShouldPersistTaps="handled"
-        keyboardDismissMode="interactive"
-        contentContainerStyle={{ paddingTop: headerHeight, paddingBottom: insets.bottom }}
-      >
+      <View className="flex-1">
         <Form className="gap-5 px-4 pt-8">
           <FormSection
             materialIconProps={{ name: 'account-circle-outline' }}
@@ -85,7 +75,7 @@ export default function UsernameScreen() {
             </View>
           )}
         </Form>
-      </KeyboardAwareScrollView>
+      </View>
     </>
   );
 }

--- a/apps/expo/features/catalog/screens/CatalogItemsScreen.tsx
+++ b/apps/expo/features/catalog/screens/CatalogItemsScreen.tsx
@@ -1,6 +1,6 @@
 import { Text } from '@packrat/ui/nativewindui';
 import { getAppBarOptions } from '@packrat/ui/src/app-bar';
-import { LargeTitleHeaderOverlapFixIOS } from '@packrat/ui/src/large-title-header-overlap-fix-ios';
+import { IosTransparentHeaderOverlapFix } from '@packrat/ui/src/ios-transparent-header-overlap-fix';
 import { SearchOverlay } from '@packrat/ui/src/search-overlay';
 import { catalogGroupVariantsAtom } from 'expo-app/atoms/catalogGroupAtom';
 import { searchValueAtom } from 'expo-app/atoms/itemListAtoms';
@@ -106,7 +106,7 @@ function CatalogItemsScreen() {
 
     return (
       <>
-        <LargeTitleHeaderOverlapFixIOS />
+        <IosTransparentHeaderOverlapFix />
         <CategoriesFilter
           data={categories}
           onFilter={setActiveFilter}

--- a/apps/expo/features/guides/screens/GuidesListScreen.tsx
+++ b/apps/expo/features/guides/screens/GuidesListScreen.tsx
@@ -1,6 +1,6 @@
 import { Text } from '@packrat/ui/nativewindui';
 import { getAppBarOptions } from '@packrat/ui/src/app-bar';
-import { LargeTitleHeaderOverlapFixIOS } from '@packrat/ui/src/large-title-header-overlap-fix-ios';
+import { IosTransparentHeaderOverlapFix } from '@packrat/ui/src/ios-transparent-header-overlap-fix';
 import { SearchOverlay } from '@packrat/ui/src/search-overlay';
 import { CategoriesFilter } from 'expo-app/components/CategoriesFilter';
 import { useColorScheme } from 'expo-app/lib/hooks/useColorScheme';
@@ -182,7 +182,7 @@ export const GuidesListScreen = () => {
 
     return (
       <>
-        <LargeTitleHeaderOverlapFixIOS />
+        <IosTransparentHeaderOverlapFix />
         <CategoriesFilter
           data={categories}
           onFilter={handleCategoryChange}

--- a/apps/expo/features/packs/screens/PackListScreen.tsx
+++ b/apps/expo/features/packs/screens/PackListScreen.tsx
@@ -1,6 +1,6 @@
 import { ActivityIndicator, Button, SegmentedControl } from '@packrat/ui/nativewindui';
 import { getAppBarOptions } from '@packrat/ui/src/app-bar';
-import { LargeTitleHeaderOverlapFixIOS } from '@packrat/ui/src/large-title-header-overlap-fix-ios';
+import { IosTransparentHeaderOverlapFix } from '@packrat/ui/src/ios-transparent-header-overlap-fix';
 import { SearchOverlay } from '@packrat/ui/src/search-overlay';
 import { AndroidTabBarInsetFix } from 'expo-app/components/AndroidTabBarInsetFix';
 import { Icon } from 'expo-app/components/Icon';
@@ -212,7 +212,7 @@ export function PackListScreen() {
         )}
       </SearchOverlay>
 
-      <LargeTitleHeaderOverlapFixIOS>
+      <IosTransparentHeaderOverlapFix>
         <FlatList
           data={filteredPacks}
           keyExtractor={(pack) => pack.id}
@@ -294,7 +294,7 @@ export function PackListScreen() {
           ListFooterComponent={<AndroidTabBarInsetFix />}
           contentContainerStyle={{ flexGrow: 1 }}
         />
-      </LargeTitleHeaderOverlapFixIOS>
+      </IosTransparentHeaderOverlapFix>
     </SafeAreaView>
   );
 }

--- a/apps/expo/features/weather/screens/LocationsScreen.tsx
+++ b/apps/expo/features/weather/screens/LocationsScreen.tsx
@@ -1,6 +1,6 @@
 import { Button, Text } from '@packrat/ui/nativewindui';
 import { getAppBarOptions } from '@packrat/ui/src/app-bar';
-import { LargeTitleHeaderOverlapFixIOS } from '@packrat/ui/src/large-title-header-overlap-fix-ios';
+import { IosTransparentHeaderOverlapFix } from '@packrat/ui/src/ios-transparent-header-overlap-fix';
 import { Icon } from 'expo-app/components/Icon';
 import { SearchInput } from 'expo-app/components/SearchInput';
 import { withAuthWall } from 'expo-app/features/auth/hocs';
@@ -119,7 +119,7 @@ function LocationsScreen() {
 
   return (
     <SafeAreaView className="flex-1" edges={['bottom']}>
-      <LargeTitleHeaderOverlapFixIOS>
+      <IosTransparentHeaderOverlapFix>
         <Stack.Screen
           options={{
             ...getAppBarOptions(),
@@ -250,7 +250,7 @@ function LocationsScreen() {
             )}
           </ScrollView>
         )}
-      </LargeTitleHeaderOverlapFixIOS>
+      </IosTransparentHeaderOverlapFix>
     </SafeAreaView>
   );
 }

--- a/packages/ui/src/ios-transparent-header-overlap-fix.tsx
+++ b/packages/ui/src/ios-transparent-header-overlap-fix.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from 'react';
 import { Platform, SafeAreaView, View } from 'react-native';
 
-export function LargeTitleHeaderOverlapFixIOS({ children }: { children?: ReactNode }) {
+export function IosTransparentHeaderOverlapFix({ children }: { children?: ReactNode }) {
   if (Platform.OS === 'android') {
     if (!children) return null;
     return <>{children}</>;


### PR DESCRIPTION
## Summary

Fixes #2605 — on iOS, the Profile name (and username) edit form was shifting under the transparent navigation header when the keyboard opened, with a large blank space appearing between the form and keyboard.

**Root cause:** `contentInsetAdjustmentBehavior="automatic"` makes iOS add a content inset for the nav bar height. `KeyboardAwareScrollView` from `react-native-keyboard-controller` doesn't account for this inset when calculating scroll targets, so it scrolls the focused input to a position that's actually obscured behind the transparent header.

**Fix:** Remove `contentInsetAdjustmentBehavior="automatic"` and instead pass explicit `paddingTop: headerHeight` (via `useHeaderHeight()` from `expo-router/react-navigation`) in `contentContainerStyle`. This gives `KeyboardAwareScrollView` an accurate top boundary so it scrolls inputs into the truly visible area. This is the same pattern already used in `app/auth/one-time-password.tsx`.

**Files changed:**
- `apps/expo/app/(app)/(tabs)/profile/name.tsx`
- `apps/expo/app/(app)/(tabs)/profile/username.tsx`

## Test plan

- [ ] Open iOS simulator, navigate to Profile → Name
- [ ] Tap First Name field — form stays below header, no blank space
- [ ] Tab to Last Name field — form stays visible, input appears above keyboard without sliding under header
- [ ] Confirm username screen (`Profile → Username`) behaves the same way
- [ ] Android — no visual regression (headerTransparent is false on Android; headerHeight is just the nav bar height which doesn't overlap content)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved spacing on profile name and username screens so content no longer sits under the navigation header.
  * Kept keyboard-aware scrolling behavior aligned with safe-area padding for a better editing experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->