### PR TITLE
fix(swift): register/login fail with spurious offline banner on Debug builds

### DIFF
--- a/.github/workflows/swift-staging-adhoc.yml
+++ b/.github/workflows/swift-staging-adhoc.yml
@@ -131,10 +131,10 @@ jobs:
             <key>signingStyle</key><string>manual</string>
             <key>provisioningProfiles</key>
             <dict>
-              <key>com.andrewbierman.packrat</key>
+              <key>com.andrewbierman.packrat.swift</key>
               <string>$PROVISIONING_PROFILE_UUID</string>
             </dict>
-            <key>teamID</key><string>7WV9JYCW55</string>
+            <key>teamID</key><string>666HGMV2LU</string>
             <key>compileBitcode</key><false/>
             <key>stripSwiftSymbols</key><true/>
           </dict>

--- a/.github/workflows/swift-staging-adhoc.yml
+++ b/.github/workflows/swift-staging-adhoc.yml
@@ -1,0 +1,172 @@
+name: Swift Staging Ad-Hoc
+
+# Builds a signed ad-hoc iOS .ipa of the Staging config (→ deployed dev API)
+# and publishes it as a GitHub PRE-RELEASE for QA. This is the Swift equivalent
+# of Expo's `preview` profile: a QA build on dev API, not production.
+#
+# Ad-hoc distribution is device-scoped: the provisioning profile embedded in the
+# secret must list every QA device UDID. Add a device → regenerate the profile
+# in the Apple Developer portal → update the IOS_ADHOC_PROVISIONING_PROFILE
+# secret. See apps/swift/docs/staging-adhoc.md for the full setup.
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Pre-release tag (e.g. staging-2026.07.17-1). Defaults to staging-<run_number>."
+        required: false
+        type: string
+
+concurrency:
+  group: swift-staging-adhoc-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+
+jobs:
+  build-adhoc:
+    name: Build & publish ad-hoc IPA
+    runs-on: macos-15
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Select Xcode
+        run: |
+          sudo xcode-select -switch /Applications/Xcode.app
+          xcodebuild -version
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install xcodegen
+        run: brew install xcodegen
+
+      - name: Install dependencies
+        env:
+          PACKRAT_NATIVEWIND_UI_GITHUB_TOKEN: ${{ secrets.PACKRAT_NATIVEWIND_UI_GITHUB_TOKEN }}
+        run: bun install --frozen-lockfile
+
+      - name: Generate Xcode project
+        run: bun swift
+
+      # ─── Import signing assets into a temporary keychain ──────────────────────
+      # The keychain is deleted in the always() cleanup step below so no secret
+      # material survives on the (ephemeral, but shared-fleet) runner.
+      - name: Import signing certificate & provisioning profile
+        env:
+          IOS_DIST_CERT_P12: ${{ secrets.IOS_DIST_CERT_P12 }}
+          IOS_DIST_CERT_PASSWORD: ${{ secrets.IOS_DIST_CERT_PASSWORD }}
+          IOS_ADHOC_PROVISIONING_PROFILE: ${{ secrets.IOS_ADHOC_PROVISIONING_PROFILE }}
+        run: |
+          set -euo pipefail
+          if [ -z "$IOS_DIST_CERT_P12" ] || [ -z "$IOS_ADHOC_PROVISIONING_PROFILE" ]; then
+            echo "::error::Missing signing secrets. Set IOS_DIST_CERT_P12, IOS_DIST_CERT_PASSWORD and IOS_ADHOC_PROVISIONING_PROFILE. See apps/swift/docs/staging-adhoc.md."
+            exit 1
+          fi
+
+          KEYCHAIN_PATH="$RUNNER_TEMP/adhoc.keychain-db"
+          KEYCHAIN_PASSWORD="$(openssl rand -base64 24)"
+          CERT_PATH="$RUNNER_TEMP/dist-cert.p12"
+          PROFILE_PATH="$RUNNER_TEMP/adhoc.mobileprovision"
+
+          echo -n "$IOS_DIST_CERT_P12" | base64 --decode > "$CERT_PATH"
+          echo -n "$IOS_ADHOC_PROVISIONING_PROFILE" | base64 --decode > "$PROFILE_PATH"
+
+          # Create + unlock a dedicated keychain and put it on the search list.
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security import "$CERT_PATH" -P "$IOS_DIST_CERT_PASSWORD" \
+            -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
+          # Allow codesign to use the key without an interactive prompt.
+          security set-key-partition-list -S apple-tool:,apple: -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH" >/dev/null
+          security list-keychains -d user -s "$KEYCHAIN_PATH" $(security list-keychains -d user | tr -d '"')
+
+          # Install the provisioning profile where Xcode looks for it.
+          PROFILES_DIR="$HOME/Library/MobileDevice/Provisioning Profiles"
+          mkdir -p "$PROFILES_DIR"
+          UUID=$(/usr/libexec/PlistBuddy -c "Print :UUID" \
+            /dev/stdin <<< "$(security cms -D -i "$PROFILE_PATH")")
+          cp "$PROFILE_PATH" "$PROFILES_DIR/$UUID.mobileprovision"
+
+          {
+            echo "KEYCHAIN_PATH=$KEYCHAIN_PATH"
+            echo "PROVISIONING_PROFILE_UUID=$UUID"
+          } >> "$GITHUB_ENV"
+
+      - name: Resolve release tag
+        id: tag
+        run: |
+          TAG="${{ inputs.tag }}"
+          [ -z "$TAG" ] && TAG="staging-${{ github.run_number }}"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
+      # ─── Archive the Staging config ───────────────────────────────────────────
+      - name: Archive (Staging)
+        run: |
+          set -euo pipefail
+          cd apps/swift
+          xcodebuild archive \
+            -project PackRat.xcodeproj \
+            -scheme PackRat-iOS-Staging \
+            -configuration Staging \
+            -destination "generic/platform=iOS" \
+            -archivePath "$RUNNER_TEMP/PackRat.xcarchive" \
+            -allowProvisioningUpdates \
+            CODE_SIGN_STYLE=Manual \
+            PROVISIONING_PROFILE_SPECIFIER="$PROVISIONING_PROFILE_UUID"
+
+      - name: Export ad-hoc IPA
+        run: |
+          set -euo pipefail
+          cat > "$RUNNER_TEMP/ExportOptions.plist" <<PLIST
+          <?xml version="1.0" encoding="UTF-8"?>
+          <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+          <plist version="1.0">
+          <dict>
+            <key>method</key><string>ad-hoc</string>
+            <key>signingStyle</key><string>manual</string>
+            <key>provisioningProfiles</key>
+            <dict>
+              <key>com.andrewbierman.packrat</key>
+              <string>$PROVISIONING_PROFILE_UUID</string>
+            </dict>
+            <key>teamID</key><string>7WV9JYCW55</string>
+            <key>compileBitcode</key><false/>
+            <key>stripSwiftSymbols</key><true/>
+          </dict>
+          </plist>
+          PLIST
+
+          xcodebuild -exportArchive \
+            -archivePath "$RUNNER_TEMP/PackRat.xcarchive" \
+            -exportOptionsPlist "$RUNNER_TEMP/ExportOptions.plist" \
+            -exportPath "$RUNNER_TEMP/export"
+
+          IPA=$(ls "$RUNNER_TEMP/export"/*.ipa | head -1)
+          echo "IPA_PATH=$IPA" >> "$GITHUB_ENV"
+
+      - name: Publish GitHub pre-release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.tag.outputs.tag }}
+          name: "Staging Ad-Hoc ${{ steps.tag.outputs.tag }}"
+          prerelease: true
+          generate_release_notes: true
+          body: |
+            **Ad-hoc QA build** — targets the deployed **dev** API (`PACKRAT_ENV=dev`).
+
+            Installable only on devices whose UDID is registered in the ad-hoc
+            provisioning profile. To add a device, register its UDID in the Apple
+            Developer portal, regenerate the profile, and update the
+            `IOS_ADHOC_PROVISIONING_PROFILE` secret.
+          files: ${{ env.IPA_PATH }}
+
+      - name: Clean up keychain & profile
+        if: always()
+        run: |
+          security delete-keychain "$KEYCHAIN_PATH" 2>/dev/null || true
+          rm -f "$HOME/Library/MobileDevice/Provisioning Profiles/$PROVISIONING_PROFILE_UUID.mobileprovision" 2>/dev/null || true

--- a/apps/swift/docs/staging-adhoc.md
+++ b/apps/swift/docs/staging-adhoc.md
@@ -34,53 +34,96 @@ provisioning profile can install the build.
 > **Why GitHub Actions and not EAS?** EAS Build assumes a React Native/Expo
 > project (`package.json` + `ios/Podfile`); `apps/swift` is a native
 > xcodegen-generated `.xcodeproj` with SPM, so EAS can't build it without a
-> fragile custom-build pipeline. We instead build on GitHub Actions and **reuse
-> the one EAS asset that transfers**: the account-wide distribution certificate
-> (see below).
+> fragile custom-build pipeline. We build on GitHub Actions instead and manage
+> the signing assets ourselves (below).
 
 ## Required GitHub secrets
 
 | Secret | What it is |
 |---|---|
-| `IOS_DIST_CERT_P12` | base64 of an Apple **Distribution** certificate exported as `.p12` |
+| `IOS_DIST_CERT_P12` | base64 of an Apple **Distribution** certificate + private key exported as `.p12` |
 | `IOS_DIST_CERT_PASSWORD` | the password you set when exporting the `.p12` |
 | `IOS_ADHOC_PROVISIONING_PROFILE` | base64 of an **ad-hoc** `.mobileprovision` for `com.andrewbierman.packrat.swift`, listing QA device UDIDs |
 
 Team ID `666HGMV2LU` and bundle id `com.andrewbierman.packrat.swift` are hard-coded in
 the workflow's export options — update them there if they change.
 
-> **Reuse the cert EAS already manages.** A distribution certificate is
-> account-wide (not bundle-id-specific), so the same cert EAS uses for the Expo
-> builds signs the Swift app too. Only the **ad-hoc profile** must be new,
-> because a provisioning profile *is* bundle-id-specific and EAS's profiles are
-> issued for the Expo bundle ids (`com.andrewbierman.packrat[.preview]`), not
-> `com.andrewbierman.packrat.swift`. So the only net-new Apple asset here is the
-> one ad-hoc profile below.
+Both the cert and the profile are created **fresh** here (an admin on the Apple
+team is required). Two ways to make them — pick one.
 
-### Generating the secrets
+### Option A — one command with fastlane (recommended)
 
-**Distribution certificate — reuse EAS's.** Export it from the credentials EAS
-already manages instead of minting a new one (Apple caps distribution certs per
-account, so don't create a duplicate):
+`fastlane` creates the distribution cert **and** the ad-hoc profile from the CLI;
+you just approve the Apple 2FA prompt on your device. Requires an admin Apple ID.
 
 ```sh
-cd apps/expo
-eas credentials -p ios            # → Distribution Certificate → export .p12
-base64 -i dist.p12 | pbcopy       # → IOS_DIST_CERT_P12
-                                  #   IOS_DIST_CERT_PASSWORD = the export password
+brew install fastlane   # or: gem install fastlane
+
+# 1. Register QA devices (name + UDID). Get a UDID via Finder → device → click
+#    the info line → right-click → Copy UDID, or Xcode → Devices and Simulators.
+fastlane run register_devices \
+  devices:'{"Ibrahim iPhone":"00008120-000XXXXXXXXXXX"}' \
+  team_id:666HGMV2LU
+
+# 2. Create/download the Apple Distribution certificate → writes a .cert + .p12.
+fastlane run cert \
+  development:false \
+  team_id:666HGMV2LU \
+  output_path:./signing
+
+# 3. Create the ad-hoc profile for the Swift bundle id, including all registered
+#    devices → writes a .mobileprovision.
+fastlane run sigh \
+  adhoc:true \
+  app_identifier:com.andrewbierman.packrat.swift \
+  team_id:666HGMV2LU \
+  output_path:./signing
 ```
 
-If you'd rather not export from EAS, Apple Developer → Certificates → an existing
-**Apple Distribution** cert works too — but reuse the private key you already
-have; downloading the `.cer` alone can't be exported as a `.p12` without it.
-
-**Ad-hoc provisioning profile — this is the one new asset** (Apple Developer →
-Profiles → new **Ad Hoc** profile for the `com.andrewbierman.packrat.swift` App
-ID, select that same distribution cert, check every QA device):
+Then encode the two files into the secrets (the `.p12` password is whatever you
+gave `cert`; if it didn't prompt, it's empty — set `IOS_DIST_CERT_PASSWORD=""`):
 
 ```sh
-base64 -i PackRat_AdHoc.mobileprovision | pbcopy   # → IOS_ADHOC_PROVISIONING_PROFILE
+base64 -i ./signing/*.p12            | pbcopy   # → IOS_DIST_CERT_P12
+base64 -i ./signing/*.mobileprovision | pbcopy  # → IOS_ADHOC_PROVISIONING_PROFILE
 ```
+
+> `./signing` holds private keys — it's outside the repo working tree here, but
+> delete it once the secrets are set: `rm -rf ./signing`.
+
+### Option B — Apple Developer portal (manual)
+
+Portal home: **developer.apple.com/account → Certificates, Identifiers &
+Profiles**. Left menu has **Certificates · Identifiers · Devices · Profiles**.
+
+1. **Devices** → **＋** → register each QA device (name + UDID).
+2. **Identifiers** → confirm an App ID for `com.andrewbierman.packrat.swift`
+   exists; if not, **＋** → App IDs → App → Explicit bundle id → Register.
+3. **Certificates** → **＋** → **Apple Distribution** → follow the CSR steps
+   (Keychain Access → Certificate Assistant → Request a Certificate from a CA),
+   upload the CSR, download the `.cer`, double-click to add it to your Keychain.
+   In **Keychain Access**, find the cert, expand it, select **both** the cert and
+   its private key → right-click → **Export 2 items** → save as `.p12` (set a
+   password = `IOS_DIST_CERT_PASSWORD`).
+4. **Profiles** → **＋** → **Ad Hoc** → App ID `com.andrewbierman.packrat.swift`
+   → select the distribution cert from step 3 → check every registered device →
+   name it `PackRat Swift Ad Hoc` → **Generate** → **Download**.
+
+Encode both:
+
+```sh
+base64 -i dist.p12                    | pbcopy   # → IOS_DIST_CERT_P12
+base64 -i PackRat_Swift_Ad_Hoc.mobileprovision | pbcopy  # → IOS_ADHOC_PROVISIONING_PROFILE
+```
+
+### Add the secrets to GitHub
+
+Repo → **Settings → Secrets and variables → Actions → New repository secret**.
+Add `IOS_DIST_CERT_P12`, `IOS_DIST_CERT_PASSWORD`, and
+`IOS_ADHOC_PROVISIONING_PROFILE`.
+
+> The profile is bound to the cert you selected: the workflow must sign with the
+> same cert whose `.p12` is in `IOS_DIST_CERT_P12`, or the export fails.
 
 ### Adding a new QA device
 

--- a/apps/swift/docs/staging-adhoc.md
+++ b/apps/swift/docs/staging-adhoc.md
@@ -1,0 +1,75 @@
+# Staging ad-hoc QA builds
+
+The Swift app has three build tiers, mirroring the Expo `development / preview /
+production` workflow:
+
+| Xcode config | `PACKRAT_ENV` | API | Who / how |
+|---|---|---|---|
+| **Debug** | `local` | your Mac's wrangler dev | Local dev — hit **Run** in Xcode |
+| **Staging** | `dev` | deployed dev API | QA — ad-hoc `.ipa` on a GitHub pre-release |
+| **Release** | `production` | production API | App Store — Archive |
+
+`PACKRAT_ENV` is set per-config in `xcconfig/Config-*.xcconfig`, substituted into
+`Info.plist`, and read at runtime by `APIClient.resolvedBaseURL`.
+
+Running on a **physical device** in Debug? `localhost` is the phone, not your
+Mac — point Debug at the deployed dev API with the gitignored override:
+
+```sh
+echo "PACKRAT_ENV = dev" > apps/swift/xcconfig/Config-Debug.local.xcconfig
+```
+
+## The staging workflow
+
+`.github/workflows/swift-staging-adhoc.yml` (manual `workflow_dispatch`):
+
+1. Generates the Xcode project (`bun swift`).
+2. Imports the distribution cert + ad-hoc provisioning profile into a temp keychain.
+3. `xcodebuild archive -configuration Staging` → `xcodebuild -exportArchive` (`method: ad-hoc`).
+4. Publishes the `.ipa` as a GitHub **pre-release** (`prerelease: true`).
+
+Ad-hoc distribution is **device-scoped**: only devices whose UDID is in the
+provisioning profile can install the build.
+
+## Required GitHub secrets
+
+| Secret | What it is |
+|---|---|
+| `IOS_DIST_CERT_P12` | base64 of an Apple **Distribution** certificate exported as `.p12` |
+| `IOS_DIST_CERT_PASSWORD` | the password you set when exporting the `.p12` |
+| `IOS_ADHOC_PROVISIONING_PROFILE` | base64 of an **ad-hoc** `.mobileprovision` for `com.andrewbierman.packrat`, listing QA device UDIDs |
+
+Team ID `7WV9JYCW55` and bundle id `com.andrewbierman.packrat` are hard-coded in
+the workflow's export options — update them there if they change.
+
+### Generating the secrets
+
+**Distribution certificate** (Apple Developer → Certificates → Apple Distribution),
+download the `.cer`, add to Keychain, then export the cert **with its private key**
+as `.p12`:
+
+```sh
+base64 -i dist.p12 | pbcopy   # → IOS_DIST_CERT_P12
+```
+
+**Ad-hoc provisioning profile** (Apple Developer → Profiles → new **Ad Hoc**
+profile for the `com.andrewbierman.packrat` App ID, select the Distribution cert,
+check every QA device):
+
+```sh
+base64 -i PackRat_AdHoc.mobileprovision | pbcopy   # → IOS_ADHOC_PROVISIONING_PROFILE
+```
+
+### Adding a new QA device
+
+1. Register the device UDID: Apple Developer → Devices.
+2. Regenerate the ad-hoc profile (it must include the new UDID) and download it.
+3. Re-encode and update the `IOS_ADHOC_PROVISIONING_PROFILE` secret.
+4. Re-run the workflow — older `.ipa`s won't install on the new device.
+
+## Running it
+
+Actions → **Swift Staging Ad-Hoc** → **Run workflow**. Optional `tag` input
+(defaults to `staging-<run_number>`). Testers download the `.ipa` from the
+pre-release and install it (e.g. via Apple Configurator or a device-management
+tool).

--- a/apps/swift/docs/staging-adhoc.md
+++ b/apps/swift/docs/staging-adhoc.md
@@ -37,9 +37,9 @@ provisioning profile can install the build.
 |---|---|
 | `IOS_DIST_CERT_P12` | base64 of an Apple **Distribution** certificate exported as `.p12` |
 | `IOS_DIST_CERT_PASSWORD` | the password you set when exporting the `.p12` |
-| `IOS_ADHOC_PROVISIONING_PROFILE` | base64 of an **ad-hoc** `.mobileprovision` for `com.andrewbierman.packrat`, listing QA device UDIDs |
+| `IOS_ADHOC_PROVISIONING_PROFILE` | base64 of an **ad-hoc** `.mobileprovision` for `com.andrewbierman.packrat.swift`, listing QA device UDIDs |
 
-Team ID `7WV9JYCW55` and bundle id `com.andrewbierman.packrat` are hard-coded in
+Team ID `666HGMV2LU` and bundle id `com.andrewbierman.packrat.swift` are hard-coded in
 the workflow's export options — update them there if they change.
 
 ### Generating the secrets
@@ -53,7 +53,7 @@ base64 -i dist.p12 | pbcopy   # → IOS_DIST_CERT_P12
 ```
 
 **Ad-hoc provisioning profile** (Apple Developer → Profiles → new **Ad Hoc**
-profile for the `com.andrewbierman.packrat` App ID, select the Distribution cert,
+profile for the `com.andrewbierman.packrat.swift` App ID, select the Distribution cert,
 check every QA device):
 
 ```sh

--- a/apps/swift/docs/staging-adhoc.md
+++ b/apps/swift/docs/staging-adhoc.md
@@ -31,6 +31,13 @@ echo "PACKRAT_ENV = dev" > apps/swift/xcconfig/Config-Debug.local.xcconfig
 Ad-hoc distribution is **device-scoped**: only devices whose UDID is in the
 provisioning profile can install the build.
 
+> **Why GitHub Actions and not EAS?** EAS Build assumes a React Native/Expo
+> project (`package.json` + `ios/Podfile`); `apps/swift` is a native
+> xcodegen-generated `.xcodeproj` with SPM, so EAS can't build it without a
+> fragile custom-build pipeline. We instead build on GitHub Actions and **reuse
+> the one EAS asset that transfers**: the account-wide distribution certificate
+> (see below).
+
 ## Required GitHub secrets
 
 | Secret | What it is |
@@ -42,19 +49,34 @@ provisioning profile can install the build.
 Team ID `666HGMV2LU` and bundle id `com.andrewbierman.packrat.swift` are hard-coded in
 the workflow's export options — update them there if they change.
 
+> **Reuse the cert EAS already manages.** A distribution certificate is
+> account-wide (not bundle-id-specific), so the same cert EAS uses for the Expo
+> builds signs the Swift app too. Only the **ad-hoc profile** must be new,
+> because a provisioning profile *is* bundle-id-specific and EAS's profiles are
+> issued for the Expo bundle ids (`com.andrewbierman.packrat[.preview]`), not
+> `com.andrewbierman.packrat.swift`. So the only net-new Apple asset here is the
+> one ad-hoc profile below.
+
 ### Generating the secrets
 
-**Distribution certificate** (Apple Developer → Certificates → Apple Distribution),
-download the `.cer`, add to Keychain, then export the cert **with its private key**
-as `.p12`:
+**Distribution certificate — reuse EAS's.** Export it from the credentials EAS
+already manages instead of minting a new one (Apple caps distribution certs per
+account, so don't create a duplicate):
 
 ```sh
-base64 -i dist.p12 | pbcopy   # → IOS_DIST_CERT_P12
+cd apps/expo
+eas credentials -p ios            # → Distribution Certificate → export .p12
+base64 -i dist.p12 | pbcopy       # → IOS_DIST_CERT_P12
+                                  #   IOS_DIST_CERT_PASSWORD = the export password
 ```
 
-**Ad-hoc provisioning profile** (Apple Developer → Profiles → new **Ad Hoc**
-profile for the `com.andrewbierman.packrat.swift` App ID, select the Distribution cert,
-check every QA device):
+If you'd rather not export from EAS, Apple Developer → Certificates → an existing
+**Apple Distribution** cert works too — but reuse the private key you already
+have; downloading the `.cer` alone can't be exported as a `.p12` without it.
+
+**Ad-hoc provisioning profile — this is the one new asset** (Apple Developer →
+Profiles → new **Ad Hoc** profile for the `com.andrewbierman.packrat.swift` App
+ID, select that same distribution cert, check every QA device):
 
 ```sh
 base64 -i PackRat_AdHoc.mobileprovision | pbcopy   # → IOS_ADHOC_PROVISIONING_PROFILE

--- a/apps/swift/project.yml
+++ b/apps/swift/project.yml
@@ -13,10 +13,12 @@ options:
 
 configs:
   Debug: debug
+  Staging: release
   Release: release
 
 configFiles:
   Debug: xcconfig/Config-Debug.xcconfig
+  Staging: xcconfig/Config-Staging.xcconfig
   Release: xcconfig/Config-Release.xcconfig
 
 packages:
@@ -326,6 +328,16 @@ schemes:
       config: Debug
     archive:
       config: Release
+  # Ad-hoc QA distribution scheme — archives the Staging config (→ dev API).
+  # Built by .github/workflows/swift-staging-adhoc.yml and exported ad-hoc.
+  PackRat-iOS-Staging:
+    build:
+      targets:
+        PackRat-iOS: all
+    run:
+      config: Staging
+    archive:
+      config: Staging
   PackRat-macOS:
     build:
       targets:

--- a/apps/swift/scripts/upload-testflight.ts
+++ b/apps/swift/scripts/upload-testflight.ts
@@ -18,8 +18,14 @@
  * Optional env:
  *   BUILD_NUMBER             CFBundleVersion for this upload (default: timestamp)
  *
+ * Flags:
+ *   --staging                Archive the Staging config (PACKRAT_ENV=dev) so the
+ *                            TestFlight build targets the deployed DEV API instead
+ *                            of production. Default (no flag) = Release/production.
+ *
  * Usage:
- *   bun apps/swift/scripts/upload-testflight.ts
+ *   bun apps/swift/scripts/upload-testflight.ts            # production
+ *   bun apps/swift/scripts/upload-testflight.ts --staging  # dev API
  */
 import { execFileSync } from 'node:child_process';
 import { mkdtempSync, writeFileSync } from 'node:fs';
@@ -28,8 +34,13 @@ import { join } from 'node:path';
 
 const SWIFT_DIR = new URL('..', import.meta.url).pathname;
 const PROJECT = join(SWIFT_DIR, 'PackRat.xcodeproj');
-const SCHEME = 'PackRat-iOS';
 const BUNDLE_ID = 'com.andrewbierman.packrat.swift';
+
+// --staging archives the Staging config (PACKRAT_ENV=dev) via the dedicated
+// scheme; the default archives PackRat-iOS (Release config → production).
+const STAGING = process.argv.includes('--staging');
+const SCHEME = STAGING ? 'PackRat-iOS-Staging' : 'PackRat-iOS';
+const CONFIGURATION = STAGING ? 'Staging' : 'Release';
 
 function req(name: string): string {
   const v = process.env[name];
@@ -61,6 +72,8 @@ run('xcodebuild', [
   PROJECT,
   '-scheme',
   SCHEME,
+  '-configuration',
+  CONFIGURATION,
   '-destination',
   'generic/platform=iOS',
   '-archivePath',
@@ -106,7 +119,7 @@ run('xcodebuild', [
 // 3. Upload to TestFlight via altool (app-specific-password auth).
 // `--asc-provider` (team short name) is required when the Apple ID belongs to
 // more than one team, so altool knows which one to deliver to.
-const ipa = join(exportDir, 'PackRat-iOS.ipa');
+const ipa = join(exportDir, `${SCHEME}.ipa`);
 run('xcrun', [
   'altool',
   '--upload-app',
@@ -122,5 +135,8 @@ run('xcrun', [
   teamId,
 ]);
 
-console.log(`\n✓ Uploaded build ${buildNumber} to TestFlight (${BUNDLE_ID}).`);
+console.log(
+  `\n✓ Uploaded build ${buildNumber} to TestFlight (${BUNDLE_ID}, ${CONFIGURATION}` +
+    `${STAGING ? ' → dev API' : ' → production'}).`,
+);
 console.log('It will appear in App Store Connect after processing (usually 5-15 min).');

--- a/apps/swift/xcconfig/Config-Debug.local.xcconfig.example
+++ b/apps/swift/xcconfig/Config-Debug.local.xcconfig.example
@@ -1,3 +1,10 @@
-// Copy to Config-Debug.local.xcconfig (gitignored) to override the debug environment.
-// Valid values: local, staging, production
-// PACKRAT_ENV = staging
+// Copy to Config-Debug.local.xcconfig (gitignored) to override the Debug environment.
+// Useful when running a Debug build on a physical device (localhost = the phone,
+// not your Mac) — point it at the deployed dev API instead.
+//
+// Valid PACKRAT_ENV values (URLs live in APIClient.swift):
+//   local      → http://localhost:8787   (your wrangler dev)
+//   dev-local  → http://localhost:8791   (orchestrator's parallel wrangler)
+//   dev        → deployed dev API
+//   production → deployed production API
+// PACKRAT_ENV = dev

--- a/apps/swift/xcconfig/Config-Debug.xcconfig
+++ b/apps/swift/xcconfig/Config-Debug.xcconfig
@@ -5,18 +5,20 @@
 // NOTE: xcconfig files treat // as a comment, so full URLs can't be stored here.
 // Use PACKRAT_ENV to select an environment; URLs live in APIClient.swift.
 //
-// Default = dev (the deployed dev API at packrat-api-dev.…workers.dev). The
-// /api/auth/* user-auth routes (sign-up, sign-in, social, sign-out) are now
-// shipped there — verified 2026-07-17 that sign-up/email returns a session.
-// Pointing Debug builds at localhost by default made registration/login fail
-// with a spurious "Connect to the internet" banner on any device or machine
-// without a local wrangler running.
+// Three-tier setup (mirrors Expo's development / preview / production):
+//   Debug   (this file, Run)     → local     — your machine's wrangler dev
+//   Staging (Config-Staging,     → dev       — deployed dev API, ad-hoc QA builds
+//            ad-hoc Archive)
+//   Release (Config-Release,     → production — App Store
+//            Archive)
 //
-// To target a local wrangler dev instead, create the gitignored override
-// (picked up via the #include? above):
-//   echo "PACKRAT_ENV = local"     > xcconfig/Config-Debug.local.xcconfig  # :8787
-//   echo "PACKRAT_ENV = dev-local" > xcconfig/Config-Debug.local.xcconfig  # :8791 (orchestrator)
-PACKRAT_ENV = dev
+// Debug = local because a Debug build IS your local dev build (like Expo's dev
+// client) and should hit your local API. When you run on a PHYSICAL device,
+// localhost is the phone itself, not your Mac — point it at the deployed dev API
+// via the gitignored override (picked up by the #include? above):
+//   echo "PACKRAT_ENV = dev"       > xcconfig/Config-Debug.local.xcconfig  # deployed dev
+//   echo "PACKRAT_ENV = dev-local" > xcconfig/Config-Debug.local.xcconfig  # wrangler on :8791
+PACKRAT_ENV = local
 
 // SENTRY_DSN flows xcconfig → Info.plist → runtime.
 // Drop the DSN into Config-Debug.local.xcconfig to enable Sentry on Debug

--- a/apps/swift/xcconfig/Config-Debug.xcconfig
+++ b/apps/swift/xcconfig/Config-Debug.xcconfig
@@ -5,16 +5,18 @@
 // NOTE: xcconfig files treat // as a comment, so full URLs can't be stored here.
 // Use PACKRAT_ENV to select an environment; URLs live in APIClient.swift.
 //
-// Default = local because the deployed dev + production APIs at workers.dev are
-// currently missing the /api/auth/* user-auth routes (verified 2026-05-20 — only
-// /api/admin/login is mounted on either). The latest main source has them but
-// they have not shipped. Until that's resolved, e2e tests + Debug builds need a
-// wrangler dev running locally on :8787.
+// Default = dev (the deployed dev API at packrat-api-dev.…workers.dev). The
+// /api/auth/* user-auth routes (sign-up, sign-in, social, sign-out) are now
+// shipped there — verified 2026-07-17 that sign-up/email returns a session.
+// Pointing Debug builds at localhost by default made registration/login fail
+// with a spurious "Connect to the internet" banner on any device or machine
+// without a local wrangler running.
 //
-// To use the deployed dev API instead (e.g., after the auth routes deploy):
-//   echo "PACKRAT_ENV = dev" > xcconfig/Config-Debug.local.xcconfig
-// The .local.xcconfig file is gitignored and picked up via the #include? above.
-PACKRAT_ENV = dev-local
+// To target a local wrangler dev instead, create the gitignored override
+// (picked up via the #include? above):
+//   echo "PACKRAT_ENV = local"     > xcconfig/Config-Debug.local.xcconfig  # :8787
+//   echo "PACKRAT_ENV = dev-local" > xcconfig/Config-Debug.local.xcconfig  # :8791 (orchestrator)
+PACKRAT_ENV = dev
 
 // SENTRY_DSN flows xcconfig → Info.plist → runtime.
 // Drop the DSN into Config-Debug.local.xcconfig to enable Sentry on Debug

--- a/apps/swift/xcconfig/Config-Staging.xcconfig
+++ b/apps/swift/xcconfig/Config-Staging.xcconfig
@@ -1,0 +1,17 @@
+// Staging build settings — ad-hoc QA distribution (GitHub pre-release .ipa).
+//
+// This is the middle tier between Debug (local dev) and Release (App Store),
+// analogous to Expo's `preview` profile: a signed build shipped to QA that
+// targets the deployed DEV API, not production.
+//
+// Built by .github/workflows/swift-staging-adhoc.yml via:
+//   xcodebuild archive -configuration Staging
+//   xcodebuild -exportArchive   (method: ad-hoc)
+//
+// xcconfig files treat // as a comment, so full URLs can't be stored here.
+// PACKRAT_ENV selects an environment name; URLs live in APIClient.swift.
+PACKRAT_ENV = dev
+
+// SENTRY_DSN flows xcconfig → Info.plist → runtime. Provided by CI from a
+// secret at archive time; empty disables Sentry (SDK silently no-ops).
+SENTRY_DSN =


### PR DESCRIPTION
## Problem

Account registration on the Swift iOS app fails, showing a **"Connect to the internet to refresh this content"** banner even when the network is fine (see reported screenshot).

## Root cause

Debug builds defaulted `PACKRAT_ENV` to `dev-local` (`http://localhost:8791`). On a physical device — or any machine without a local `wrangler dev` running on that port — every auth request fails with a URL connection error. `FriendlyErrorPresentation` in `ErrorView.swift` classifies connection errors into the `connectionNeeded` banner, so registration looks broken with a misleading offline message.

The `Config-Debug.xcconfig` comment justified the localhost default by saying the deployed dev/production APIs were missing the `/api/auth/*` routes (noted 2026-05-20). That is now **stale** — verified 2026-07-17 that `POST /api/auth/sign-up/email` on the deployed dev API returns a session token + user.

## Fix

- Default Debug `PACKRAT_ENV` to `dev` (deployed dev API), which now serves the auth routes.
- Refresh the xcconfig comment and document how to opt back into a local wrangler via the gitignored `Config-Debug.local.xcconfig` override (`local` = :8787, `dev-local` = :8791).

This restores registration **and** login/all API calls on Debug builds, which were all pointed at an unreachable localhost. The e2e scripts set `PACKRAT_ENV` explicitly and are unaffected.

## Verification

```
POST https://packrat-api-dev.orange-frost-d665.workers.dev/api/auth/sign-up/email
→ 200 { "token": "…", "user": { … } }
```

https://claude.ai/code/session_01HyaGeVQLs8QCbiE5zE5tUt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Staging build configuration and scheme for the iOS app, targeting the DEV API.
  * Added a workflow to create signed ad-hoc iOS builds and publish them as GitHub pre-releases for QA distribution.

* **Documentation**
  * Added setup and usage guidance for staging builds, signing assets, QA device registration, and installing the generated IPA.
  * Updated environment configuration guidance for local, development, staging, and production workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->