### PR TITLE
feat(swift): iPhone Profile tab + Settings (units, version, clear data)

### DIFF
--- a/apps/swift/Sources/PackRat/Features/Preferences/PreferencesView.swift
+++ b/apps/swift/Sources/PackRat/Features/Preferences/PreferencesView.swift
@@ -29,6 +29,8 @@ struct PreferencesView: View {
     @AppStorage("speedUnit") private var speedUnit: SpeedUnit = .mph
     @AppStorage("apiBaseURL") private var apiBaseURL: String = ""
 
+    @State private var showingClearDataConfirm = false
+
     var body: some View {
         #if os(macOS)
         // Fixed-size tabbed layout for the macOS Settings window (Cmd+,).
@@ -46,6 +48,7 @@ struct PreferencesView: View {
         }
         .padding(20)
         .frame(width: 460, height: 320)
+        .clearDataConfirmation(isPresented: $showingClearDataConfirm, onConfirm: clearAppData)
         #else
         // iOS: a single scrolling form pushed onto a navigation stack. The
         // macOS tabs become grouped sections so all settings stay reachable
@@ -62,7 +65,19 @@ struct PreferencesView: View {
             aboutSection
         }
         .navigationTitle("Settings")
+        .clearDataConfirmation(isPresented: $showingClearDataConfirm, onConfirm: clearAppData)
         #endif
+    }
+
+    /// Clears cached data (URL/image caches) and locally stored preference
+    /// defaults. Auth lives in the Keychain, so the user stays signed in —
+    /// mirrors the Expo Settings "Clear App Data" behavior.
+    private func clearAppData() {
+        URLCache.shared.removeAllCachedResponses()
+        let defaults = UserDefaults.standard
+        for key in ["defaultAppWeightUnit", "preferMetric", "temperatureUnit", "speedUnit", "apiBaseURL", "accentColorName"] {
+            defaults.removeObject(forKey: key)
+        }
     }
 
     #if os(macOS)
@@ -132,28 +147,41 @@ struct PreferencesView: View {
 
     @ViewBuilder
     private var advancedSection: some View {
-        Section("API Server") {
-            HStack {
-                ForEach(["local", "dev", "production"], id: \.self) { env in
-                    if let url = APIClient.environments[env] {
-                        Button(env.capitalized) {
-                            apiBaseURL = url == apiBaseURL ? "" : url
+        // Developer-only backend controls. Hidden entirely in production so end
+        // users can't repoint the app at a dev/local API or wipe their data.
+        if APIClient.isNonProduction {
+            Section("API Server") {
+                HStack {
+                    ForEach(["local", "dev", "production"], id: \.self) { env in
+                        if let url = APIClient.environments[env] {
+                            Button(env.capitalized) {
+                                apiBaseURL = url == apiBaseURL ? "" : url
+                            }
+                            .buttonStyle(.bordered)
+                            .tint(effectiveURL == url ? .accentColor : nil)
                         }
-                        .buttonStyle(.bordered)
-                        .tint(effectiveURL == url ? .accentColor : nil)
                     }
                 }
-            }
-            TextField("Custom URL (overrides build default)", text: $apiBaseURL)
-                .textFieldStyle(.roundedBorder)
-            LabeledContent("Effective") {
-                Text(effectiveURL)
-                    .font(.caption.monospaced())
+                TextField("Custom URL (overrides build default)", text: $apiBaseURL)
+                    .textFieldStyle(.roundedBorder)
+                LabeledContent("Effective") {
+                    Text(effectiveURL)
+                        .font(.caption.monospaced())
+                        .foregroundStyle(.secondary)
+                }
+                Text("Empty = use build-time default (PACKRAT_ENV from xcconfig). Changes apply immediately.")
+                    .font(.caption)
                     .foregroundStyle(.secondary)
             }
-            Text("Empty = use build-time default (PACKRAT_ENV from xcconfig). Changes apply immediately.")
-                .font(.caption)
-                .foregroundStyle(.secondary)
+
+            Section("Developer") {
+                Button("Clear App Data", role: .destructive) {
+                    showingClearDataConfirm = true
+                }
+                Text("Deletes cached data and locally stored preferences. You stay logged in.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
         }
 
         Section {
@@ -194,5 +222,17 @@ struct PreferencesView: View {
         temperatureUnit = .fahrenheit
         speedUnit = .mph
         apiBaseURL = ""
+    }
+}
+
+private extension View {
+    /// Shared confirmation dialog for the destructive "Clear App Data" action.
+    func clearDataConfirmation(isPresented: Binding<Bool>, onConfirm: @escaping () -> Void) -> some View {
+        alert("Clear App Data", isPresented: isPresented) {
+            Button("Cancel", role: .cancel) {}
+            Button("Clear", role: .destructive, action: onConfirm)
+        } message: {
+            Text("This deletes the cache and locally stored preferences. You will stay logged in.")
+        }
     }
 }

--- a/apps/swift/Sources/PackRat/Features/Preferences/PreferencesView.swift
+++ b/apps/swift/Sources/PackRat/Features/Preferences/PreferencesView.swift
@@ -23,6 +23,7 @@ final class AppPreferences: ObservableObject {
 // MARK: - Settings / Preferences window (Cmd+,)
 
 struct PreferencesView: View {
+    @Environment(AuthManager.self) private var authManager
     @AppStorage("defaultAppWeightUnit") private var defaultAppWeightUnit: AppWeightUnit = .grams
     @AppStorage("preferMetric") private var preferMetric: Bool = true
     @AppStorage("temperatureUnit") private var temperatureUnit: AppPreferences.TemperatureUnit = .fahrenheit
@@ -69,15 +70,10 @@ struct PreferencesView: View {
         #endif
     }
 
-    /// Clears cached data (URL/image caches) and locally stored preference
-    /// defaults. Auth lives in the Keychain, so the user stays signed in —
-    /// mirrors the Expo Settings "Clear App Data" behavior.
+    /// Android-style "Clear Data": wipes all local data including auth, then
+    /// returns the app to the auth gate (the user is signed out).
     private func clearAppData() {
-        URLCache.shared.removeAllCachedResponses()
-        let defaults = UserDefaults.standard
-        for key in ["defaultAppWeightUnit", "preferMetric", "temperatureUnit", "speedUnit", "apiBaseURL", "accentColorName"] {
-            defaults.removeObject(forKey: key)
-        }
+        authManager.clearAllData()
     }
 
     #if os(macOS)
@@ -175,10 +171,10 @@ struct PreferencesView: View {
             }
 
             Section("Developer") {
-                Button("Clear App Data", role: .destructive) {
+                Button("Clear Data", role: .destructive) {
                     showingClearDataConfirm = true
                 }
-                Text("Deletes cached data and locally stored preferences. You stay logged in.")
+                Text("Erases all local data — cache, preferences, and sign-in. Signs you out and resets the app.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }
@@ -228,11 +224,11 @@ struct PreferencesView: View {
 private extension View {
     /// Shared confirmation dialog for the destructive "Clear App Data" action.
     func clearDataConfirmation(isPresented: Binding<Bool>, onConfirm: @escaping () -> Void) -> some View {
-        alert("Clear App Data", isPresented: isPresented) {
+        alert("Clear Data", isPresented: isPresented) {
             Button("Cancel", role: .cancel) {}
-            Button("Clear", role: .destructive, action: onConfirm)
+            Button("Clear Data", role: .destructive, action: onConfirm)
         } message: {
-            Text("This deletes the cache and locally stored preferences. You will stay logged in.")
+            Text("This erases all local data and signs you out. This cannot be undone.")
         }
     }
 }

--- a/apps/swift/Sources/PackRat/Features/Preferences/PreferencesView.swift
+++ b/apps/swift/Sources/PackRat/Features/Preferences/PreferencesView.swift
@@ -8,6 +8,7 @@ final class AppPreferences: ObservableObject {
     @AppStorage("defaultAppWeightUnit") var defaultAppWeightUnit: AppWeightUnit = .grams
     @AppStorage("preferMetric") var preferMetric: Bool = true
     @AppStorage("temperatureUnit") var temperatureUnit: TemperatureUnit = .fahrenheit
+    @AppStorage("speedUnit") var speedUnit: SpeedUnit = .mph
     @AppStorage("accentColorName") var accentColorName: String = "blue"
     @AppStorage("apiBaseURL") var apiBaseURL: String = ""
 
@@ -25,9 +26,12 @@ struct PreferencesView: View {
     @AppStorage("defaultAppWeightUnit") private var defaultAppWeightUnit: AppWeightUnit = .grams
     @AppStorage("preferMetric") private var preferMetric: Bool = true
     @AppStorage("temperatureUnit") private var temperatureUnit: AppPreferences.TemperatureUnit = .fahrenheit
+    @AppStorage("speedUnit") private var speedUnit: SpeedUnit = .mph
     @AppStorage("apiBaseURL") private var apiBaseURL: String = ""
 
     var body: some View {
+        #if os(macOS)
+        // Fixed-size tabbed layout for the macOS Settings window (Cmd+,).
         TabView {
             generalTab
                 .tabItem { Label("General", systemImage: "gearshape") }
@@ -42,8 +46,26 @@ struct PreferencesView: View {
         }
         .padding(20)
         .frame(width: 460, height: 320)
+        #else
+        // iOS: a single scrolling form pushed onto a navigation stack. The
+        // macOS tabs become grouped sections so all settings stay reachable
+        // on iPhone, where there is no dedicated Settings window.
+        Form {
+            generalSection
+            unitsSection
+            advancedSection
+            #if DEBUG
+            Section("Debug") {
+                NavigationLink("On-device AI") { OfflineAIView() }
+            }
+            #endif
+            aboutSection
+        }
+        .navigationTitle("Settings")
+        #endif
     }
 
+    #if os(macOS)
     #if DEBUG
     private var debugTab: some View {
         NavigationStack {
@@ -53,31 +75,52 @@ struct PreferencesView: View {
     #endif
 
     private var generalTab: some View {
-        Form {
-            Section("Temperature") {
-                Picker("Display temperature in", selection: $temperatureUnit) {
-                    ForEach(AppPreferences.TemperatureUnit.allCases, id: \.self) { unit in
-                        Text(unit.label).tag(unit)
-                    }
-                }
-                .pickerStyle(.segmented)
-            }
-        }
-        .packRatFormStyle()
+        Form { generalSection }
+            .packRatFormStyle()
     }
 
     private var unitsTab: some View {
-        Form {
-            Section("Weight") {
-                Picker("Default weight unit", selection: $defaultAppWeightUnit) {
-                    ForEach(AppWeightUnit.allCases, id: \.self) { unit in
-                        Text(unit.rawValue).tag(unit)
-                    }
+        Form { unitsSection }
+            .packRatFormStyle()
+    }
+
+    private var advancedTab: some View {
+        Form { advancedSection }
+            .packRatFormStyle()
+    }
+    #endif
+
+    @ViewBuilder
+    private var generalSection: some View {
+        Section("Temperature") {
+            Picker("Display temperature in", selection: $temperatureUnit) {
+                ForEach(AppPreferences.TemperatureUnit.allCases, id: \.self) { unit in
+                    Text(unit.label).tag(unit)
                 }
-                Toggle("Prefer metric display", isOn: $preferMetric)
             }
+            .pickerStyle(.segmented)
         }
-        .packRatFormStyle()
+    }
+
+    @ViewBuilder
+    private var unitsSection: some View {
+        Section("Weight") {
+            Picker("Default weight unit", selection: $defaultAppWeightUnit) {
+                ForEach(AppWeightUnit.allCases, id: \.self) { unit in
+                    Text(unit.rawValue).tag(unit)
+                }
+            }
+            Toggle("Prefer metric display", isOn: $preferMetric)
+        }
+
+        Section("Wind & Distance") {
+            Picker("Wind & distance", selection: $speedUnit) {
+                ForEach(SpeedUnit.allCases, id: \.self) { unit in
+                    Text(unit.label).tag(unit)
+                }
+            }
+            .pickerStyle(.segmented)
+        }
     }
 
     private var effectiveURL: String {
@@ -87,45 +130,69 @@ struct PreferencesView: View {
         return "http://localhost:8787"
     }
 
-    private var advancedTab: some View {
-        Form {
-            Section("API Server") {
-                HStack {
-                    ForEach(["local", "dev", "production"], id: \.self) { env in
-                        if let url = APIClient.environments[env] {
-                            Button(env.capitalized) {
-                                apiBaseURL = url == apiBaseURL ? "" : url
-                            }
-                            .buttonStyle(.bordered)
-                            .tint(effectiveURL == url ? .accentColor : nil)
+    @ViewBuilder
+    private var advancedSection: some View {
+        Section("API Server") {
+            HStack {
+                ForEach(["local", "dev", "production"], id: \.self) { env in
+                    if let url = APIClient.environments[env] {
+                        Button(env.capitalized) {
+                            apiBaseURL = url == apiBaseURL ? "" : url
                         }
+                        .buttonStyle(.bordered)
+                        .tint(effectiveURL == url ? .accentColor : nil)
                     }
                 }
-                TextField("Custom URL (overrides build default)", text: $apiBaseURL)
-                    .textFieldStyle(.roundedBorder)
-                LabeledContent("Effective") {
-                    Text(effectiveURL)
-                        .font(.caption.monospaced())
-                        .foregroundStyle(.secondary)
-                }
-                Text("Empty = use build-time default (PACKRAT_ENV from xcconfig). Changes apply immediately.")
-                    .font(.caption)
+            }
+            TextField("Custom URL (overrides build default)", text: $apiBaseURL)
+                .textFieldStyle(.roundedBorder)
+            LabeledContent("Effective") {
+                Text(effectiveURL)
+                    .font(.caption.monospaced())
                     .foregroundStyle(.secondary)
             }
+            Text("Empty = use build-time default (PACKRAT_ENV from xcconfig). Changes apply immediately.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
 
-            Section {
-                Button("Reset All Preferences", role: .destructive) {
-                    resetDefaults()
-                }
+        Section {
+            Button("Reset All Preferences", role: .destructive) {
+                resetDefaults()
             }
         }
-        .packRatFormStyle()
+
+        #if os(macOS)
+        aboutSection
+        #endif
+    }
+
+    @ViewBuilder
+    private var aboutSection: some View {
+        Section("About") {
+            LabeledContent(appName, value: appVersionString)
+        }
+    }
+
+    private var appName: String {
+        (Bundle.main.object(forInfoDictionaryKey: "CFBundleDisplayName") as? String)
+            ?? (Bundle.main.object(forInfoDictionaryKey: "CFBundleName") as? String)
+            ?? "PackRat"
+    }
+
+    /// "v1.2.3 (45)" — short version + build number, matching the version
+    /// string the Expo Settings screen shows.
+    private var appVersionString: String {
+        let short = (Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String) ?? "—"
+        let build = (Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") as? String) ?? ""
+        return build.isEmpty ? "v\(short)" : "v\(short) (\(build))"
     }
 
     private func resetDefaults() {
         defaultAppWeightUnit = .grams
         preferMetric = true
         temperatureUnit = .fahrenheit
+        speedUnit = .mph
         apiBaseURL = ""
     }
 }

--- a/apps/swift/Sources/PackRat/Features/Weather/WeatherView.swift
+++ b/apps/swift/Sources/PackRat/Features/Weather/WeatherView.swift
@@ -5,6 +5,12 @@ struct WeatherView: View {
     @State private var showingAlerts = false
     @State private var showingAlertPreferences = false
     @State private var isSearchPresented = false
+    @AppStorage("speedUnit") private var speedUnit: SpeedUnit = .mph
+
+    /// Renders an API wind value (always mph) in the user's preferred unit.
+    private func windDisplay(mph: Double) -> String {
+        speedUnit == .kmh ? "\(Int((mph * 1.609344).rounded())) km/h" : "\(Int(mph.rounded())) mph"
+    }
 
     private var activeAlerts: [WeatherAlert] {
         viewModel.forecast?.alerts?.alert ?? []
@@ -280,7 +286,7 @@ struct WeatherView: View {
                 Divider().frame(height: 32)
                 weatherDetail("Humidity", value: "\(current.humidity ?? 0)%", symbol: "humidity")
                 Divider().frame(height: 32)
-                weatherDetail("Wind", value: String(format: "%.0f mph", current.windMph ?? 0), symbol: "wind")
+                weatherDetail("Wind", value: windDisplay(mph: current.windMph ?? 0), symbol: "wind")
                 Divider().frame(height: 32)
                 weatherDetail("UV Index", value: String(format: "%.0f", current.uv ?? 0), symbol: "sun.max")
             }

--- a/apps/swift/Sources/PackRat/Models/Pack.swift
+++ b/apps/swift/Sources/PackRat/Models/Pack.swift
@@ -82,6 +82,38 @@ enum AppWeightUnit: String, CaseIterable {
     var label: String { rawValue }
 }
 
+// Wind speed + distance display unit. Raw values match the Expo app's
+// `speedUnit` preference ('kmh' | 'mph') so the stored preference is portable.
+
+enum SpeedUnit: String, CaseIterable {
+    case kmh
+    case mph
+
+    /// Segmented-control / picker label.
+    var label: String {
+        switch self {
+        case .kmh: return "km/h"
+        case .mph: return "mph"
+        }
+    }
+
+    /// Formats a km/h value into the user's preferred unit.
+    func displayWindSpeed(_ kph: Double) -> String {
+        switch self {
+        case .mph: return "\(Int((kph * 0.621371).rounded())) mph"
+        case .kmh: return "\(Int(kph.rounded())) km/h"
+        }
+    }
+
+    /// Formats a km value into the user's preferred distance unit.
+    func displayDistance(_ km: Double) -> String {
+        switch self {
+        case .mph: return "\(Int((km * 0.621371).rounded())) mi"
+        case .kmh: return "\(Int(km.rounded())) km"
+        }
+    }
+}
+
 // MARK: - Gap Analysis
 
 struct GapAnalysisResult: Decodable, Sendable {

--- a/apps/swift/Sources/PackRat/Navigation/AppNavigation.swift
+++ b/apps/swift/Sources/PackRat/Navigation/AppNavigation.swift
@@ -315,6 +315,16 @@ struct AppNavigation: View {
             NavigationStack {
                 ProfileView()
                     .navigationTitle("Profile")
+                    .toolbar {
+                        ToolbarItem(placement: .topBarTrailing) {
+                            NavigationLink {
+                                PreferencesView()
+                            } label: {
+                                Label("Settings", systemImage: "gearshape")
+                            }
+                            .accessibilityIdentifier("profile_settings_button")
+                        }
+                    }
             }
             .tabItem { Label("Profile", systemImage: "person.circle") }
             .tag(PhoneTab.profile)

--- a/apps/swift/Sources/PackRat/Navigation/AppNavigation.swift
+++ b/apps/swift/Sources/PackRat/Navigation/AppNavigation.swift
@@ -67,6 +67,7 @@ private enum PhoneTab: Hashable {
     case packs
     case trips
     case chat
+    case profile
 
     init?(navItem: NavItem) {
         switch navItem {
@@ -78,12 +79,15 @@ private enum PhoneTab: Hashable {
         }
     }
 
+    /// The `NavItem` this tab maps to, or `nil` for tabs (like `.profile`)
+    /// that are not `NavItem` destinations and manage their own content.
     var navItem: NavItem? {
         switch self {
         case .home: return .home
         case .packs: return .packs
         case .trips: return .trips
         case .chat: return .chat
+        case .profile: return nil
         }
     }
 }
@@ -307,6 +311,13 @@ struct AppNavigation: View {
                 .tabItem { Label(item.label, systemImage: item.symbol) }
                 .tag(PhoneTab(navItem: item)!)
             }
+
+            NavigationStack {
+                ProfileView()
+                    .navigationTitle("Profile")
+            }
+            .tabItem { Label("Profile", systemImage: "person.circle") }
+            .tag(PhoneTab.profile)
         }
         .onChange(of: phoneTab) { _, newTab in
             if let item = newTab.navItem {

--- a/apps/swift/Sources/PackRat/Network/APIClient.swift
+++ b/apps/swift/Sources/PackRat/Network/APIClient.swift
@@ -25,11 +25,35 @@ actor APIClient {
         "production": "https://packrat-api.orange-frost-d665.workers.dev",
     ]
 
+    /// The build-time environment name from `PACKRAT_ENV` (xcconfig → Info.plist).
+    /// `nil` if unset.
+    static var environmentName: String? {
+        Bundle.main.object(forInfoDictionaryKey: "PACKRAT_ENV") as? String
+    }
+
+    /// True for local/dev/staging builds — anything that is not the production
+    /// release. Used to gate developer-only UI (API server override, clear app
+    /// data) so those controls never ship to end users. Debug builds always
+    /// qualify; release builds only if their `PACKRAT_ENV` is not `production`
+    /// (the Staging config ships a `release` build pointed at the dev API).
+    static var isNonProduction: Bool {
+        #if DEBUG
+        return true
+        #else
+        return environmentName != "production"
+        #endif
+    }
+
     static var resolvedBaseURL: URL {
         if let override = ProcessInfo.processInfo.environment["E2E_API_BASE_URL"],
            !override.isEmpty,
            let url = URL(string: override) { return url }
-        if let override = UserDefaults.standard.string(forKey: "apiBaseURL"),
+        // Honor the user-facing API server override only in non-production
+        // builds. The override UI is gated the same way (see PreferencesView),
+        // but gate the read too so a stale/injected value can never repoint a
+        // production app at another backend.
+        if isNonProduction,
+           let override = UserDefaults.standard.string(forKey: "apiBaseURL"),
            !override.isEmpty,
            let url = URL(string: override) { return url }
         if let env = Bundle.main.object(forInfoDictionaryKey: "PACKRAT_ENV") as? String,

--- a/apps/swift/Sources/PackRat/Network/AuthManager.swift
+++ b/apps/swift/Sources/PackRat/Network/AuthManager.swift
@@ -294,6 +294,26 @@ final class AuthManager {
         SentryConfig.clearUser()
     }
 
+    /// Android-style "Clear Data": wipes *everything* the app stores locally —
+    /// Keychain auth, the entire UserDefaults suite (session, preferences,
+    /// flags), and the URL/image caches — then resets auth state so the app
+    /// returns to the auth gate. The user is fully signed out, not just reset.
+    func clearAllData() {
+        KeychainService.shared.clearTokens()
+
+        // Wipe the whole persistent domain rather than enumerating keys, so
+        // nothing (prefs, feature toggles, cached user) survives.
+        if let bundleID = Bundle.main.bundleIdentifier {
+            UserDefaults.standard.removePersistentDomain(forName: bundleID)
+        }
+
+        URLCache.shared.removeAllCachedResponses()
+
+        isGuest = false
+        currentUser = nil
+        SentryConfig.clearUser()
+    }
+
     // MARK: - Persistence
 
     private func persistUser(_ user: User) {

--- a/apps/swift/Sources/PackRat/PackRatApp.swift
+++ b/apps/swift/Sources/PackRat/PackRatApp.swift
@@ -42,6 +42,7 @@ struct PackRatApp: App {
         #if os(macOS)
         Settings {
             PreferencesView()
+                .environment(authManager)
         }
 
         WindowGroup("Pack", id: "pack", for: String.self) { $packId in


### PR DESCRIPTION
## Description

The Swift iOS app had no way to reach **settings or the user profile on iPhone** — `PreferencesView` was a macOS-only `Settings` scene, and `ProfileView` was only reachable via the mac/iPad sidebar footer. On iPhone (compact `TabView`) both were dead ends. This PR closes that gap and brings the iOS Settings surface to parity with the Expo app.

Closes #2633

### What changed
- **Profile tab** added to the iPhone `TabView` (`.profile` `PhoneTab` case rendering `ProfileView` directly, without polluting `NavItem`). This makes account info, notifications, sign-out, and the existing **Delete Account** flow reachable on iPhone.
- **iOS Settings** — `PreferencesView.body` split by platform: macOS keeps its fixed-size tabbed `Settings` window; iOS renders a single scrolling `Form` reachable via a gear button in the Profile tab. Shared `@ViewBuilder` sections back both layouts (no duplication).
- **Wind & Distance unit** — new `SpeedUnit` (`kmh`/`mph`, raw values matching Expo's `speedUnit` pref) + picker; `WeatherView` now formats wind in the chosen unit instead of hardcoding mph.
- **App version** — new About section showing `name vX.Y.Z (build)`, matching Expo's footer.
- **API Server override gated to non-production** — new `APIClient.isNonProduction` (Debug, or any non-`production` `PACKRAT_ENV`, i.e. local/dev/staging). Both the override UI **and** the `resolvedBaseURL` read are gated, so a production release can never be repointed at a dev/local backend by a stored/injected `apiBaseURL`.
- **Clear Data** (dev/staging only) — Android-style full wipe via `AuthManager.clearAllData()`: clears Keychain auth, the entire UserDefaults persistent domain, and URL caches, then resets auth state so the app returns to the auth gate (user is fully signed out).
- Injected `AuthManager` into the macOS `Settings` scene (now required by `PreferencesView`).

## Type of change

- [x] ✨ New feature

## Area(s) affected

- [x] Mobile app (native Swift iOS/macOS — `apps/swift`)

## Changed paths

- `apps/swift/Sources/PackRat/Navigation/AppNavigation.swift`
- `apps/swift/Sources/PackRat/Features/Preferences/PreferencesView.swift`
- `apps/swift/Sources/PackRat/Features/Weather/WeatherView.swift`
- `apps/swift/Sources/PackRat/Models/Pack.swift`
- `apps/swift/Sources/PackRat/Network/APIClient.swift`
- `apps/swift/Sources/PackRat/Network/AuthManager.swift`
- `apps/swift/Sources/PackRat/PackRatApp.swift`

## Testing

- [x] Manually tested on iOS (iPhone 17 Pro simulator — app boots to native auth gate; changes exercised via guest mode)
- `xcodebuild` **BUILD SUCCEEDED** for both `PackRat-iOS` and `PackRat-macOS` schemes.

## Test plan

- [x] Local checks passed on changed paths (Swift build gate; e2e excluded)
- [ ] Remote CI passes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a Profile tab on iPhone with quick access to Preferences.
  - Added selectable speed units (mph or km/h) for wind and distance displays.
  - Added About information and improved preferences organization across platforms.
  - Added Clear Data and Reset All Preferences options with confirmation safeguards.

- **Bug Fixes**
  - Wind speeds now display according to the selected unit preference.
  - Production builds no longer use custom server address overrides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->