### PR TITLE
feat(profile): cache avatar images on-device via CachedImage

### DIFF
--- a/apps/expo/app/(app)/(tabs)/profile/index.tsx
+++ b/apps/expo/app/(app)/(tabs)/profile/index.tsx
@@ -1,10 +1,9 @@
 import { clientEnvs } from '@packrat/env/expo-client';
-import { isString } from '@packrat/guards';
+import { isRemoteUrl, isString } from '@packrat/guards';
 import {
   ActivityIndicator,
   Avatar,
   AvatarFallback,
-  AvatarImage,
   Button,
   List,
   ListItem,
@@ -25,6 +24,7 @@ import {
 import { withAuthWall } from 'expo-app/features/auth/hocs';
 import { useAuth } from 'expo-app/features/auth/hooks/useAuth';
 import { useUser } from 'expo-app/features/auth/hooks/useUser';
+import { CachedImage } from 'expo-app/features/packs/components/CachedImage';
 import { useImagePicker } from 'expo-app/features/packs/hooks/useImagePicker';
 import { uploadImage } from 'expo-app/features/packs/utils/uploadImage';
 import { ProfileAuthWall } from 'expo-app/features/profile/components';
@@ -35,6 +35,7 @@ import { useColorScheme } from 'expo-app/lib/hooks/useColorScheme';
 import { useTranslation } from 'expo-app/lib/hooks/useTranslation';
 import { testIds } from 'expo-app/lib/testIds';
 import { buildPackTemplateItemImageUrl } from 'expo-app/lib/utils/buildPackTemplateItemImageUrl';
+import { getRemoteImageCacheKey } from 'expo-app/lib/utils/getRemoteImageCacheKey';
 import * as FileSystem from 'expo-file-system/legacy';
 import { Link, router, Stack } from 'expo-router';
 import { useSetAtom } from 'jotai';
@@ -180,7 +181,24 @@ function ListHeaderComponent() {
   const username = user?.email || '';
 
   // Build the full avatar URL from the stored R2 key or an absolute URL
-  const avatarUri = user?.avatarUrl ? buildPackTemplateItemImageUrl(user.avatarUrl) : null;
+  const avatarKey = user?.avatarUrl ?? null;
+  const avatarUri = avatarKey ? buildPackTemplateItemImageUrl(avatarKey) : null;
+
+  function renderAvatarImage() {
+    if (!avatarKey || !avatarUri) return null;
+    // R2-hosted avatars cache by their object key; absolute OAuth URLs aren't valid
+    // cache filenames, so derive a stable key from the URL instead.
+    const cacheKey = isRemoteUrl(avatarKey)
+      ? getRemoteImageCacheKey(avatarUri, 'oauth-avatar')
+      : avatarKey;
+    return (
+      <CachedImage
+        imageObjectKey={cacheKey}
+        imageRemoteUrl={avatarUri}
+        className="aspect-square h-full w-full"
+      />
+    );
+  }
 
   async function handleAvatarPress() {
     try {
@@ -223,7 +241,7 @@ function ListHeaderComponent() {
     <SafeAreaView className="ios:pb-8 items-center pb-4 pt-8">
       <TouchableOpacity onPress={handleAvatarPress} disabled={isUploading}>
         <Avatar alt={`${displayName}'s Profile`} className="h-24 w-24">
-          {avatarUri ? <AvatarImage source={{ uri: avatarUri }} /> : null}
+          {renderAvatarImage()}
           <AvatarFallback>
             <Text
               variant="largeTitle"

--- a/apps/expo/app/(app)/(tabs)/profile/index.tsx
+++ b/apps/expo/app/(app)/(tabs)/profile/index.tsx
@@ -189,7 +189,7 @@ function ListHeaderComponent() {
     // R2-hosted avatars cache by their object key; absolute OAuth URLs aren't valid
     // cache filenames, so derive a stable key from the URL instead.
     const cacheKey = isRemoteUrl(avatarKey)
-      ? getRemoteImageCacheKey(avatarUri, 'oauth-avatar')
+      ? getRemoteImageCacheKey({ url: avatarUri, prefix: 'oauth-avatar' })
       : avatarKey;
     return (
       <CachedImage

--- a/apps/expo/lib/utils/__tests__/getRemoteImageCacheKey.test.ts
+++ b/apps/expo/lib/utils/__tests__/getRemoteImageCacheKey.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+
+import { getRemoteImageCacheKey } from '../getRemoteImageCacheKey';
+
+describe('getRemoteImageCacheKey', () => {
+  describe('determinism', () => {
+    it('returns the same key for the same URL', () => {
+      const url = 'https://lh3.googleusercontent.com/a/ACg8ocK=s96-c';
+      expect(getRemoteImageCacheKey({ url })).toBe(getRemoteImageCacheKey({ url }));
+    });
+
+    it('returns different keys for different URLs', () => {
+      const a = getRemoteImageCacheKey({ url: 'https://example.com/a.jpg' });
+      const b = getRemoteImageCacheKey({ url: 'https://example.com/b.jpg' });
+      expect(a).not.toBe(b);
+    });
+  });
+
+  describe('filesystem safety', () => {
+    it('produces a key without slashes, query strings, or hashes', () => {
+      const key = getRemoteImageCacheKey({
+        url: 'https://cdn.example.com/path/to/avatar.png?size=200#frag',
+      });
+      expect(key).not.toMatch(/[/?#]/);
+    });
+
+    it('ignores query strings when deriving the extension', () => {
+      const key = getRemoteImageCacheKey({ url: 'https://example.com/avatar.jpg?v=2' });
+      expect(key.endsWith('.jpg')).toBe(true);
+    });
+  });
+
+  describe('prefix', () => {
+    it('defaults to the remote-img prefix', () => {
+      const key = getRemoteImageCacheKey({ url: 'https://example.com/a.jpg' });
+      expect(key.startsWith('remote-img-')).toBe(true);
+    });
+
+    it('uses a custom prefix when provided', () => {
+      const key = getRemoteImageCacheKey({
+        url: 'https://example.com/a.jpg',
+        prefix: 'oauth-avatar',
+      });
+      expect(key.startsWith('oauth-avatar-')).toBe(true);
+    });
+  });
+
+  describe('extension handling', () => {
+    it('preserves and lowercases a known extension', () => {
+      const key = getRemoteImageCacheKey({ url: 'https://example.com/PHOTO.PNG' });
+      expect(key.endsWith('.png')).toBe(true);
+    });
+
+    it('omits the extension when the URL has none', () => {
+      const key = getRemoteImageCacheKey({ url: 'https://lh3.googleusercontent.com/a/ACg8ocK' });
+      expect(key).not.toMatch(/\.[a-z0-9]+$/i);
+    });
+
+    it('omits the extension when the last segment is empty', () => {
+      const key = getRemoteImageCacheKey({ url: 'https://example.com/avatars/' });
+      expect(key).not.toMatch(/\.[a-z0-9]+$/i);
+    });
+  });
+});

--- a/apps/expo/lib/utils/getRemoteImageCacheKey.ts
+++ b/apps/expo/lib/utils/getRemoteImageCacheKey.ts
@@ -1,0 +1,27 @@
+// Derives a stable, filesystem-safe cache key for a remote image URL.
+//
+// ImageCacheManager uses the key directly as a flat filename (`${dir}${key}`), so the
+// key must not contain slashes, query strings, or other path-unsafe characters. Remote
+// URLs (e.g. OAuth provider avatars) do, so we hash the full URL into a short token and
+// preserve a sanitized extension when one is present for readability.
+
+const QUERY_OR_HASH_RE = /[?#]/;
+const EXTENSION_RE = /\.([a-zA-Z0-9]{1,5})$/;
+
+function fnv1a(input: string): string {
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < input.length; i++) {
+    hash ^= input.charCodeAt(i);
+    // 32-bit FNV prime multiply via shifts to stay in integer range.
+    hash = (hash + ((hash << 1) + (hash << 4) + (hash << 7) + (hash << 8) + (hash << 24))) >>> 0;
+  }
+  return hash.toString(36);
+}
+
+export function getRemoteImageCacheKey(url: string, prefix = 'remote-img'): string {
+  const withoutQuery = url.split(QUERY_OR_HASH_RE)[0] ?? url;
+  const lastSegment = withoutQuery.split('/').pop() ?? '';
+  const match = lastSegment.match(EXTENSION_RE);
+  const ext = match?.[1] ? `.${match[1].toLowerCase()}` : '';
+  return `${prefix}-${fnv1a(url)}${ext}`;
+}

--- a/apps/expo/lib/utils/getRemoteImageCacheKey.ts
+++ b/apps/expo/lib/utils/getRemoteImageCacheKey.ts
@@ -18,7 +18,13 @@ function fnv1a(input: string): string {
   return hash.toString(36);
 }
 
-export function getRemoteImageCacheKey(url: string, prefix = 'remote-img'): string {
+export function getRemoteImageCacheKey({
+  url,
+  prefix = 'remote-img',
+}: {
+  url: string;
+  prefix?: string;
+}): string {
   const withoutQuery = url.split(QUERY_OR_HASH_RE)[0] ?? url;
   const lastSegment = withoutQuery.split('/').pop() ?? '';
   const match = lastSegment.match(EXTENSION_RE);


### PR DESCRIPTION
## Summary

Renders the profile avatar through `CachedImage` so avatars are cached on-device instead of re-fetched from the network on every screen mount.

- **R2-hosted avatars** cache by their object key (as before, now via `CachedImage`).
- **OAuth/absolute-URL avatars** are now cached too. A full URL can't be used as a flat cache filename (slashes, query strings), so a new `getRemoteImageCacheKey` helper derives a stable, filesystem-safe key from the URL (FNV-1a hash + preserved extension).

## Changes

- `apps/expo/app/(app)/(tabs)/profile/index.tsx` — route the avatar through `CachedImage` for both R2 keys and OAuth URLs; drop the now-unused `AvatarImage` import.
- `apps/expo/lib/utils/getRemoteImageCacheKey.ts` — new helper to derive a cache key from a remote URL.

## Notes

- Assumes a given OAuth avatar URL is content-stable. Google/Apple avatar URLs change when the underlying image changes, so a stale cache hit isn't a concern in practice.
- While a fresh avatar downloads, `CachedImage` shows a brief spinner instead of the initials fallback; initials still show when there's no avatar at all.

## Testing

- `bun check-types` — passes
- Biome lint (pre-commit) — passes