### PR TITLE
fix(mcp): repair in-worker OAuth end-to-end flow

### DIFF
--- a/packages/mcp/src/auth.ts
+++ b/packages/mcp/src/auth.ts
@@ -33,6 +33,11 @@ const OAuthStateSchema = z.object({
   redirectUri: z.string(),
   scope: z.array(z.string()),
   state: z.string(),
+  // PKCE fields must survive the KV round-trip so completeAuthorization mints a
+  // code bound to the challenge; otherwise the client's code_verifier at /token
+  // is rejected with "code_verifier provided for a flow that did not use PKCE".
+  codeChallenge: z.string().optional(),
+  codeChallengeMethod: z.string().optional(),
 });
 
 const SessionKvSchema = z.object({
@@ -40,7 +45,11 @@ const SessionKvSchema = z.object({
   userId: z.string(),
 });
 
+// Better Auth's `/sign-in/email` (with the bearer() plugin) returns the session
+// token at the top level: `{ token, user }`. Older/other flows nest it under
+// `session.token`, so accept both shapes for robustness.
 const SignInResponseSchema = z.object({
+  token: z.string().optional(),
   session: z.object({ token: z.string() }).optional(),
   user: z.object({ id: z.string() }).optional(),
 });
@@ -256,7 +265,9 @@ async function handleLoginPost({
   }
 
   const signInResult = SignInResponseSchema.safeParse(await signInRes.json().catch(() => null));
-  const betterAuthToken = signInResult.success ? signInResult.data.session?.token : undefined;
+  const betterAuthToken = signInResult.success
+    ? (signInResult.data.token ?? signInResult.data.session?.token)
+    : undefined;
   const userId = signInResult.success ? signInResult.data.user?.id : undefined;
 
   if (!betterAuthToken || !userId) {

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -212,7 +212,9 @@ export class PackRatMCP extends McpAgent<Env, State, Record<string, never>> {
 
 const BEARER_REGEX = /^Bearer\s+(\S+)/i;
 
-const mcpDoHandler = PackRatMCP.serve('/mcp');
+// The Agents SDK's serve() defaults to a DO binding named `MCP_OBJECT`; our
+// wrangler config names the binding `PackRatMCP`, so point serve() at it.
+const mcpDoHandler = PackRatMCP.serve('/mcp', { binding: 'PackRatMCP' });
 
 // ── Props schema (OAuthProvider injects this at runtime via ctx) ──────────────
 


### PR DESCRIPTION
## Summary

Manual end-to-end verification of the `development`-branch MCP server (MCP Inspector → local API) surfaced **three stacked bugs** that together made the in-worker OAuth flow non-functional end-to-end. Each was masked by the one before it — login had to work before the token bug appeared, and the token had to mint before the transport bug appeared — which is why unit tests (transport mocked) never caught them.

## Bugs fixed

| # | Symptom | Root cause | Fix |
|---|---|---|---|
| 1 | Login → `502` "session data was missing" | Better Auth's `bearer()` `/sign-in/email` returns the session token at the **top level** (`{ token, user }`), but `SignInResponseSchema` only read `session.token` | `auth.ts`: read top-level `token` (kept `session.token` as fallback) |
| 2 | Token → `400` "code_verifier provided for a flow that did not use PKCE" | `OAuthStateSchema` dropped `codeChallenge`/`codeChallengeMethod` on the KV round-trip, so `completeAuthorization` minted a **non-PKCE** code | `auth.ts`: carry the PKCE fields through the schema |
| 3 | `/mcp` → `500` "Could not find McpAgent binding for MCP_OBJECT" | `McpAgent.serve()` defaults to a DO binding named `MCP_OBJECT`; our wrangler binding is `PackRatMCP` | `index.ts`: `serve('/mcp', { binding: 'PackRatMCP' })` |

## Verification

Ran the full flow locally against a real Neon-backed API:

- discovery (PRM / AS metadata S256 / 401 challenge) ✅
- OAuth login → PKCE token exchange (`POST /token 200`) ✅
- MCP transport connect (`POST /mcp 200`, `GET /mcp 200`) ✅
- authed tool calls return `200` ✅

## Notes

- Scope is the **in-worker OAuth** path on `development` only. PR #2497 (`plan/mcp-connector-store-readiness`) re-architects this layer onto Better Auth as a separate authorization server and may address some/all of these independently — worth reconciling so the fixes aren't lost or duplicated when that lands.
- No test changes: the existing unit suite mocks the MCP transport, so it can't exercise this flow. A `vitest-pool-workers` integration test would be the right home (tracked as deferred work on #2497).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved authentication flow reliability by preserving sign-in state needed for completing login steps.

* **Bug Fixes**
  * Expanded support for sign-in responses, allowing successful login when session data is returned in a different format.
  * Fixed MCP endpoint routing so requests are handled by the correct service binding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->