### PR TITLE
fix(auth): return additionalFields so profile name/avatar persist after re-login

### DIFF
--- a/apps/expo/features/auth/hooks/useAuthActions.ts
+++ b/apps/expo/features/auth/hooks/useAuthActions.ts
@@ -38,11 +38,15 @@ function redirect(route: string) {
 function mapToUser(raw: Record<string, unknown>): User {
   const name = asString(raw.name) ?? '';
   const spaceIdx = name.indexOf(' ');
+  // Prefer explicit firstName/lastName additionalFields from Better Auth over
+  // splitting the combined name field, which may be stale after a profile update.
+  const firstName = asString(raw.firstName) ?? (spaceIdx >= 0 ? name.slice(0, spaceIdx) : name);
+  const lastName = asString(raw.lastName) ?? (spaceIdx >= 0 ? name.slice(spaceIdx + 1) : '');
   return {
     id: asString(raw.id) ?? '',
     email: asString(raw.email) ?? '',
-    firstName: spaceIdx >= 0 ? name.slice(0, spaceIdx) : name,
-    lastName: spaceIdx >= 0 ? name.slice(spaceIdx + 1) : '',
+    firstName,
+    lastName,
     role: asString(raw.role) ?? 'USER',
     emailVerified: asBoolean(raw.emailVerified) ?? null,
     avatarUrl: asString(raw.avatarUrl) ?? asString(raw.image) ?? null,

--- a/packages/api/src/auth/auth.config.ts
+++ b/packages/api/src/auth/auth.config.ts
@@ -41,13 +41,16 @@ export const auth = betterAuth({
     },
   }),
 
+  // Keep in sync with auth/index.ts. No snake_case fieldName — the Drizzle adapter
+  // keys rows by camelCase property names, so a fieldName mismatch drops the field
+  // from every auth response.
   user: {
     additionalFields: {
       role: { type: 'string', defaultValue: 'USER' },
-      firstName: { type: 'string', fieldName: 'first_name' },
-      lastName: { type: 'string', fieldName: 'last_name' },
-      avatarUrl: { type: 'string', fieldName: 'avatar_url' },
-      passwordHash: { type: 'string', fieldName: 'password_hash' },
+      firstName: { type: 'string' },
+      lastName: { type: 'string' },
+      avatarUrl: { type: 'string' },
+      passwordHash: { type: 'string', input: false, returned: false },
     },
   },
 

--- a/packages/api/src/auth/index.ts
+++ b/packages/api/src/auth/index.ts
@@ -106,14 +106,23 @@ async function buildAuth(env: ValidatedEnv): Promise<any> {
       },
     }),
 
-    // Map Better Auth's model field names to our column names.
+    // Do NOT set a snake_case `fieldName` here. The Drizzle adapter returns rows
+    // keyed by the table's camelCase property names (firstName, lastName, …), and
+    // Better Auth's transformOutput looks each value up by `field.fieldName || key`.
+    // A `fieldName: 'first_name'` makes it read data['first_name'] — which Drizzle
+    // never produces — so the field silently drops out of every session/sign-in
+    // response (this is exactly why firstName/lastName/avatarUrl were missing).
+    // Omitting fieldName uses the field name, which already matches the Drizzle
+    // property; Drizzle owns the snake_case SQL column mapping.
     user: {
       additionalFields: {
         role: { type: 'string', defaultValue: 'USER' },
-        firstName: { type: 'string', fieldName: 'first_name' },
-        lastName: { type: 'string', fieldName: 'last_name' },
-        avatarUrl: { type: 'string', fieldName: 'avatar_url' },
-        passwordHash: { type: 'string', fieldName: 'password_hash' },
+        firstName: { type: 'string' },
+        lastName: { type: 'string' },
+        avatarUrl: { type: 'string' },
+        // Legacy column from pre-migration auth; Better Auth verifies against
+        // account.password, not this. Never accept from clients or echo it back.
+        passwordHash: { type: 'string', input: false, returned: false },
       },
     },
 

--- a/packages/api/src/routes/user/index.ts
+++ b/packages/api/src/routes/user/index.ts
@@ -101,6 +101,19 @@ export const userRoutes = new Elysia({ prefix: '/user' })
         };
         if (firstName !== undefined) updateData.firstName = firstName;
         if (lastName !== undefined) updateData.lastName = lastName;
+        // Keep Better Auth's combined name field in sync to prevent stale display
+        // when the sign-in response derives firstName/lastName from name.
+        if (firstName !== undefined || lastName !== undefined) {
+          const [existingUser] = await db
+            .tag('user.getNameForSync')
+            .select({ firstName: users.firstName, lastName: users.lastName })
+            .from(users)
+            .where(eq(users.id, user.userId))
+            .limit(1);
+          const newFirst = firstName ?? existingUser?.firstName ?? '';
+          const newLast = lastName ?? existingUser?.lastName ?? '';
+          updateData.name = `${newFirst} ${newLast}`.trim();
+        }
         if (avatarUrl !== undefined) updateData.avatarUrl = avatarUrl;
         if (email !== undefined) {
           updateData.email = email.toLowerCase();


### PR DESCRIPTION
Closes #2606

## Problem

On iOS, after updating profile **name** and **picture**, the changes stick while logged in but **revert to defaults after logout + sign-in** — name falls back to the old value and the avatar reverts to initials.

## Root cause

A field-name mapping bug in the Better Auth user config. The `additionalFields` declared a snake_case `fieldName` (e.g. `firstName: { fieldName: 'first_name' }`), but the **Drizzle adapter returns rows keyed by the table's camelCase property names** (`firstName`, `lastName`, `avatarUrl`).

Better Auth core's `transformOutput` reads each value as:

```js
const originalKey = field.fieldName || key;  // 'first_name'
let newValue = data[originalKey];            // data['first_name'] → undefined
```

So it looked up `data['first_name']`, which Drizzle never produces, and **silently dropped `firstName`/`lastName`/`avatarUrl` from every sign-in/session response** (`role` survived only because it had no `fieldName`). Verified against the actual sign-in payload — those keys were absent.

On a fresh login, `clearLocalData` wipes the local store, so the client had nothing to fall back on except splitting the stale `name` column (wrong name) and a `null` avatar (initials).

## Fix

- **`auth/index.ts` + `auth.config.ts`** — remove the snake_case `fieldName` overrides. The Better Auth field name already matches the Drizzle property, and Drizzle owns the snake_case SQL column mapping. Fields now serialize into every auth response.
- **`passwordHash`** — set `input: false, returned: false`. It now resolves on read, so it must be explicitly kept out of API responses (prevents leaking the hash).
- **`useAuthActions.ts` (`mapToUser`)** — prefer explicit `firstName`/`lastName` from the response over splitting the combined `name`.
- **`PUT /user/profile`** — keep Better Auth's combined `name` column in sync when first/last name change, so anything reading `name` (emails, etc.) stays fresh.

## Testing

- `bun check-types` — clean (0 errors)
- `bun test:api:unit` — 472/472 pass
- Biome pre-commit lint — clean

### Manual verification
Restart the API dev server, then on iOS: update name + picture → log out → sign back in → Profile retains the updated name and picture.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Profile updates now keep the full name in sync when first name or last name is changed.
  * User name details are now populated more reliably, improving consistency across profile data.
  * Account fields such as first name, last name, avatar, and password info are handled more consistently in auth responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->