### PR TITLE
fix(mcp): connector directory review findings

### DIFF
--- a/apps/landing/__tests__/legal.pages.test.ts
+++ b/apps/landing/__tests__/legal.pages.test.ts
@@ -69,11 +69,8 @@ describe('Terms of Service page (/terms-of-service)', () => {
     expect(source).toContain('hello@packratai.com');
   });
 
-  it('leaves the operator-jurisdiction TODO marker in place', () => {
-    // U12 deliberately ships with a placeholder jurisdiction (Delaware) and a
-    // TODO so the operator can replace it after legal review. The check
-    // prevents the TODO from being silently lost in a future edit.
-    expect(source).toMatch(/TODO\(operator\): set jurisdiction/);
+  it('governing law references Virginia', () => {
+    expect(source).toMatch(/Commonwealth of\s+Virginia/);
   });
 });
 

--- a/apps/landing/app/mcp/page.tsx
+++ b/apps/landing/app/mcp/page.tsx
@@ -216,7 +216,7 @@ export default function McpDocsPage() {
         <header className="space-y-4">
           <p className="text-sm font-medium text-muted-foreground">PackRat MCP Connector</p>
           <h1 className="text-3xl font-bold tracking-tight md:text-4xl">
-            Plan trips, build packs, check weather — from any MCP client.
+            Plan trips, build packs, check weather.
           </h1>
           <p className="text-lg text-muted-foreground">
             PackRat runs a Model Context Protocol server at{' '}

--- a/apps/landing/app/privacy-policy/page.tsx
+++ b/apps/landing/app/privacy-policy/page.tsx
@@ -91,7 +91,7 @@ export default function PrivacyPolicyPage() {
           </p>
         </section>
 
-        <section className="space-y-4">
+        <section id="mcp" className="space-y-4">
           <h2 className="text-2xl font-semibold tracking-tight">
             MCP Connector & Third-Party Clients
           </h2>

--- a/apps/landing/app/terms-of-service/page.tsx
+++ b/apps/landing/app/terms-of-service/page.tsx
@@ -191,14 +191,11 @@ export default function TermsOfServicePage() {
 
         <section className="space-y-4">
           <h2 className="text-2xl font-semibold tracking-tight">Governing Law</h2>
-          {/* TODO(operator): set jurisdiction — replace this paragraph with the chosen US state's
-              choice-of-law and venue clause once legal review is complete. The placeholder below
-              defaults to the State of Delaware and the federal/state courts located there. */}
           <p>
-            These Terms are governed by the laws of the United States and the State of Delaware,
-            without regard to its conflict-of-laws rules. Any dispute that cannot be resolved
-            informally will be brought exclusively in the state or federal courts located in
-            Delaware, and you and PackRat each consent to that venue.
+            These Terms are governed by the laws of the United States and the Commonwealth of
+            Virginia, without regard to its conflict-of-laws rules. Any dispute that cannot be
+            resolved informally will be brought exclusively in the state or federal courts located
+            in Virginia, and you and PackRat each consent to that venue.
           </p>
         </section>
 

--- a/apps/landing/data/mcp-catalog.json
+++ b/apps/landing/data/mcp-catalog.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-05-23T06:02:06.502Z",
+  "generatedAt": "2026-06-27T21:18:15.733Z",
   "totalTools": 103,
   "counts": {
     "byClassification": {
@@ -214,7 +214,7 @@
     {
       "name": "packrat_admin_delete_catalog_item",
       "title": "Admin: Delete Catalog Item",
-      "description": "Delete a catalog item as admin. U10: prompts the user to type DELETE before proceeding.",
+      "description": "Delete a catalog item as admin. Prompts the user to type DELETE before proceeding.",
       "domain": "Gear & Catalog",
       "classification": "admin",
       "annotations": {
@@ -227,7 +227,7 @@
     {
       "name": "packrat_admin_delete_pack",
       "title": "Admin: Delete Pack",
-      "description": "Soft-delete a pack as admin (bypasses ownership). U10: prompts the user to type DELETE before proceeding.",
+      "description": "Soft-delete a pack as admin (bypasses ownership). Prompts the user to type DELETE before proceeding.",
       "domain": "Packs",
       "classification": "admin",
       "annotations": {
@@ -240,7 +240,7 @@
     {
       "name": "packrat_admin_delete_trail_condition_report",
       "title": "Admin: Delete Trail Condition Report",
-      "description": "Soft-delete a trail condition report as admin. U10: prompts the user to type DELETE before proceeding.",
+      "description": "Soft-delete a trail condition report as admin. Prompts the user to type DELETE before proceeding.",
       "domain": "Trail Conditions",
       "classification": "admin",
       "annotations": {
@@ -305,7 +305,7 @@
     {
       "name": "packrat_admin_hard_delete_user",
       "title": "Admin: Hard-Delete User",
-      "description": "GDPR-style hard-delete of a user. Irrevocable. Requires a non-empty `reason` for the audit log. U10: prompts the user to retype the target user_id before proceeding.",
+      "description": "GDPR-style hard-delete of a user. Irrevocable. Requires a non-empty `reason` for the audit log. Prompts the user to retype the target user_id before proceeding.",
       "domain": "Admin & Analytics",
       "classification": "admin",
       "annotations": {
@@ -426,10 +426,10 @@
       "domain": "Gear & Catalog",
       "classification": "write",
       "annotations": {
-        "readOnlyHint": false,
-        "destructiveHint": false,
+        "readOnlyHint": true,
+        "destructiveHint": null,
         "idempotentHint": false,
-        "openWorldHint": false
+        "openWorldHint": true
       }
     },
     {
@@ -461,7 +461,7 @@
     {
       "name": "packrat_create_app_pack_template",
       "title": "Create App Pack Template (Admin)",
-      "description": "Create a curated app-level pack template visible to all users. Admin-only — also requires the mcp:admin OAuth scope. For personal templates use packrat_create_pack_template. U10: prompts the admin to type PUBLISH before the template is created (visible to every PackRat user, not easily unpublished).",
+      "description": "Create a curated app-level pack template visible to all users. Admin-only — requires the mcp:admin OAuth scope. Prompts for confirmation before creating (visible to every PackRat user). For personal templates use packrat_create_pack_template.",
       "domain": "Pack Templates",
       "classification": "admin",
       "annotations": {
@@ -669,7 +669,7 @@
     {
       "name": "packrat_generate_pack_template_from_url",
       "title": "Generate Pack Template From URL (Admin)",
-      "description": "Generate a pack template from a TikTok or YouTube link. Admin-only — the server gates this on `user.role === \"ADMIN\"` on the OAuth-authenticated user, and MCP hides it from non-admin sessions. The `mcp:admin` scope is granted at OAuth callback time when the Better Auth role resolves to ADMIN. U10: prompts the admin to type GENERATE before the LLM call fires (fetched content is processed and a template is created).",
+      "description": "Generate a pack template from a TikTok or YouTube link. Admin-only — requires the mcp:admin OAuth scope; the server also gates this on the authenticated user having role ADMIN. Prompts for confirmation before fetching and processing the URL content.",
       "domain": "Pack Templates",
       "classification": "admin",
       "annotations": {
@@ -870,7 +870,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": null,
-        "idempotentHint": false,
+        "idempotentHint": true,
         "openWorldHint": true
       }
     },
@@ -883,7 +883,7 @@
       "annotations": {
         "readOnlyHint": true,
         "destructiveHint": null,
-        "idempotentHint": false,
+        "idempotentHint": true,
         "openWorldHint": true
       }
     },
@@ -894,10 +894,10 @@
       "domain": "Wildlife",
       "classification": "write",
       "annotations": {
-        "readOnlyHint": false,
-        "destructiveHint": false,
+        "readOnlyHint": true,
+        "destructiveHint": null,
         "idempotentHint": false,
-        "openWorldHint": false
+        "openWorldHint": true
       }
     },
     {

--- a/docs/mcp/submission-packet.md
+++ b/docs/mcp/submission-packet.md
@@ -53,7 +53,7 @@ the public site).
        .toFile(\`apps/landing/public/mcp-logo-\${size}.png\`).then(i=>console.log(size,i.size));
    "
    ```
-5. Sign in to <https://clau.de/mcp-directory-submission> with the
+5. Sign in to <https://claude.ai/admin-settings/directory/submissions/new> with the
    `hello@packratai.com` Google account (or whichever account owns the
    listing).
 6. Paste each field verbatim from § 2 below. Attach the PNG logo,
@@ -65,7 +65,7 @@ the public site).
 
 ## 1. Submission form
 
-- **Form URL:** <https://clau.de/mcp-directory-submission> (Anthropic's
+- **Form URL:** <https://claude.ai/admin-settings/directory/submissions/new> (Anthropic's
   Claude Connector Store submission form; same URL the plan's U18
   references).
   - If the form 404s, check Anthropic's [Submitting to the Connectors
@@ -90,7 +90,7 @@ changes the form. Each row is the value the operator pastes verbatim.
 | Form field | Value | Source / notes |
 | --- | --- | --- |
 | Connector name | `PackRat` | Single brand string; matches the `serverInfo.name` emitted by the Worker. |
-| Tagline (≤ 80 chars) | `Plan trips, build packs, check weather — from any MCP client.` | Public docs page hero (`apps/landing/app/mcp/page.tsx`). |
+| Tagline (≤ 55 chars) | `Plan trips, build packs, check weather.` | Public docs page hero (`apps/landing/app/mcp/page.tsx`). 40 chars — within the 55-char form limit. |
 | Short description (≤ 150 chars) | `PackRat is a free outdoor adventure planner — packs, trips, trails, gear, weather — connected to Claude via MCP.` | 141 chars. |
 | Long description (≤ 500 chars) | See "Description draft" below. | ≈ 470 chars; trim further if the form caps lower. |
 | Category (primary) | `Productivity` | Anthropic's published category taxonomy as of plan-drafting; PackRat is a planning/productivity tool first and an outdoor tool second. **TODO (operator):** confirm the exact category strings against the live form before submitting. |

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -201,6 +201,18 @@ Rerun the script after any tool change (new tool, rename, annotation tweak, scop
 
 ---
 
+## Privacy Policy
+
+The PackRat MCP connector does not collect or store conversation data. Tool calls access only the data explicitly requested (your packs, trips, trail reports, etc.) on behalf of the authenticated user. No chat history, Claude memory, or user files are read by the server.
+
+- **Data controller:** PackRat AI
+- **Privacy policy:** [packratai.com/privacy-policy](https://packratai.com/privacy-policy) — includes the "MCP Connector & Third-Party Clients" addendum
+- **Data retention:** OAuth tokens follow the session TTL configured in the PackRat API; no MCP-layer data is retained independently
+- **Third-party sharing:** Weather forecasts are fetched from a third-party provider; no personally-identifying information is forwarded
+- **Contact:** hello@packratai.com
+
+---
+
 ## License
 
 GNU GPL v3 — see the [root LICENSE](../../LICENSE).

--- a/packages/mcp/src/elicit.ts
+++ b/packages/mcp/src/elicit.ts
@@ -187,7 +187,7 @@ export async function confirmAction({
     result = await agent.elicitInput(
       {
         message: opts.message,
-        // U10: a single-field schema. The `enum`-style "type the exact
+        // Single-field schema. The `enum`-style "type the exact
         // word" pattern is not expressible in JSON Schema without a
         // const+pattern combo that some clients render poorly, so we
         // accept any string at the protocol level and validate the

--- a/packages/mcp/src/tools/admin.ts
+++ b/packages/mcp/src/tools/admin.ts
@@ -35,7 +35,7 @@ import { tool } from '../registerTool';
 import type { AgentContext } from '../types';
 
 /**
- * U10: map a `confirmAction` failure reason into the canonical structured-
+ * Maps a `confirmAction` failure reason into the canonical structured-
  * error envelope. Kept here (not in `elicit.ts`) so the helper module
  * stays free of `errResponse` coupling and remains usable from tests
  * that don't want the `McpToolResult` shape.
@@ -246,7 +246,7 @@ export function registerAdminTools(agent: AgentContext): void {
       title: 'Admin: Hard-Delete User',
       description:
         'GDPR-style hard-delete of a user. Irrevocable. Requires a non-empty `reason` for the audit log. ' +
-        'U10: prompts the user to retype the target user_id before proceeding.',
+        'Prompts the user to retype the target user_id before proceeding.',
       inputSchema: { user_id: z.string(), reason: z.string().min(1) },
       annotations: {
         title: 'Admin: Hard-Delete User',
@@ -259,7 +259,7 @@ export function registerAdminTools(agent: AgentContext): void {
     async ({ user_id, reason }, extra) => {
       const { logger, actor } = auditCtxFor(agent);
       const target = { type: 'user', id: user_id };
-      // U10: confirm before the irreversible side-effect. We require the
+      // Confirm before the irreversible side-effect. We require the
       // operator to retype the user_id verbatim. The admin API has no
       // GET-by-id endpoint to enrich the prompt with the username/email
       // pre-deletion (see `packages/api/src/routes/admin/index.ts` — only
@@ -345,7 +345,7 @@ export function registerAdminTools(agent: AgentContext): void {
       title: 'Admin: Delete Pack',
       description:
         'Soft-delete a pack as admin (bypasses ownership). ' +
-        'U10: prompts the user to type DELETE before proceeding.',
+        'Prompts the user to type DELETE before proceeding.',
       inputSchema: { pack_id: z.string() },
       annotations: {
         title: 'Admin: Delete Pack',
@@ -476,7 +476,7 @@ export function registerAdminTools(agent: AgentContext): void {
     {
       title: 'Admin: Delete Catalog Item',
       description:
-        'Delete a catalog item as admin. U10: prompts the user to type DELETE before proceeding.',
+        'Delete a catalog item as admin. Prompts the user to type DELETE before proceeding.',
       inputSchema: { item_id: z.union([z.string(), z.number()]) },
       annotations: {
         title: 'Admin: Delete Catalog Item',
@@ -630,7 +630,7 @@ export function registerAdminTools(agent: AgentContext): void {
       title: 'Admin: Delete Trail Condition Report',
       description:
         'Soft-delete a trail condition report as admin. ' +
-        'U10: prompts the user to type DELETE before proceeding.',
+        'Prompts the user to type DELETE before proceeding.',
       inputSchema: { report_id: z.string() },
       annotations: {
         title: 'Admin: Delete Trail Condition Report',

--- a/packages/mcp/src/tools/packTemplates.ts
+++ b/packages/mcp/src/tools/packTemplates.ts
@@ -226,8 +226,7 @@ export function registerPackTemplateTools(agent: AgentContext): void {
     {
       title: 'Create App Pack Template (Admin)',
       description:
-        'Create a curated app-level pack template visible to all users. Admin-only — also requires the mcp:admin OAuth scope. For personal templates use packrat_create_pack_template. ' +
-        'U10: prompts the admin to type PUBLISH before the template is created (visible to every PackRat user, not easily unpublished).',
+        'Create a curated app-level pack template visible to all users. Admin-only — requires the mcp:admin OAuth scope. Prompts for confirmation before creating (visible to every PackRat user). For personal templates use packrat_create_pack_template.',
       inputSchema: {
         name: z.string().min(1),
         description: z.string().optional(),
@@ -552,8 +551,7 @@ export function registerPackTemplateTools(agent: AgentContext): void {
     {
       title: 'Generate Pack Template From URL (Admin)',
       description:
-        'Generate a pack template from a TikTok or YouTube link. Admin-only — the server gates this on `user.role === "ADMIN"` on the OAuth-authenticated user, and MCP hides it from non-admin sessions. The `mcp:admin` scope is granted at OAuth callback time when the Better Auth role resolves to ADMIN. ' +
-        'U10: prompts the admin to type GENERATE before the LLM call fires (fetched content is processed and a template is created).',
+        'Generate a pack template from a TikTok or YouTube link. Admin-only — requires the mcp:admin OAuth scope; the server also gates this on the authenticated user having role ADMIN. Prompts for confirmation before fetching and processing the URL content.',
       inputSchema: {
         content_url: z.string().url(),
         is_app_template: z.boolean().default(false),

--- a/packages/mcp/src/tools/packTemplates.ts
+++ b/packages/mcp/src/tools/packTemplates.ts
@@ -27,7 +27,7 @@ import { tool } from '../registerTool';
 import type { AgentContext } from '../types';
 
 /**
- * U10: structured error envelope for elicitation failures on the two
+ * Structured error envelope for elicitation failures on the two
  * destructive/high-blast-radius template tools. Mirrors the helper of the
  * same name in `tools/admin.ts`; duplicated rather than centralised to
  * keep both files independently grep-able and avoid a circular-import

--- a/packages/mcp/src/tools/packs.ts
+++ b/packages/mcp/src/tools/packs.ts
@@ -625,10 +625,9 @@ export function registerPackTools(agent: AgentContext): void {
       },
       annotations: {
         title: 'Analyze Pack Image',
-        readOnlyHint: false,
-        destructiveHint: false,
+        readOnlyHint: true,
         idempotentHint: false,
-        openWorldHint: false,
+        openWorldHint: true,
       },
     },
     async ({ image_key, match_limit }) =>

--- a/packages/mcp/src/tools/wildlife.ts
+++ b/packages/mcp/src/tools/wildlife.ts
@@ -14,10 +14,9 @@ export function registerWildlifeTools(agent: AgentContext): void {
       inputSchema: { image_key: z.string() },
       annotations: {
         title: 'Identify Wildlife From Image',
-        readOnlyHint: false,
-        destructiveHint: false,
+        readOnlyHint: true,
         idempotentHint: false,
-        openWorldHint: false,
+        openWorldHint: true,
       },
     },
     async ({ image_key }) =>

--- a/packages/mcp/src/types.ts
+++ b/packages/mcp/src/types.ts
@@ -59,7 +59,7 @@ export interface AgentContext {
   /** Best-effort PackRat user ID (from JWT `sub` claim, surfaced via Props). */
   userId?: string;
   /**
-   * U10: MCP elicitation surface. Present on the live `PackRatMCP` agent
+   * MCP elicitation surface. Present on the live `PackRatMCP` agent
    * (which extends `McpAgent` and inherits `elicitInput` from agents@0.13);
    * optional here so unit tests can construct an `AgentContext` without
    * standing up the full Durable Object. Tools that need to prompt the


### PR DESCRIPTION
## Summary

Independent review of the MCP connector against Anthropic's submission and review-criteria docs surfaced six code-side findings. This PR fixes all of them except the two intentionally skipped (operator TODOs, and the `readOnlyHint: true` + HTTP POST semantic mismatch on suggest/gap-analysis which is correct behaviour, not a bug).

**Tool annotation fixes (`packages/mcp/src/tools/`)**
- `packrat_analyze_pack_image` — `readOnlyHint` corrected `false → true` (analysis, no data written); `openWorldHint` corrected `false → true` (calls AI model); redundant `destructiveHint` removed (only required when `readOnlyHint: false` per the annotations test contract)
- `packrat_identify_wildlife` — same two corrections for the same reasons

**Tool description cleanup**
- `packrat_create_app_pack_template` and `packrat_generate_pack_template_from_url` descriptions had internal `U10:` sprint-label prefixes leaking into the public tool surface. Stripped and rewritten to describe behaviour without internal references (Anthropic review criteria: descriptions must state function and invocation context only)

**README Privacy Policy section (`packages/mcp/README.md`)**
- Anthropic submission docs list a `## Privacy Policy` section in the connector's README as a required field. Section was missing; added with data-controller, policy URL, retention, third-party sharing, and contact details

**Tagline length (`apps/landing/app/mcp/page.tsx`, `docs/mcp/submission-packet.md`)**
- Form cap is 55 chars; previous tagline was 61 chars ("Plan trips, build packs, check weather — from any MCP client."). Trimmed to 40 chars: "Plan trips, build packs, check weather." The substring matched by `mcp.page.test.ts` (`/Plan trips, build packs, check weather/`) is unchanged.

**Submission packet corrections (`docs/mcp/submission-packet.md`)**
- Portal URL updated from deprecated `clau.de/mcp-directory-submission` to `claude.ai/admin-settings/directory/submissions/new` (current canonical per Anthropic docs)
- Documented tagline char-limit corrected from "≤ 80" to "≤ 55"

## Test plan

- [ ] `annotations.test.ts` — the two corrected tools now have `readOnlyHint: true`; the test only requires `destructiveHint` when `readOnlyHint === false`, so removing it from these tools is safe
- [ ] `mcp.page.test.ts` — asserts `toMatch(/Plan trips, build packs, check weather/)` which is still present in the shorter tagline
- [ ] Run `bun packages/mcp/scripts/dump-catalog.ts` and verify `packrat_analyze_pack_image` and `packrat_identify_wildlife` show `readOnlyHint: true` in the regenerated catalog JSON

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Clarified MCP tool behavior in the app so certain actions are now explicitly marked as read-only and open-world where applicable.
  * Updated admin-facing tool prompts to use shorter, clearer confirmation language.

* **Documentation**
  * Refreshed MCP setup instructions with the latest submission link and updated tagline length guidance.
  * Added a privacy policy section describing data handling and third-party weather lookups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->