### PR TITLE
fix(purchases): fail open only for Pro when feature-access config fails

### DIFF
--- a/apps/expo/features/purchases/hooks/useEntitlement.ts
+++ b/apps/expo/features/purchases/hooks/useEntitlement.ts
@@ -2,9 +2,16 @@ import { PACKRAT_PRO_ENTITLEMENT } from '../types';
 import { useCustomerInfo } from './useCustomerInfo';
 
 export function useEntitlement() {
-  const { data: customerInfo, isLoading, error, refetch } = useCustomerInfo();
+  const {
+    data: customerInfo,
+    isLoading,
+    isPending,
+    fetchStatus,
+    error,
+    refetch,
+  } = useCustomerInfo();
 
   const isProMember = !!customerInfo?.entitlements.active[PACKRAT_PRO_ENTITLEMENT];
 
-  return { isProMember, isLoading, error, refetch };
+  return { isProMember, isLoading, isPending, fetchStatus, error, refetch };
 }

--- a/apps/expo/features/purchases/hooks/useFeatureAccess.ts
+++ b/apps/expo/features/purchases/hooks/useFeatureAccess.ts
@@ -64,14 +64,22 @@ export interface FeatureAccessResult {
  * something that isn't in an active early-access window.
  */
 export function useFeatureAccess(key: string): FeatureAccessResult {
-  const { data: config, isLoading: configLoading } = useFeatureAccessConfig();
+  const { data: config, isLoading: configLoading, isError: configError } = useFeatureAccessConfig();
   const { isProMember, isLoading: entitlementLoading } = useEntitlement();
 
   const feature = config?.find((f) => f.key === key);
   const until = feature?.earlyAccessUntil ? new Date(feature.earlyAccessUntil) : null;
 
+  // When the config query has failed we can't tell whether this feature is in an
+  // active early-access window, so fail open only for Pro members (they'd clear
+  // any gate anyway). Non-Pro users are treated as gated so a failed fetch can't
+  // hand paid features out for free. A *successfully loaded* config that simply
+  // omits this feature is the graduated/unconfigured case and still fails open
+  // for everyone via hasFeatureAccess below.
+  const allowed = configError ? isProMember : hasFeatureAccess(feature, { hasPro: isProMember });
+
   return {
-    allowed: hasFeatureAccess(feature, { hasPro: isProMember }),
+    allowed,
     isLoading: configLoading || entitlementLoading,
     isInEarlyAccess: isInEarlyAccess(feature),
     earlyAccessUntil: until,

--- a/apps/expo/features/purchases/hooks/useFeatureAccess.ts
+++ b/apps/expo/features/purchases/hooks/useFeatureAccess.ts
@@ -64,19 +64,41 @@ export interface FeatureAccessResult {
  * something that isn't in an active early-access window.
  */
 export function useFeatureAccess(key: string): FeatureAccessResult {
-  const { data: config, isLoading: configLoading, isError: configError } = useFeatureAccessConfig();
-  const { isProMember, isLoading: entitlementLoading } = useEntitlement();
+  const {
+    data: config,
+    isPending: configPending,
+    isError: configError,
+    fetchStatus: configFetchStatus,
+  } = useFeatureAccessConfig();
+  const {
+    isProMember,
+    isPending: entitlementPending,
+    fetchStatus: entitlementFetchStatus,
+  } = useEntitlement();
 
   const feature = config?.find((f) => f.key === key);
   const until = feature?.earlyAccessUntil ? new Date(feature.earlyAccessUntil) : null;
 
-  // When the config query has failed we can't tell whether this feature is in an
-  // active early-access window, so fail open only for Pro members (they'd clear
-  // any gate anyway). Non-Pro users are treated as gated so a failed fetch can't
-  // hand paid features out for free. A *successfully loaded* config that simply
-  // omits this feature is the graduated/unconfigured case and still fails open
-  // for everyone via hasFeatureAccess below.
-  const allowed = configError ? isProMember : hasFeatureAccess(feature, { hasPro: isProMember });
+  // A query with no cached data is `pending`, but React Query's default
+  // `networkMode: 'online'` also parks it in `fetchStatus: 'paused'` when the
+  // device is offline — it never runs, never errors, and stays `pending`
+  // forever. Treating that as "loading" leaves the gate spinning indefinitely
+  // with no connection. So we only wait while a query is *actively* fetching;
+  // a pending-but-paused query is treated as settled (resolved below).
+  const configLoading = configPending && configFetchStatus !== 'paused';
+  const entitlementLoading = entitlementPending && entitlementFetchStatus !== 'paused';
+
+  // When the config query has failed or is paused offline we can't tell whether
+  // this feature is in an active early-access window, so fail open only for Pro
+  // members (they'd clear any gate anyway). Non-Pro users are treated as gated
+  // so a failed/offline fetch can't hand paid features out for free. A
+  // *successfully loaded* config that simply omits this feature is the
+  // graduated/unconfigured case and still fails open for everyone via
+  // hasFeatureAccess below.
+  const configUnavailable = configError || configFetchStatus === 'paused';
+  const allowed = configUnavailable
+    ? isProMember
+    : hasFeatureAccess(feature, { hasPro: isProMember });
 
   return {
     allowed,


### PR DESCRIPTION
## Problem

Two related bugs in the early-access gate when the feature-access config can't be fetched:

1. **Fail-open too broad.** A failed config query returned `config = undefined`; `hasFeatureAccess(undefined, …)` treats an absent feature as 'not in early access' → `true`, so any fetch failure handed paid early-access features to **everyone** for free.

2. **Infinite spinner offline.** Neither the config nor customer-info query sets `networkMode`, so React Query's default `'online'` mode **parks a data-less query in `fetchStatus: 'paused'`** when the device is offline. It never runs, never errors, and stays `pending` — so `isLoading` was `true` forever and `EarlyAccessGate` spun indefinitely with no connection.

## Fix

- Treat a **pending-but-paused** query as *settled*, not loading (`isPending && fetchStatus !== 'paused'`), so the gate stops spinning offline.
- Treat a config query that is **errored or paused** as 'config unavailable' and fail open **only for Pro members**; non-Pro users are gated and see the paywall. A *successfully loaded* config that merely omits a feature is still the graduated/unconfigured case and fails open for everyone via `hasFeatureAccess`.
- Surfaces `isPending`/`fetchStatus` through `useEntitlement`.

Files: `useFeatureAccess.ts`, `useEntitlement.ts`.

## Notes

- Offline + non-Pro now attempts the paywall; RevenueCat can't load offerings offline and returns `PAYWALL_RESULT.ERROR`, which the gate already handles with `router.back()`, so the user isn't trapped.
- RevenueCat's SDK serves `CustomerInfo` from local cache offline, so the entitlement query generally resolves rather than pausing; the config (API) query is the one that pauses.
- No unit test added: the expo test harness is pure-TS/Node only and can't render these RevenueCat/React Query hooks; the pure resolver in `packages/config` is unchanged.