### PR TITLE
fix(mcp): request write scope by default and expose logo_uri in connector metadata

### DIFF
--- a/packages/mcp/src/__tests__/metadata.test.ts
+++ b/packages/mcp/src/__tests__/metadata.test.ts
@@ -87,6 +87,7 @@ describe('buildResourceMetadata', () => {
     expect(meta.scopes_supported).toEqual([...SCOPES_SUPPORTED]);
     expect(meta.bearer_methods_supported).toEqual(['header']);
     expect(meta.resource_name).toBe('PackRat MCP');
+    expect(meta.logo_uri).toBe('https://packratai.com/mcp-logo-256.png');
   });
 
   it('uses the local resource URL in local dev (MCP_PUBLIC_URL set)', () => {
@@ -104,8 +105,8 @@ describe('buildWwwAuthenticateHeader', () => {
     );
   });
 
-  it('defaults the scope hint to "mcp:read"', () => {
-    expect(buildWwwAuthenticateHeader({ env })).toContain('scope="mcp:read"');
+  it('defaults the scope hint to "mcp:write" so Claude requests write access', () => {
+    expect(buildWwwAuthenticateHeader({ env })).toContain('scope="mcp:write"');
   });
 
   it('passes through a specific requested scope when provided', () => {

--- a/packages/mcp/src/__tests__/submission-readiness.test.ts
+++ b/packages/mcp/src/__tests__/submission-readiness.test.ts
@@ -183,7 +183,7 @@ describe('checkStreamableHttpAuth', () => {
       status: 401,
       headers: new Headers({
         'WWW-Authenticate':
-          'Bearer resource_metadata="https://mcp.packratai.com/.well-known/oauth-protected-resource", scope="mcp:read"',
+          'Bearer resource_metadata="https://mcp.packratai.com/.well-known/oauth-protected-resource", scope="mcp:write"',
       }),
     });
     expect(checkStreamableHttpAuth(res).status).toBe('pass');

--- a/packages/mcp/src/metadata.ts
+++ b/packages/mcp/src/metadata.ts
@@ -49,6 +49,7 @@ export function buildResourceMetadata(env: Env) {
     scopes_supported: [...SCOPES_SUPPORTED],
     bearer_methods_supported: ['header'] as const,
     resource_name: 'PackRat MCP',
+    logo_uri: 'https://packratai.com/mcp-logo-256.png',
   };
 }
 
@@ -108,7 +109,7 @@ export function authorizationServerUrl(env: Env): string {
  */
 export function buildWwwAuthenticateHeader({
   env,
-  scope = 'mcp:read',
+  scope = 'mcp:write',
 }: {
   env: Env;
   scope?: Scope;


### PR DESCRIPTION
## Summary

- **Write access not requested**: The `WWW-Authenticate` scope hint was hardcoded to `mcp:read`, so Claude.ai only initiated the OAuth flow requesting read-only access. Changed the default in `buildWwwAuthenticateHeader` to `mcp:write` so write access is granted on first connection. (Note: the glossary already described `mcp:write` as "the default scope Claude.ai requests" — the code now matches the documented intent.)
- **Logo not showing**: `buildResourceMetadata` (served at `/.well-known/oauth-protected-resource`) omitted the `logo_uri` field. Claude.ai reads this document to show the connector icon. Added `logo_uri: 'https://packratai.com/mcp-logo-256.png'` — the 256px MCP logo already hosted on the landing site.

## Files changed

- `packages/mcp/src/metadata.ts` — default scope `mcp:read` → `mcp:write`; add `logo_uri` to resource metadata
- `packages/mcp/src/__tests__/metadata.test.ts` — update scope default assertion; add `logo_uri` assertion
- `packages/mcp/src/__tests__/submission-readiness.test.ts` — update hardcoded example header to use `mcp:write`

## Test plan

- [x] All 37 MCP test files pass (`bun test:mcp`)
- [x] TypeScript type-check clean (`bun check-types` in `packages/mcp`)
- [x] Biome lint clean (pre-commit + pre-push hooks passed)