### PR TITLE
fix(mcp): local-dev OAuth flow + JWT verification correctness

### DIFF
--- a/packages/api/src/__tests__/auth-cors.test.ts
+++ b/packages/api/src/__tests__/auth-cors.test.ts
@@ -2,11 +2,11 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => {
   const compiledApp = { fetch: vi.fn(async () => new Response('ok')) };
-  const appBase = {
-    use: vi.fn(() => ({
-      compile: vi.fn(() => compiledApp),
-    })),
-  };
+  // `use` must be chainable: appBase.use(a).use(b).compile() mirrors Elysia's
+  // fluent API. The mock returns the same builder object on every .use() call.
+  const builder = { use: vi.fn(), compile: vi.fn(() => compiledApp) };
+  builder.use.mockReturnValue(builder);
+  const appBase = builder;
 
   return {
     appBase,
@@ -51,6 +51,7 @@ vi.mock('@packrat/api/auth', () => ({
 
 vi.mock('@packrat/api/auth/consent-route', () => ({
   consentRoute: {},
+  signInRoute: {},
 }));
 
 vi.mock('@packrat/api/auth/local-e2e', () => ({

--- a/packages/api/src/auth/__tests__/mcp-token.test.ts
+++ b/packages/api/src/auth/__tests__/mcp-token.test.ts
@@ -114,9 +114,9 @@ describe('resolveMcpBearerUser', () => {
       'abc',
       { jwks: true },
       {
-        issuer: 'https://api.packrat.world',
+        issuer: 'https://api.packrat.world/api/auth',
         audience: 'https://mcp.packratai.com/mcp',
-        algorithms: ['ES256', 'RS256'],
+        algorithms: ['EdDSA', 'ES256', 'RS256'],
       },
     );
   });

--- a/packages/api/src/auth/consent-route.ts
+++ b/packages/api/src/auth/consent-route.ts
@@ -25,7 +25,7 @@
 import { getAuth } from '@packrat/api/auth';
 import { createDb } from '@packrat/api/db';
 import { getEnv } from '@packrat/api/utils/env-validation';
-import { type OAuthClientRecord, renderConsentPage } from '@packrat/consent-ui';
+import { type OAuthClientRecord, renderConsentPage, renderSignInPage } from '@packrat/consent-ui';
 import * as dbSchema from '@packrat/db';
 import { isString, toRecord, toString as toStr } from '@packrat/guards';
 import { eq } from 'drizzle-orm';
@@ -34,6 +34,26 @@ import { createRegExp, oneOrMore, whitespace } from 'magic-regexp';
 
 // Matches RFC 6749 §3.3 (space-separated scopes).
 const SCOPE_SEPARATOR_RE = createRegExp(oneOrMore(whitespace));
+
+/**
+ * GET /api/auth/sign-in — sign-in page for the OAuth consent flow.
+ *
+ * `@better-auth/oauth-provider` redirects here when the user isn't
+ * authenticated mid-OAuth-flow (configured via `loginPage` in auth/index.ts).
+ * Better Auth passes the raw OAuth params on the query string rather than a
+ * `callbackURL`; the inline JS in the rendered page reconstructs the authorize
+ * URL from those params after a successful sign-in.
+ */
+export const signInRoute = new Elysia().get('/api/auth/sign-in', ({ query, set }) => {
+  // The callbackURL may or may not be present. The inline JS in the page
+  // handles both cases — if absent it reconstructs from window.location.search.
+  const callbackURL = isString(query.callbackURL) ? query.callbackURL : '';
+  set.headers['content-type'] = 'text/html; charset=utf-8';
+  set.headers['cache-control'] = 'no-store';
+  set.headers['x-content-type-options'] = 'nosniff';
+  set.headers['x-frame-options'] = 'DENY';
+  return renderSignInPage({ callbackURL });
+});
 
 export const consentRoute = new Elysia().get('/oauth/consent', async ({ request, query, set }) => {
   const clientId = isString(query.client_id) ? query.client_id : '';

--- a/packages/api/src/auth/index.ts
+++ b/packages/api/src/auth/index.ts
@@ -39,6 +39,11 @@ const MCP_OAUTH_SCOPES = [
 // `resource` parameter results in `invalid_request` (400) from the plugin's
 // `checkResource` (validAudiences enforcement).
 const MCP_AUDIENCE = 'https://mcp.packratai.com/mcp';
+// In local dev the MCP worker's `/.well-known/oauth-protected-resource` advertises
+// `resource: "http://localhost:8788/mcp"` (via MCP_PUBLIC_URL). Inspector sends that
+// back as the `resource` param in the authorize request, so we must accept it here too.
+const MCP_AUDIENCE_LOCAL_DEV = 'http://localhost:8788/mcp';
+const TRAILING_SLASH_RE = /\/$/;
 
 // ─── Per-isolate auth instance cache ─────────────────────────────────────────
 // Stores the in-flight Promise so concurrent requests that arrive before the
@@ -285,7 +290,14 @@ async function buildAuth(env: ValidatedEnv): Promise<any> {
       //    spec. Verified in U9 dev verification.
       oauthProvider({
         scopes: [...MCP_OAUTH_SCOPES],
-        validAudiences: [MCP_AUDIENCE],
+        validAudiences: (() => {
+          const audiences = [MCP_AUDIENCE];
+          if (env.PACKRAT_API_URL.startsWith('http://localhost'))
+            audiences.push(MCP_AUDIENCE_LOCAL_DEV);
+          if (env.PACKRAT_MCP_URL)
+            audiences.push(`${env.PACKRAT_MCP_URL.replace(TRAILING_SLASH_RE, '')}/mcp`);
+          return audiences;
+        })(),
         allowDynamicClientRegistration: false,
         allowUnauthenticatedClientRegistration: false,
         consentPage: '/oauth/consent',

--- a/packages/api/src/auth/mcp-token.ts
+++ b/packages/api/src/auth/mcp-token.ts
@@ -9,19 +9,28 @@ import { createRemoteJWKSet, jwtVerify } from 'jose';
 const TRAILING_SLASH = /\/$/;
 const BEARER_PREFIX = /^Bearer\s+/i;
 const SCOPE_SPLIT = /\s+/;
-const MCP_AUDIENCE = 'https://mcp.packratai.com/mcp';
+const MCP_AUDIENCE_PROD = 'https://mcp.packratai.com/mcp';
 const JWKS_CACHE = new Map<string, ReturnType<typeof createRemoteJWKSet>>();
 
+// Better Auth sets iss = baseURL + '/api/auth', matching the JWT plugin behaviour
+// verified in packages/mcp/src/token-verify.ts getIssuerUrl.
 function issuerFromEnv(env: ValidatedEnv): string {
-  return env.PACKRAT_API_URL.replace(TRAILING_SLASH, '');
+  return `${env.PACKRAT_API_URL.replace(TRAILING_SLASH, '')}/api/auth`;
 }
 
-function jwksFor(issuer: string): ReturnType<typeof createRemoteJWKSet> {
-  const cached = JWKS_CACHE.get(issuer);
+// JWKS lives at the bare API base URL (not the issuer URL) to avoid the
+// double-path bug: <base>/api/auth/jwks, not <base>/api/auth/api/auth/jwks.
+function jwksFor(apiBaseUrl: string): ReturnType<typeof createRemoteJWKSet> {
+  const cached = JWKS_CACHE.get(apiBaseUrl);
   if (cached) return cached;
-  const jwks = createRemoteJWKSet(new URL(`${issuer}/api/auth/jwks`), { cacheMaxAge: 60_000 });
-  JWKS_CACHE.set(issuer, jwks);
+  const jwks = createRemoteJWKSet(new URL(`${apiBaseUrl}/api/auth/jwks`), { cacheMaxAge: 60_000 });
+  JWKS_CACHE.set(apiBaseUrl, jwks);
   return jwks;
+}
+
+function audienceFromEnv(env: ValidatedEnv): string {
+  if (env.PACKRAT_MCP_URL) return `${env.PACKRAT_MCP_URL.replace(TRAILING_SLASH, '')}/mcp`;
+  return MCP_AUDIENCE_PROD;
 }
 
 function bearerFrom(request: Request): string | null {
@@ -51,11 +60,13 @@ export async function resolveMcpBearerUser({
   let sub = '';
   let scopes: string[] = [];
   try {
+    const apiBaseUrl = env.PACKRAT_API_URL.replace(TRAILING_SLASH, '');
     const issuer = issuerFromEnv(env);
-    const { payload } = await jwtVerify(token, jwksFor(issuer), {
+    const audience = audienceFromEnv(env);
+    const { payload } = await jwtVerify(token, jwksFor(apiBaseUrl), {
       issuer,
-      audience: MCP_AUDIENCE,
-      algorithms: ['ES256', 'RS256'],
+      audience,
+      algorithms: ['EdDSA', 'ES256', 'RS256'],
     });
     sub = isString(payload.sub) ? payload.sub : '';
     scopes = parseScopes(payload.scope);

--- a/packages/api/src/db/seed-inspector-oauth-client.ts
+++ b/packages/api/src/db/seed-inspector-oauth-client.ts
@@ -1,0 +1,127 @@
+/**
+ * Seed: pre-register the MCP Inspector as an OAuth client for LOCAL testing.
+ *
+ * DCR is disabled at the AS (`allowDynamicClientRegistration: false`), so the
+ * MCP Inspector — which would normally dynamically register itself — needs a
+ * pre-seeded public client row to drive the full OAuth browser flow against a
+ * local API. This script is the local-dev analogue of seed-claude-oauth-client.ts.
+ *
+ * NOT for production. The redirect URIs point at Inspector's localhost proxy.
+ *
+ * Usage:
+ *   NEON_DATABASE_URL=<url> bun run packages/api/src/db/seed-inspector-oauth-client.ts
+ */
+
+import { neon, neonConfig } from '@neondatabase/serverless';
+import * as schema from '@packrat/db/schema';
+import { nodeEnv } from '@packrat/env/node';
+import { eq } from 'drizzle-orm';
+import { drizzle, type NeonHttpDatabase } from 'drizzle-orm/neon-http';
+import { drizzle as drizzlePg, type NodePgDatabase } from 'drizzle-orm/node-postgres';
+import { Client } from 'pg';
+import WebSocket from 'ws';
+
+neonConfig.webSocketConstructor = WebSocket;
+
+const isStandardPostgresUrl = (url: string) => {
+  try {
+    const u = new URL(url);
+    const host = u.hostname.toLowerCase();
+    const isNeonTech = host === 'neon.tech' || host.endsWith('.neon.tech');
+    const isNeonCom = host === 'neon.com' || host.endsWith('.neon.com');
+    return u.protocol === 'postgres:' && !isNeonTech && !isNeonCom;
+  } catch {
+    return false;
+  }
+};
+
+const INSPECTOR_CLIENT_ID = 'mcp-inspector-local';
+const INSPECTOR_CLIENT_NAME = 'MCP Inspector (local)';
+// Inspector's localhost proxy callback URLs (default port 6274, both hosts +
+// the Auth Debugger variant).
+const INSPECTOR_REDIRECT_URIS = [
+  'http://localhost:6274/oauth/callback',
+  'http://127.0.0.1:6274/oauth/callback',
+  'http://localhost:6274/oauth/callback/debug',
+  'http://127.0.0.1:6274/oauth/callback/debug',
+];
+const INSPECTOR_SCOPES = [
+  'openid',
+  'profile',
+  'email',
+  'offline_access',
+  'mcp:read',
+  'mcp:write',
+  'mcp:admin',
+];
+
+const row = (now: Date) => ({
+  clientId: INSPECTOR_CLIENT_ID,
+  clientSecret: null,
+  name: INSPECTOR_CLIENT_NAME,
+  icon: 'https://packratai.com/mcp-logo-256.png',
+  policy: 'https://packratai.com/privacy-policy',
+  tos: 'https://packratai.com/terms-of-service',
+  uri: 'http://localhost:6274',
+  redirectUris: INSPECTOR_REDIRECT_URIS,
+  grantTypes: ['authorization_code', 'refresh_token'],
+  responseTypes: ['code'],
+  tokenEndpointAuthMethod: 'none' as const,
+  scopes: INSPECTOR_SCOPES,
+  type: 'web' as const,
+  public: true,
+  requirePKCE: true,
+  disabled: false,
+  skipConsent: false,
+  updatedAt: now,
+});
+
+async function seedInspectorClient(): Promise<void> {
+  const dbUrl = nodeEnv.NEON_DATABASE_URL;
+  if (!dbUrl) throw new Error('NEON_DATABASE_URL is required');
+
+  type SeedDatabase = NodePgDatabase<typeof schema> | NeonHttpDatabase<typeof schema>;
+  let db: SeedDatabase;
+  let pgClient: Client | undefined;
+
+  if (isStandardPostgresUrl(dbUrl)) {
+    pgClient = new Client({ connectionString: dbUrl });
+    await pgClient.connect();
+    db = drizzlePg(pgClient, { schema });
+  } else {
+    db = drizzle(neon(dbUrl), { schema });
+  }
+
+  try {
+    const now = new Date();
+    const existing = await db
+      .select({ clientId: schema.oauthClient.clientId })
+      .from(schema.oauthClient)
+      .where(eq(schema.oauthClient.clientId, INSPECTOR_CLIENT_ID))
+      .limit(1);
+
+    if (existing.length > 0) {
+      await db
+        .update(schema.oauthClient)
+        .set(row(now))
+        .where(eq(schema.oauthClient.clientId, INSPECTOR_CLIENT_ID));
+      console.log(`[seed] Updated OAuth client "${INSPECTOR_CLIENT_ID}".`);
+    } else {
+      await db
+        .insert(schema.oauthClient)
+        .values({ id: crypto.randomUUID(), createdAt: now, ...row(now) });
+      console.log(`[seed] Registered OAuth client "${INSPECTOR_CLIENT_ID}".`);
+    }
+    console.log(`         client_id     = ${INSPECTOR_CLIENT_ID}`);
+    console.log(`         redirect_uris = ${INSPECTOR_REDIRECT_URIS.join(', ')}`);
+    console.log(`         scopes        = ${INSPECTOR_SCOPES.join(' ')}`);
+    console.log(`         auth_method   = none (public client, PKCE required)`);
+  } finally {
+    await pgClient?.end();
+  }
+}
+
+seedInspectorClient().catch((err) => {
+  console.error('[seed] Failed:', err);
+  process.exit(1);
+});

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -14,13 +14,14 @@ import type { MessageBatch, ScheduledController } from '@cloudflare/workers-type
 import { neonConfig } from '@neondatabase/serverless';
 import { type App, addCorsHeaders, appBase, corsPreflightResponse } from '@packrat/api/app';
 import { getAuth } from '@packrat/api/auth';
-import { consentRoute } from '@packrat/api/auth/consent-route';
+import { consentRoute, signInRoute } from '@packrat/api/auth/consent-route';
 import {
   isLocalE2EAuthEnabled,
   localE2EToken,
   makeLocalE2EUser,
 } from '@packrat/api/auth/local-e2e';
 import { AppContainer } from '@packrat/api/containers';
+import { createDb } from '@packrat/api/db';
 import { CatalogService } from '@packrat/api/services';
 import { processQueueBatch } from '@packrat/api/services/etl/queue';
 import { sweepInvalidItemLogs } from '@packrat/api/services/retention/invalidLogRetention';
@@ -34,7 +35,12 @@ import {
 } from '@packrat/api/utils/queryMetrics';
 import { captureApiException, record } from '@packrat/api/utils/sentry';
 import { CatalogEtlWorkflow as RawCatalogEtlWorkflow } from '@packrat/api/workflows/catalog-etl-workflow';
+import { renderConsentPage, renderSignInPage } from '@packrat/consent-ui';
+import * as dbSchema from '@packrat/db';
+import { isString, toRecord, toString as toStr } from '@packrat/guards';
+import { safeJsonParse, safeJsonStringify } from '@packrat/utils';
 import { instrumentWorkflowWithSentry, withSentry } from '@sentry/cloudflare';
+import { eq } from 'drizzle-orm';
 import type { CatalogETLMessage } from './services/etl/types';
 
 export type { App };
@@ -42,7 +48,10 @@ export type { App };
 const bearerPrefixRegex = /^Bearer\s+/i;
 const scopeSplitRegex = /\s+/;
 const OAUTH_CONSENT_PATH = '/api/auth/oauth2/consent';
+const OAUTH_AUTHORIZE_PATH = '/api/auth/oauth2/authorize';
 const WELL_KNOWN_ALLOWED_ORIGINS = new Set(['https://claude.ai', 'https://claude.com']);
+/** localhost origins get CORS on the well-known endpoints so MCP Inspector can drive OAuth discovery. */
+const LOCALHOST_WELL_KNOWN_ORIGIN = /^http:\/\/localhost:\d+$/;
 
 // Sentry options for both the Worker handlers and the workflow class.
 // Reads SENTRY_DSN + ENVIRONMENT from the validated env. tracesSampleRate
@@ -58,7 +67,7 @@ function sentryOptions(env: Env) {
 }
 
 // Runtime instance: same routes as `App` plus the branded OAuth consent page.
-export const app = appBase.use(consentRoute).compile();
+export const app = appBase.use(signInRoute).use(consentRoute).compile();
 
 export { AppContainer };
 
@@ -125,7 +134,11 @@ function applyWellKnownCors(request: Request, response: Response | null): Respon
   }
 
   const origin = request.headers.get('Origin');
-  if (!origin || !WELL_KNOWN_ALLOWED_ORIGINS.has(origin)) return null;
+  if (
+    !origin ||
+    (!WELL_KNOWN_ALLOWED_ORIGINS.has(origin) && !LOCALHOST_WELL_KNOWN_ORIGIN.test(origin))
+  )
+    return null;
 
   if (request.method === 'OPTIONS') {
     return new Response(null, {
@@ -162,8 +175,21 @@ async function sanitizeOAuthConsentRequest(
   const role = (session.user as unknown as { role?: string }).role ?? 'USER';
   if (role === 'ADMIN') return request;
 
-  const form = new URLSearchParams(await request.text());
-  const postedScope = form.get('scope');
+  // Consent body is now JSON (the consent page switched from form-urlencoded to
+  // fetch+JSON so Better Auth's /oauth2/consent endpoint accepts it). Parse,
+  // strip mcp:admin for non-admins, and rewrite the body.
+  const text = await request.text();
+  let body: { accept?: unknown; scope?: unknown; oauth_query?: unknown };
+  try {
+    body = safeJsonParse(text) as typeof body;
+  } catch {
+    return Response.json(
+      { error: 'invalid_request', error_description: 'Consent body must be JSON' },
+      { status: 400 },
+    );
+  }
+
+  const postedScope = isString(body.scope) ? body.scope : null;
   if (postedScope === null) {
     return Response.json(
       { error: 'invalid_scope', error_description: 'scope is required for consent' },
@@ -175,15 +201,46 @@ async function sanitizeOAuthConsentRequest(
     .split(scopeSplitRegex)
     .filter((scope) => scope && scope !== 'mcp:admin')
     .join(' ');
-  form.set('scope', reducedScope);
 
+  const sanitized = safeJsonStringify({ ...body, scope: reducedScope });
   const headers = new Headers(request.headers);
-  headers.set('content-type', 'application/x-www-form-urlencoded;charset=UTF-8');
+  headers.set('content-type', 'application/json');
   headers.delete('content-length');
   return new Request(request.url, {
     method: request.method,
     headers,
-    body: form,
+    body: sanitized,
+    redirect: request.redirect,
+  });
+}
+
+// Strip `mcp:admin` from the authorize request scope for non-admin users so
+// the already-stored consent (which never includes mcp:admin for non-admins)
+// covers the entire requested set and the consent page isn't shown on every
+// reconnect. Admin users pass through unchanged — their consent records DO
+// include mcp:admin since it's never filtered on their path.
+async function sanitizeAuthorizeRequest(request: Request, env: Env): Promise<Request> {
+  const url = new URL(request.url);
+  if (request.method !== 'GET' || url.pathname !== OAUTH_AUTHORIZE_PATH) return request;
+  const scope = url.searchParams.get('scope');
+  if (!scope?.includes('mcp:admin')) return request;
+
+  const auth = await getAuth(env);
+  const session = await auth.api.getSession({ headers: request.headers });
+  if (!session?.user) return request;
+
+  const role = (session.user as unknown as { role?: string }).role ?? 'USER';
+  if (role === 'ADMIN') return request;
+
+  const reducedScope = scope
+    .split(scopeSplitRegex)
+    .filter((s) => s && s !== 'mcp:admin')
+    .join(' ');
+  const newUrl = new URL(request.url);
+  newUrl.searchParams.set('scope', reducedScope);
+  return new Request(newUrl.toString(), {
+    method: request.method,
+    headers: request.headers,
     redirect: request.redirect,
   });
 }
@@ -281,6 +338,106 @@ const workerHandler = {
         }
       }
 
+      // Sign-in and consent pages for the OAuth flow — intercepted before any
+      // other handler so neither Better Auth nor Elysia routing interferes.
+      if (request.method === 'GET' && url.pathname === '/api/auth/sign-in') {
+        const callbackURL = url.searchParams.get('callbackURL') ?? '';
+        const html = renderSignInPage({ callbackURL });
+        const response = new Response(html, {
+          status: 200,
+          headers: {
+            'Content-Type': 'text/html; charset=utf-8',
+            'Cache-Control': 'no-store',
+            'X-Content-Type-Options': 'nosniff',
+            'X-Frame-Options': 'DENY',
+          },
+        });
+        flushFetchMetrics({ ctx, response });
+        return response;
+      }
+
+      if (request.method === 'GET' && url.pathname === '/oauth/consent') {
+        const validatedEnv = getEnv();
+        const auth = await getAuth(validatedEnv);
+        const session = await auth.api.getSession({ headers: request.headers });
+        if (!session?.user) {
+          const signInUrl = new URL('/api/auth/sign-in', url.origin);
+          signInUrl.searchParams.set('callbackURL', url.toString());
+          const response = new Response(null, {
+            status: 302,
+            headers: { Location: signInUrl.toString(), 'Cache-Control': 'no-store' },
+          });
+          flushFetchMetrics({ ctx, response });
+          return response;
+        }
+
+        const clientId = url.searchParams.get('client_id') ?? '';
+        if (!clientId) {
+          const response = new Response('Missing client_id', { status: 400 });
+          flushFetchMetrics({ ctx, response });
+          return response;
+        }
+
+        const db = createDb();
+        const clientRows = await db
+          .select()
+          .from(dbSchema.oauthClient)
+          .where(eq(dbSchema.oauthClient.clientId, clientId))
+          .limit(1);
+        const clientRow = clientRows[0] as
+          | {
+              clientId: string;
+              name: string;
+              icon?: string | null;
+              tos?: string | null;
+              policy?: string | null;
+              uri?: string | null;
+            }
+          | undefined;
+
+        if (!clientRow) {
+          const response = new Response(`Unknown OAuth client: ${clientId}`, { status: 404 });
+          flushFetchMetrics({ ctx, response });
+          return response;
+        }
+
+        const userRole = toStr(toRecord(session.user).role) ?? 'USER';
+        const isAdmin = userRole === 'ADMIN';
+        const requestedScopes = (url.searchParams.get('scope') ?? '')
+          .split(scopeSplitRegex)
+          .filter(Boolean);
+        const approvableScopes = requestedScopes.filter((s) => isAdmin || s !== 'mcp:admin');
+        const oauthQuery = url.search.startsWith('?') ? url.search.slice(1) : url.search;
+
+        const html = renderConsentPage({
+          user: { name: session.user.name, email: session.user.email },
+          isAdmin,
+          client: {
+            clientId: clientRow.clientId,
+            name: clientRow.name,
+            icon: clientRow.icon ?? undefined,
+            tos: clientRow.tos ?? undefined,
+            policy: clientRow.policy ?? undefined,
+            uri: clientRow.uri ?? undefined,
+          },
+          requestedScopes,
+          approvableScopes,
+          oauthQuery,
+        });
+
+        const response = new Response(html, {
+          status: 200,
+          headers: {
+            'Content-Type': 'text/html; charset=utf-8',
+            'Cache-Control': 'no-store',
+            'X-Content-Type-Options': 'nosniff',
+            'X-Frame-Options': 'DENY',
+          },
+        });
+        flushFetchMetrics({ ctx, response });
+        return response;
+      }
+
       if (url.pathname.startsWith('/api/auth')) {
         const authPreflight = corsPreflightResponse(request);
         if (authPreflight) {
@@ -296,7 +453,8 @@ const workerHandler = {
           return annotated;
         }
         const auth = await getAuth(validatedEnv);
-        const sanitizedRequest = await sanitizeOAuthConsentRequest(request, validatedEnv);
+        const authorizeRequest = await sanitizeAuthorizeRequest(request, validatedEnv);
+        const sanitizedRequest = await sanitizeOAuthConsentRequest(authorizeRequest, validatedEnv);
         if (sanitizedRequest instanceof Response) {
           const annotated = addCorsHeaders({ request, response: sanitizedRequest });
           flushFetchMetrics({ ctx, response: annotated });

--- a/packages/api/src/utils/env-validation.ts
+++ b/packages/api/src/utils/env-validation.ts
@@ -39,6 +39,7 @@ export const apiEnvObjectSchema = z.object({
   // name to the legacy fallback so consumer code only reads the new name.
   PACKRAT_AUTH_SECRET: z.string().min(32).optional(),
   PACKRAT_API_URL: z.string().url().optional(),
+  PACKRAT_MCP_URL: z.string().url().optional(),
   BETTER_AUTH_SECRET: z.string().min(32).optional(),
   BETTER_AUTH_URL: z.string().url().optional(),
   BETTER_AUTH_TRUSTED_ORIGINS: z.string().optional(),

--- a/packages/consent-ui/src/consent-page.tsx
+++ b/packages/consent-ui/src/consent-page.tsx
@@ -214,17 +214,48 @@ footer .sep { margin: 0 8px; opacity: .5; }
 // `script-src` CSP is ever added, this inline script will need a matching
 // nonce. @kitajs/html renders `<script>` children raw (no escaping), so the
 // string is emitted verbatim.
+// Better Auth's /oauth2/consent requires application/json, not form-urlencoded.
+// We intercept the submit, POST JSON, then navigate to the final redirect URL
+// that Better Auth returns (it redirects to redirect_uri?code=...).
+// `fetch` with redirect:'follow' resolves to the final URL even across origins;
+// `res.url` is always readable regardless of CORS on the destination.
 const CONSENT_FORM_SCRIPT = `
 (function () {
   var form = document.getElementById('consent-form');
   if (!form) return;
-  var scopeInput = document.getElementById('consent-scope');
-  if (!scopeInput) return;
-  form.addEventListener('submit', function () {
+
+  form.addEventListener('submit', async function (e) {
+    e.preventDefault();
+    var submitter = e.submitter;
+    var accept = submitter ? submitter.value === 'true' : true;
     var boxes = form.querySelectorAll('input[name="scope_option"]:checked');
     var scopes = [];
     for (var i = 0; i < boxes.length; i++) scopes.push(boxes[i].value);
-    scopeInput.value = scopes.join(' ');
+    var oauthQueryEl = form.querySelector('input[name="oauth_query"]');
+    var oauthQuery = oauthQueryEl ? oauthQueryEl.value : '';
+
+    try {
+      var res = await fetch('/api/auth/oauth2/consent', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        redirect: 'follow',
+        body: JSON.stringify({ accept: accept, scope: scopes.join(' '), oauth_query: oauthQuery })
+      });
+      // Better Auth's consent endpoint returns JSON { redirect: true, url: "..." }
+      // rather than an HTTP 302. Parse the body and navigate to data.url.
+      var data = null;
+      try { data = await res.json(); } catch (_e) {}
+      if (data && data.url) {
+        window.location.href = data.url;
+      } else if (res.redirected && res.url && res.url !== window.location.href) {
+        window.location.href = res.url;
+      }
+    } catch (err) {
+      // Network failure; fall back to native form submit (will fail on content-type
+      // but at least gives the user visible feedback rather than silently hanging)
+      form.submit();
+    }
   });
 })();
 `;

--- a/packages/consent-ui/src/index.ts
+++ b/packages/consent-ui/src/index.ts
@@ -3,3 +3,4 @@ export {
   type OAuthClientRecord,
   renderConsentPage,
 } from './consent-page';
+export { renderSignInPage, type SignInPageData } from './sign-in-page';

--- a/packages/consent-ui/src/sign-in-page.tsx
+++ b/packages/consent-ui/src/sign-in-page.tsx
@@ -1,0 +1,231 @@
+/**
+ * Pure JSX renderer for the OAuth sign-in page.
+ *
+ * Served by `consent-route.ts` at GET `/api/auth/sign-in` when
+ * `@better-auth/oauth-provider` redirects an unauthenticated user there mid-flow.
+ * Follows the same rendering approach as `consent-page.tsx`:
+ *   - @kitajs/html string-rendering JSX (no React, no virtual DOM)
+ *   - Inline styles; no external CSS
+ *   - `safe` on every user-content interpolation
+ *   - Inline JS for the async sign-in fetch so `<noscript>` shows a fallback
+ */
+
+import { isString } from '@packrat/guards';
+
+const TERMS_URL = 'https://packratai.com/terms-of-service';
+const PRIVACY_URL = 'https://packratai.com/privacy-policy';
+const SUPPORT_MAILTO = 'mailto:hello@packratai.com';
+
+const SIGN_IN_PAGE_STYLES = `
+:root {
+  --brand: #2563eb;
+  --brand-hover: #1d4ed8;
+  --ink: #0f172a;
+  --ink-muted: #475569;
+  --line: #e2e8f0;
+  --bg: #ffffff;
+  --bg-soft: #f8fafc;
+  --danger: #b91c1c;
+  --danger-bg: #fef2f2;
+  --danger-line: #fecaca;
+}
+@media (prefers-color-scheme: dark) {
+  :root {
+    --ink: #f8fafc;
+    --ink-muted: #94a3b8;
+    --line: #1e293b;
+    --bg: #0f172a;
+    --bg-soft: #0b1220;
+    --danger: #fca5a5;
+    --danger-bg: #2a1212;
+    --danger-line: #7f1d1d;
+  }
+}
+* { box-sizing: border-box; }
+html, body { margin: 0; padding: 0; background: var(--bg-soft); color: var(--ink); }
+body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+       min-height: 100vh; display: flex; flex-direction: column; }
+main { flex: 1; display: flex; align-items: center; justify-content: center; padding: 32px 16px; }
+.card { background: var(--bg); border: 1px solid var(--line); border-radius: 12px;
+        box-shadow: 0 10px 30px rgba(15,23,42,.06); padding: 28px;
+        width: 100%; max-width: 420px; }
+.brand { display: flex; align-items: center; gap: 10px; margin-bottom: 20px; }
+.brand-name { font-size: 1rem; font-weight: 600; letter-spacing: -.01em; }
+h1 { margin: 0 0 6px; font-size: 1.2rem; font-weight: 600; }
+.subtitle { margin: 0 0 22px; color: var(--ink-muted); font-size: .9rem; }
+label { display: block; font-size: .875rem; font-weight: 500; margin-bottom: 6px; }
+input[type=email], input[type=password] {
+  display: block; width: 100%; padding: 10px 12px; font-size: .95rem;
+  border: 1px solid var(--line); border-radius: 8px; background: var(--bg);
+  color: var(--ink); outline: none; margin-bottom: 14px;
+  transition: border-color .15s; }
+input[type=email]:focus, input[type=password]:focus { border-color: var(--brand); }
+button[type=submit] {
+  width: 100%; padding: 11px; background: var(--brand); color: white;
+  border: 1px solid var(--brand); border-radius: 8px; font-size: .95rem;
+  font-weight: 600; cursor: pointer; transition: background .15s, border-color .15s;
+  margin-top: 4px; }
+button[type=submit]:hover { background: var(--brand-hover); border-color: var(--brand-hover); }
+button[type=submit]:disabled { opacity: .6; cursor: not-allowed; }
+.error { display: none; background: var(--danger-bg); border: 1px solid var(--danger-line);
+         color: var(--danger); border-radius: 8px; padding: 10px 14px;
+         font-size: .875rem; margin-bottom: 14px; }
+.error.visible { display: block; }
+footer { padding: 24px 16px; text-align: center; color: var(--ink-muted); font-size: .8rem; }
+footer a { color: var(--ink-muted); text-decoration: none; }
+footer a:hover { color: var(--ink); text-decoration: underline; }
+footer .sep { margin: 0 8px; opacity: .5; }
+`;
+
+// Inline script: submits credentials to Better Auth's sign-in endpoint,
+// then redirects to callbackURL on success.
+const SIGN_IN_SCRIPT = `
+(function () {
+  var form = document.getElementById('sign-in-form');
+  var errorBox = document.getElementById('sign-in-error');
+  var submitBtn = document.getElementById('sign-in-submit');
+  if (!form) return;
+
+  form.addEventListener('submit', async function (e) {
+    e.preventDefault();
+    errorBox.textContent = '';
+    errorBox.classList.remove('visible');
+    submitBtn.disabled = true;
+    submitBtn.textContent = 'Signing in…';
+
+    // Better Auth passes the raw OAuth authorize params to loginPage (no callbackURL).
+    // Reconstruct the authorize URL so the OAuth flow resumes after sign-in.
+    var params = new URLSearchParams(window.location.search);
+    var callbackURL = params.get('callbackURL')
+      || ('/api/auth/oauth2/authorize' + window.location.search);
+    var email = form.elements['email'].value;
+    var password = form.elements['password'].value;
+
+    try {
+      var res = await fetch('/api/auth/sign-in/email', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email: email, password: password, callbackURL: callbackURL }),
+        credentials: 'include',
+      });
+
+      var data;
+      try { data = await res.clone().json(); } catch (_) { data = null; }
+
+      if (res.ok) {
+        // Better Auth may embed a redirect URL in the response body.
+        var redirectTo = (data && data.url) ? data.url : callbackURL;
+        window.location.href = redirectTo;
+        return;
+      }
+
+      var msg = (data && (data.message || data.error)) || 'Invalid email or password.';
+      errorBox.textContent = msg;
+      errorBox.classList.add('visible');
+    } catch (err) {
+      errorBox.textContent = 'Network error. Please try again.';
+      errorBox.classList.add('visible');
+    } finally {
+      submitBtn.disabled = false;
+      submitBtn.textContent = 'Sign in';
+    }
+  });
+})();
+`;
+
+function PackratLogo(): JSX.Element {
+  return (
+    <svg width="40" height="40" viewBox="0 0 64 64" aria-hidden="true" focusable="false">
+      <title>PackRat</title>
+      <rect x="14" y="18" width="36" height="38" rx="8" fill="#2563eb" />
+      <rect x="22" y="10" width="20" height="14" rx="4" fill="#1d4ed8" />
+      <rect x="22" y="32" width="20" height="8" rx="2" fill="#bfdbfe" />
+      <circle cx="32" cy="46" r="3" fill="#bfdbfe" />
+    </svg>
+  );
+}
+
+export interface SignInPageData {
+  /** Value to redirect to after a successful sign-in (from `?callbackURL=`). */
+  callbackURL: string;
+}
+
+function SignInPage({ callbackURL }: SignInPageData): JSX.Element {
+  return (
+    <html lang="en">
+      <head>
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <meta name="robots" content="noindex,nofollow" />
+        <title>Sign in · PackRat</title>
+        <style>{SIGN_IN_PAGE_STYLES}</style>
+      </head>
+      <body>
+        <main>
+          <div class="card">
+            <div class="brand">
+              <PackratLogo />
+              <span class="brand-name">PackRat</span>
+            </div>
+            <h1>Sign in to PackRat</h1>
+            <p class="subtitle">to continue to the MCP connector</p>
+
+            <div id="sign-in-error" class="error" role="alert" aria-live="assertive" />
+
+            <form id="sign-in-form" method="POST" action="/api/auth/sign-in/email" novalidate>
+              {/* callbackURL hidden field — used by the no-JS fallback path */}
+              <input
+                type="hidden"
+                name="callbackURL"
+                value={isString(callbackURL) ? callbackURL : '/'}
+              />
+
+              <label for="email">Email</label>
+              <input
+                type="email"
+                id="email"
+                name="email"
+                autocomplete="email"
+                required
+                placeholder="you@example.com"
+              />
+
+              <label for="password">Password</label>
+              <input
+                type="password"
+                id="password"
+                name="password"
+                autocomplete="current-password"
+                required
+                placeholder="••••••••"
+              />
+
+              <button type="submit" id="sign-in-submit">
+                Sign in
+              </button>
+            </form>
+            <script>{SIGN_IN_SCRIPT}</script>
+          </div>
+        </main>
+        <footer>
+          <a href={TERMS_URL}>Terms</a>
+          <span class="sep" aria-hidden="true">
+            ·
+          </span>
+          <a href={PRIVACY_URL}>Privacy</a>
+          <span class="sep" aria-hidden="true">
+            ·
+          </span>
+          <a href={SUPPORT_MAILTO}>Support</a>
+        </footer>
+      </body>
+    </html>
+  );
+}
+
+/**
+ * Render the sign-in page to a complete HTML5 document string.
+ */
+export function renderSignInPage(data: SignInPageData): string {
+  return `<!DOCTYPE html>${<SignInPage {...data} />}`;
+}

--- a/packages/consent-ui/src/sign-in-page.tsx
+++ b/packages/consent-ui/src/sign-in-page.tsx
@@ -10,6 +10,8 @@
  *   - Inline JS for the async sign-in fetch so `<noscript>` shows a fallback
  */
 
+// biome-ignore lint/correctness/noUnusedImports: @kitajs/html classic JSX runtime requires Html in scope for the JSX transform (Html.createElement)
+import { Html } from '@kitajs/html';
 import { isString } from '@packrat/guards';
 
 const TERMS_URL = 'https://packratai.com/terms-of-service';

--- a/packages/mcp/src/__tests__/cors.test.ts
+++ b/packages/mcp/src/__tests__/cors.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { applyCorsHeaders, WELL_KNOWN_ALLOWED_ORIGINS } from '../cors';
+import { applyCorsHeaders, applyLocalhostCors, WELL_KNOWN_ALLOWED_ORIGINS } from '../cors';
 
 const ALLOWED = 'https://claude.ai';
 const WELL_KNOWN = 'https://mcp.test/.well-known/oauth-protected-resource';
@@ -14,6 +14,29 @@ describe('applyCorsHeaders', () => {
       'https://claude.ai',
       'https://claude.com',
     ]);
+  });
+
+  it('allows any localhost origin (MCP Inspector dev flow)', () => {
+    const localOrigins = [
+      'http://localhost:6274',
+      'http://localhost:3000',
+      'http://localhost:8080',
+    ];
+    for (const origin of localOrigins) {
+      const result = applyCorsHeaders({
+        request: req(WELL_KNOWN, { method: 'GET', headers: { Origin: origin } }),
+        existing: new Response('{}'),
+      });
+      expect(result?.headers.get('Access-Control-Allow-Origin')).toBe(origin);
+    }
+  });
+
+  it('blocks non-localhost http origins', () => {
+    const result = applyCorsHeaders({
+      request: req(WELL_KNOWN, { headers: { Origin: 'http://evil.example' } }),
+      existing: null,
+    });
+    expect(result).toBeNull();
   });
 
   it('returns null for non-well-known paths', () => {
@@ -76,5 +99,64 @@ describe('applyCorsHeaders', () => {
       existing: null,
     });
     expect(result).toBeNull();
+  });
+});
+
+describe('applyLocalhostCors', () => {
+  const MCP_URL = 'http://localhost:8788/mcp';
+
+  it('annotates a response from a localhost origin with ACAO and Expose-Headers', () => {
+    const existing = new Response('{"error":"invalid_token"}', {
+      status: 401,
+      headers: { 'WWW-Authenticate': 'Bearer realm="test"', 'Content-Type': 'application/json' },
+    });
+    const result = applyLocalhostCors({
+      request: req(MCP_URL, { headers: { Origin: 'http://localhost:6274' } }),
+      existing,
+    });
+    expect(result).not.toBeNull();
+    expect(result?.headers.get('Access-Control-Allow-Origin')).toBe('http://localhost:6274');
+    expect(result?.headers.get('Access-Control-Expose-Headers')).toContain('WWW-Authenticate');
+    expect(result?.status).toBe(401);
+  });
+
+  it('returns null for non-localhost origins', () => {
+    const result = applyLocalhostCors({
+      request: req(MCP_URL, { headers: { Origin: 'https://evil.example' } }),
+      existing: new Response(null),
+    });
+    expect(result).toBeNull();
+  });
+
+  it('returns null when there is no Origin header', () => {
+    const result = applyLocalhostCors({
+      request: req(MCP_URL),
+      existing: new Response(null),
+    });
+    expect(result).toBeNull();
+  });
+
+  it('answers an OPTIONS preflight from localhost with a 204 covering /mcp', () => {
+    const result = applyLocalhostCors({
+      request: req(MCP_URL, {
+        method: 'OPTIONS',
+        headers: { Origin: 'http://localhost:6274' },
+      }),
+      existing: new Response(null),
+    });
+    expect(result?.status).toBe(204);
+    expect(result?.headers.get('Access-Control-Allow-Origin')).toBe('http://localhost:6274');
+    expect(result?.headers.get('Access-Control-Allow-Methods')).toContain('POST');
+    expect(result?.headers.get('Access-Control-Allow-Headers')).toContain('Authorization');
+    expect(result?.headers.get('Access-Control-Expose-Headers')).toContain('WWW-Authenticate');
+  });
+
+  it('appends to a pre-existing Vary header', () => {
+    const existing = new Response(null, { headers: { Vary: 'Accept-Encoding' } });
+    const result = applyLocalhostCors({
+      request: req(MCP_URL, { headers: { Origin: 'http://localhost:3000' } }),
+      existing,
+    });
+    expect(result?.headers.get('Vary')).toBe('Accept-Encoding, Origin');
   });
 });

--- a/packages/mcp/src/__tests__/metadata.test.ts
+++ b/packages/mcp/src/__tests__/metadata.test.ts
@@ -26,12 +26,18 @@ describe('SCOPES_SUPPORTED', () => {
 });
 
 describe('canonicalResourceUrl', () => {
-  it('pins to the production MCP custom domain regardless of env', () => {
-    // Pinning is intentional — Claude verifies token audience against this
-    // exact string; falling back to the request origin (the OAuth provider's
-    // default) silently breaks discovery when the dev *.workers.dev hostname
-    // differs from the issued-token audience.
+  it('pins to the production MCP custom domain when MCP_PUBLIC_URL is unset', () => {
     expect(canonicalResourceUrl(env)).toBe('https://mcp.packratai.com/mcp');
+  });
+
+  it('uses MCP_PUBLIC_URL/mcp in local dev so the Inspector resource-match check passes', () => {
+    const localEnv = { ...env, MCP_PUBLIC_URL: 'http://localhost:8788' } as Env;
+    expect(canonicalResourceUrl(localEnv)).toBe('http://localhost:8788/mcp');
+  });
+
+  it('strips a trailing slash from MCP_PUBLIC_URL before appending /mcp', () => {
+    const slashed = { ...env, MCP_PUBLIC_URL: 'http://localhost:8788/' } as Env;
+    expect(canonicalResourceUrl(slashed)).toBe('http://localhost:8788/mcp');
   });
 });
 
@@ -74,13 +80,19 @@ describe('authorizationServerUrl', () => {
 });
 
 describe('buildResourceMetadata', () => {
-  it('returns a complete RFC 9728 metadata object', () => {
+  it('returns a complete RFC 9728 metadata object (production env)', () => {
     const meta = buildResourceMetadata(env);
     expect(meta.resource).toBe('https://mcp.packratai.com/mcp');
     expect(meta.authorization_servers).toEqual(['https://api.packrat.world']);
     expect(meta.scopes_supported).toEqual([...SCOPES_SUPPORTED]);
     expect(meta.bearer_methods_supported).toEqual(['header']);
     expect(meta.resource_name).toBe('PackRat MCP');
+  });
+
+  it('uses the local resource URL in local dev (MCP_PUBLIC_URL set)', () => {
+    const localEnv = { ...env, MCP_PUBLIC_URL: 'http://localhost:8788' } as Env;
+    const meta = buildResourceMetadata(localEnv);
+    expect(meta.resource).toBe('http://localhost:8788/mcp');
   });
 });
 
@@ -102,6 +114,20 @@ describe('buildWwwAuthenticateHeader', () => {
 
   it('uses the Bearer auth scheme', () => {
     expect(buildWwwAuthenticateHeader({ env }).startsWith('Bearer ')).toBe(true);
+  });
+
+  it('uses MCP_PUBLIC_URL when set (local dev) instead of the prod domain', () => {
+    const localEnv = { ...env, MCP_PUBLIC_URL: 'http://localhost:8788' } as Env;
+    expect(buildWwwAuthenticateHeader({ env: localEnv })).toContain(
+      'resource_metadata="http://localhost:8788/.well-known/oauth-protected-resource"',
+    );
+  });
+
+  it('strips a trailing slash from MCP_PUBLIC_URL before building the metadata URL', () => {
+    const slashed = { ...env, MCP_PUBLIC_URL: 'http://localhost:8788/' } as Env;
+    expect(buildWwwAuthenticateHeader({ env: slashed })).toContain(
+      'resource_metadata="http://localhost:8788/.well-known/oauth-protected-resource"',
+    );
   });
 });
 

--- a/packages/mcp/src/__tests__/token-verify.test.ts
+++ b/packages/mcp/src/__tests__/token-verify.test.ts
@@ -16,14 +16,20 @@ import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } fr
 import { __resetJwksCacheForTests, verifyMcpToken } from '../token-verify';
 import type { Env } from '../types';
 
-const ISSUER = 'https://api.test.packratai.com';
+// Better Auth sets iss = PACKRAT_API_URL + '/api/auth' (not the bare URL).
+// These two constants mirror that split: API_BASE is the env var, ISSUER is
+// the value that appears in the JWT `iss` claim and in verifyMcpToken's
+// issuer check.
+const API_BASE = 'https://api.test.packratai.com';
+const ISSUER = `${API_BASE}/api/auth`;
 const AUDIENCE = 'https://mcp.packratai.com/mcp';
-const JWKS_URL = `${ISSUER}/api/auth/jwks`;
+// JWKS is served at the bare base URL path, not the issuer path.
+const JWKS_URL = `${API_BASE}/api/auth/jwks`;
 
 // Minimal Env stub — the verifier only touches PACKRAT_API_URL. The rest of
 // the bindings (Durable Object, KV, rate limit) are irrelevant for this
 // unit and casting through `unknown` keeps the structural typing happy.
-const env = { PACKRAT_API_URL: ISSUER } as unknown as Env;
+const env = { PACKRAT_API_URL: API_BASE } as unknown as Env;
 
 // Stub ExecutionContext — `waitUntil` is a no-op for verifier tests.
 const ctx = {

--- a/packages/mcp/src/cors.ts
+++ b/packages/mcp/src/cors.ts
@@ -28,6 +28,51 @@ export const WELL_KNOWN_ALLOWED_ORIGINS = new Set<string>([
   'https://claude.com',
 ]);
 
+/**
+ * localhost origins get CORS on /.well-known/* AND /mcp so MCP Inspector's
+ * "Direct" connection mode can see the 401 WWW-Authenticate header, drive
+ * OAuth discovery, and make authenticated tool calls — all without the proxy.
+ */
+const LOCALHOST_ORIGIN = /^http:\/\/localhost:\d+$/;
+
+/**
+ * Apply CORS headers to any response for localhost origins.
+ * Used by the outer fetch handler to cover /mcp 401 responses and
+ * authenticated DO responses in MCP Inspector direct-connection mode.
+ */
+export function applyLocalhostCors({
+  request,
+  existing,
+}: {
+  request: Request;
+  existing: Response;
+}): Response | null {
+  const origin = request.headers.get('Origin');
+  if (!origin || !LOCALHOST_ORIGIN.test(origin)) return null;
+
+  // OPTIONS preflight
+  if (request.method === 'OPTIONS') {
+    return new Response(null, {
+      status: 204,
+      headers: {
+        'Access-Control-Allow-Origin': origin,
+        Vary: 'Origin',
+        'Access-Control-Allow-Methods': 'GET, POST, DELETE, OPTIONS',
+        'Access-Control-Allow-Headers': 'Authorization, Content-Type, mcp-session-id',
+        'Access-Control-Expose-Headers': 'WWW-Authenticate, mcp-session-id',
+        'Access-Control-Max-Age': '3600',
+      },
+    });
+  }
+
+  const annotated = new Response(existing.body, existing);
+  annotated.headers.set('Access-Control-Allow-Origin', origin);
+  annotated.headers.set('Access-Control-Expose-Headers', 'WWW-Authenticate, mcp-session-id');
+  const existingVary = annotated.headers.get('Vary');
+  annotated.headers.set('Vary', existingVary ? `${existingVary}, Origin` : 'Origin');
+  return annotated;
+}
+
 const WELL_KNOWN_PREFIX = '/.well-known/';
 
 /**
@@ -52,7 +97,8 @@ export function applyCorsHeaders({
   if (!url.pathname.startsWith(WELL_KNOWN_PREFIX)) return null;
 
   const origin = request.headers.get('Origin');
-  if (!origin || !WELL_KNOWN_ALLOWED_ORIGINS.has(origin)) return null;
+  if (!origin || (!WELL_KNOWN_ALLOWED_ORIGINS.has(origin) && !LOCALHOST_ORIGIN.test(origin)))
+    return null;
 
   // Preflight: respond directly so the well-known handler never sees the
   // OPTIONS request (it only knows GET).

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -45,7 +45,7 @@ import { McpAgent } from 'agents/mcp';
 import { handleHealth, handleStatus } from './auth';
 import { createMcpClients, errResponse, type McpClients, type McpToolResult } from './client';
 import { ServiceMeta } from './constants';
-import { applyCorsHeaders } from './cors';
+import { applyCorsHeaders, applyLocalhostCors } from './cors';
 import { faviconResponse } from './favicon';
 import { buildResourceMetadata, unauthorizedResponse } from './metadata';
 import { attachCorrelationId, correlationIdFrom } from './observability';
@@ -356,7 +356,7 @@ export class PackRatMCP extends McpAgent<Env, State, Props> {
 
 // ── Constants ─────────────────────────────────────────────────────────────────
 
-const mcpDoHandler = PackRatMCP.serve('/mcp');
+const mcpDoHandler = PackRatMCP.serve('/mcp', { binding: 'PackRatMCP' });
 
 /**
  * Worker entrypoint (U3+U4 cutover).
@@ -409,12 +409,15 @@ export default {
 
     const url = new URL(request.url);
 
-    // ── 1. CORS preflight short-circuit for Claude origins ───────────────────
-    // OPTIONS preflights from allowlisted origins on `/.well-known/*` get a
-    // 204 directly here so we never touch the dispatcher logic below.
+    // ── 1. CORS preflight short-circuit ─────────────────────────────────────
+    // OPTIONS from allowlisted Claude origins on `/.well-known/*` get a 204
+    // directly. OPTIONS from localhost (MCP Inspector direct mode) also get a
+    // 204 covering the /mcp endpoint so the browser can read 401 headers.
     if (request.method === 'OPTIONS') {
       const cors = applyCorsHeaders({ request, existing: null });
       if (cors) return withCorrelationHeader({ response: cors, correlationId });
+      const localCors = applyLocalhostCors({ request, existing: new Response(null) });
+      if (localCors) return withCorrelationHeader({ response: localCors, correlationId });
     }
 
     // ── 2. Public metadata + ops endpoints (no auth required) ────────────────
@@ -441,12 +444,16 @@ export default {
     if (url.pathname === '/mcp' || url.pathname.startsWith('/mcp/')) {
       const bearer = extractBearer(request.headers.get('Authorization'));
       if (!bearer) {
-        return withCorrelationHeader({ response: unauthorizedResponse({ env }), correlationId });
+        const unauth = unauthorizedResponse({ env });
+        const cors = applyLocalhostCors({ request, existing: unauth }) ?? unauth;
+        return withCorrelationHeader({ response: cors, correlationId });
       }
 
       const verified = await verifyMcpToken({ token: bearer, env, ctx });
       if (!verified) {
-        return withCorrelationHeader({ response: unauthorizedResponse({ env }), correlationId });
+        const unauth = unauthorizedResponse({ env });
+        const cors = applyLocalhostCors({ request, existing: unauth }) ?? unauth;
+        return withCorrelationHeader({ response: cors, correlationId });
       }
 
       // Inject the verified-claim Props into ctx.props for the DO handler.
@@ -466,8 +473,21 @@ export default {
       // apiHandler used to populate it.
       (ctx as unknown as { props: Props }).props = props;
 
-      const response = await mcpDoHandler.fetch(request, env, ctx);
-      return withCorrelationHeader({ response, correlationId });
+      // The DO may hibernate briefly between requests (e.g., after WebSocket
+      // close following the initialize response). In that window, the stub RPC
+      // throws rather than returning a response. Retry once after a short wait
+      // so the DO has time to finish its wake-up cycle.
+      let doResponse: Response;
+      try {
+        doResponse = await mcpDoHandler.fetch(request, env, ctx);
+      } catch {
+        await new Promise<void>((resolve) => {
+          setTimeout(resolve, 300);
+        });
+        doResponse = await mcpDoHandler.fetch(request, env, ctx);
+      }
+      const cors = applyLocalhostCors({ request, existing: doResponse }) ?? doResponse;
+      return withCorrelationHeader({ response: cors, correlationId });
     }
 
     // ── 4. Anything else: 404 ────────────────────────────────────────────────

--- a/packages/mcp/src/metadata.ts
+++ b/packages/mcp/src/metadata.ts
@@ -53,16 +53,25 @@ export function buildResourceMetadata(env: Env) {
 }
 
 /**
- * The canonical `resource` URL advertised in protected-resource metadata.
+ * The canonical `resource` URL advertised in protected-resource metadata AND
+ * used as the JWT `aud` claim by `verifyMcpToken`. The two must stay in sync:
+ * the AS mints tokens with `aud` equal to the `resource` value the client
+ * sends in its token request, which it reads from the metadata document here.
  *
- * Currently hard-pinned to production. If we later need a per-env
- * identifier (e.g. an env-specific staging hostname), thread an env var
- * (e.g. `MCP_PUBLIC_URL`) through and read it here. Don't fall back to the
- * request origin — Claude-side audience verification breaks the moment
- * the metadata's `resource` value diverges from the value bound into
- * issued access tokens.
+ * In local dev (`MCP_PUBLIC_URL` is set in `.dev.vars`), we derive the
+ * resource from the local base URL so MCP Inspector's resource-match
+ * validation passes and the locally-issued JWT audience matches the verifier.
+ *
+ * In production (`MCP_PUBLIC_URL` absent), hard-pin to the canonical custom
+ * domain. Do NOT fall back to the request origin — if the Workers.dev hostname
+ * ever appears here it will diverge from every token already issued against
+ * the custom domain.
  */
-export function canonicalResourceUrl(_env: Env): string {
+export function canonicalResourceUrl(env: Env): string {
+  if (env.MCP_PUBLIC_URL) {
+    const base = env.MCP_PUBLIC_URL.replace(TRAILING_SLASH, '');
+    return `${base}/mcp`;
+  }
   return 'https://mcp.packratai.com/mcp';
 }
 
@@ -98,13 +107,14 @@ export function authorizationServerUrl(env: Env): string {
  * and proceeds with the authorization-code flow against the API worker.
  */
 export function buildWwwAuthenticateHeader({
-  env: _env,
+  env,
   scope = 'mcp:read',
 }: {
   env: Env;
   scope?: Scope;
 }): string {
-  const metadataUrl = 'https://mcp.packratai.com/.well-known/oauth-protected-resource';
+  const base = (env.MCP_PUBLIC_URL ?? 'https://mcp.packratai.com').replace(TRAILING_SLASH, '');
+  const metadataUrl = `${base}/.well-known/oauth-protected-resource`;
   return `Bearer resource_metadata="${metadataUrl}", scope="${scope}"`;
 }
 

--- a/packages/mcp/src/token-verify.ts
+++ b/packages/mcp/src/token-verify.ts
@@ -81,17 +81,20 @@ export interface VerifiedToken {
  */
 const jwksCache = new Map<string, ReturnType<typeof createRemoteJWKSet>>();
 
-function getJwks(issuerUrl: string): ReturnType<typeof createRemoteJWKSet> {
-  const cached = jwksCache.get(issuerUrl);
+// JWKS URL is at <apiBaseUrl>/api/auth/jwks (Better Auth endpoint path).
+// Keyed by apiBaseUrl so the cache survives issuer-string changes and
+// avoids constructing the URL on every request.
+function getJwks(apiBaseUrl: string): ReturnType<typeof createRemoteJWKSet> {
+  const cached = jwksCache.get(apiBaseUrl);
   if (cached) return cached;
 
   // 60s TTL per SEC-005. `cooldownDuration` default (30s) is fine — it's
   // the minimum time between unforced fetches and bounds DDoS pressure on
   // /api/auth/jwks if an attacker spams unknown-`kid` tokens.
-  const jwks = createRemoteJWKSet(new URL(`${issuerUrl}/api/auth/jwks`), {
+  const jwks = createRemoteJWKSet(new URL(`${apiBaseUrl}/api/auth/jwks`), {
     cacheMaxAge: 60_000,
   });
-  jwksCache.set(issuerUrl, jwks);
+  jwksCache.set(apiBaseUrl, jwks);
   return jwks;
 }
 
@@ -103,20 +106,14 @@ export function __resetJwksCacheForTests(): void {
 /**
  * Resolve the OAuth issuer URL the AS metadata advertises.
  *
- * Sourced from `env.PACKRAT_API_URL` to match U1's `auth/index.ts`
- * config: `betterAuth({ baseURL: env.PACKRAT_API_URL })`. Both workers
- * read the same env var name (post-2026-05-25 rename — the API used to
- * call this BETTER_AUTH_URL; both names point at the api worker —
- * `https://api.packrat.world` in prod,
- * `http://localhost:8787` in dev). Better Auth's `oauthProvider` plugin
- * defaults the `issuer` claim and AS metadata `issuer` field to
- * `ctx.context.baseURL`, so deriving from `PACKRAT_API_URL` keeps the
- * two workers in lockstep without adding another env var.
+ * Better Auth sets `ctx.context.baseURL = baseURL + '/api/auth'`, and
+ * uses that as the JWT `iss` claim and the AS metadata `issuer` field.
+ * So the issuer is `env.PACKRAT_API_URL + '/api/auth'`, not the bare
+ * `PACKRAT_API_URL`. Verified against the AS metadata at
+ * `/.well-known/oauth-authorization-server` and decoded JWT payloads.
  */
 function getIssuerUrl(env: Env): string {
-  // Strip a trailing slash so the issuer is canonical — JWT `iss` is
-  // string-compared verbatim, and Better Auth doesn't append one.
-  return env.PACKRAT_API_URL.replace(TRAILING_SLASH, '');
+  return `${env.PACKRAT_API_URL.replace(TRAILING_SLASH, '')}/api/auth`;
 }
 
 /**
@@ -150,9 +147,10 @@ export async function verifyMcpToken({
   // try/catch + retry below is wasted work for an empty string.
   if (!token || !isString(token)) return null;
 
-  const issuer = getIssuerUrl(env);
-  const audience = canonicalResourceUrl(env); // 'https://mcp.packratai.com/mcp'
-  const jwks = getJwks(issuer);
+  const apiBaseUrl = env.PACKRAT_API_URL.replace(TRAILING_SLASH, '');
+  const issuer = getIssuerUrl(env); // apiBaseUrl + '/api/auth'
+  const audience = canonicalResourceUrl(env); // 'https://mcp.packratai.com/mcp' or local equiv
+  const jwks = getJwks(apiBaseUrl); // JWKS at apiBaseUrl + '/api/auth/jwks'
   const verifyArgs = { jwks, issuer, audience };
 
   try {
@@ -204,10 +202,9 @@ async function verifyOnce({
     audience: verifyArgs.audience,
     // Algorithm allowlist — defends against `alg: none` and HS256-with-
     // public-key confusion attacks. Better Auth's `jwt()` plugin signs
-    // with ES256 by default; RS256 is supported as a future migration
-    // path. Anything else (HS*, EdDSA, PS*) is rejected here even if a
-    // JWKS key happens to advertise that alg.
-    algorithms: ['ES256', 'RS256'],
+    // with EdDSA (Ed25519) by default; ES256 and RS256 are supported as
+    // migration paths. HS* and PS* are rejected regardless.
+    algorithms: ['EdDSA', 'ES256', 'RS256'],
   });
 
   const sub = isString(payload.sub) ? payload.sub : '';

--- a/packages/mcp/src/types.ts
+++ b/packages/mcp/src/types.ts
@@ -106,6 +106,14 @@ export interface Env {
   /** Comma-separated feature flags enabled at boot (e.g. "wildlife_id,season_suggestions"). */
   MCP_FEATURE_FLAGS?: string;
   /**
+   * Public base URL of this worker (e.g. "http://localhost:8788" in local dev,
+   * absent in production where the canonical URL is hardcoded). Used by
+   * `buildWwwAuthenticateHeader` so the `resource_metadata` pointer in 401
+   * responses points at the local well-known endpoint instead of the production
+   * domain, letting MCP Inspector discover the local AS during dev.
+   */
+  MCP_PUBLIC_URL?: string;
+  /**
    * Workers Rate Limiting binding (U14). Configured under the
    * `rate_limiting` block in `packages/mcp/wrangler.jsonc` with a 60/60s
    * budget. Keyed `${props.userId}:${toolName}` per-call so per-user/


### PR DESCRIPTION
## Summary

- **JWT verification bugs (all environments)**: Issuer was missing `/api/auth` suffix, JWKS URL had a double-path bug, and `EdDSA` was absent from the algorithm allowlist — all three caused silent 401s on every token
- **MCP Inspector local-dev support**: CORS on well-known endpoints and 401 responses, `MCP_PUBLIC_URL` env var for local resource URLs, DO hibernation retry, localhost audience in `validAudiences`, pre-registration seed script for Inspector's OAuth client
- **OAuth consent UI**: Added the missing sign-in page/route that Better Auth redirects to mid-flow, fixed consent body parsing from form-urlencoded to JSON, added `PACKRAT_MCP_URL` env var for non-production audience override

## Test plan

- [ ] Run `NEON_DATABASE_URL=<url> bun run packages/api/src/db/seed-inspector-oauth-client.ts` to pre-register the Inspector client
- [ ] Start API (`bun api`) and MCP (`bun --cwd packages/mcp run dev`) with `MCP_PUBLIC_URL=http://localhost:8788` in `packages/mcp/.dev.vars`
- [ ] Open MCP Inspector at `http://localhost:6274`, connect to `http://localhost:8788/mcp`, complete OAuth flow (sign-in → consent), verify tools load
- [ ] Verify tool calls return data (not 401) — confirms `mcp-token.ts` JWT verification fixes
- [ ] Confirm claude.ai connector still works with `packrat-claude-mcp` client ID