### PR TITLE
fix(swift): restore Packs header and unify background when list has content

### DIFF
--- a/apps/swift/Sources/PackRat/Features/Home/HomeView.swift
+++ b/apps/swift/Sources/PackRat/Features/Home/HomeView.swift
@@ -393,10 +393,13 @@ private struct SummaryActionButton: View {
 
     private var buttonLabel: some View {
         Button(action: action) {
-            Label(title, systemImage: symbol)
-                .font(.subheadline.weight(.semibold))
-                .frame(maxWidth: .infinity)
-                .padding(.vertical, 10)
+            HStack(spacing: 6) {
+                Image(systemName: symbol)
+                Text(title)
+            }
+            .font(.subheadline.weight(.semibold))
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 10)
         }
         .controlSize(.regular)
     }

--- a/apps/swift/Sources/PackRat/Features/Packs/PacksListView.swift
+++ b/apps/swift/Sources/PackRat/Features/Packs/PacksListView.swift
@@ -26,36 +26,42 @@ struct PacksListView: View {
     }
 
     var body: some View {
-        Group {
-            if viewModel.isLoading && viewModel.packs.isEmpty && !isExplore {
-                ProgressView("Loading packs…").frame(maxWidth: .infinity, maxHeight: .infinity)
-            } else if let error = viewModel.error, viewModel.packs.isEmpty, !isExplore {
-                ErrorView(error, retry: { await viewModel.load(context: modelContext) })
-            } else if isLoadingPublic && publicPacks.isEmpty {
-                ProgressView("Loading…").frame(maxWidth: .infinity, maxHeight: .infinity)
-            } else if displayedPacks.isEmpty && !viewModel.searchText.isEmpty {
-                ContentUnavailableView.search(text: viewModel.searchText)
-                    .accessibilityIdentifier("packs_search_empty_state")
-            } else if displayedPacks.isEmpty && !isExplore {
-                EmptyStateView(
-                    "No Packs Yet",
-                    subtitle: "Create your first pack to start tracking gear weight",
-                    systemImage: "backpack",
-                    actionLabel: "New Pack",
-                    accessibilityIdentifier: "packs_empty_state",
-                    action: { showingCreateSheet = true }
-                )
-            } else if displayedPacks.isEmpty && isExplore {
-                EmptyStateView(
-                    "No Public Packs",
-                    subtitle: "No packs match your filter",
-                    systemImage: "globe",
-                    accessibilityIdentifier: "packs_public_empty_state"
-                )
-            } else {
-                packList
+        VStack(spacing: 0) {
+            categoryFilterBar
+
+            Group {
+                if viewModel.isLoading && viewModel.packs.isEmpty && !isExplore {
+                    ProgressView("Loading packs…").frame(maxWidth: .infinity, maxHeight: .infinity)
+                } else if let error = viewModel.error, viewModel.packs.isEmpty, !isExplore {
+                    ErrorView(error, retry: { await viewModel.load(context: modelContext) })
+                } else if isLoadingPublic && publicPacks.isEmpty {
+                    ProgressView("Loading…").frame(maxWidth: .infinity, maxHeight: .infinity)
+                } else if displayedPacks.isEmpty && !viewModel.searchText.isEmpty {
+                    ContentUnavailableView.search(text: viewModel.searchText)
+                        .accessibilityIdentifier("packs_search_empty_state")
+                } else if displayedPacks.isEmpty && !isExplore {
+                    EmptyStateView(
+                        "No Packs Yet",
+                        subtitle: "Create your first pack to start tracking gear weight",
+                        systemImage: "backpack",
+                        actionLabel: "New Pack",
+                        accessibilityIdentifier: "packs_empty_state",
+                        action: { showingCreateSheet = true }
+                    )
+                } else if displayedPacks.isEmpty && isExplore {
+                    EmptyStateView(
+                        "No Public Packs",
+                        subtitle: "No packs match your filter",
+                        systemImage: "globe",
+                        accessibilityIdentifier: "packs_public_empty_state"
+                    )
+                } else {
+                    packList
+                }
             }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
+        .background(.background)
         .navigationTitle("Packs")
         .searchable(text: $viewModel.searchText, prompt: "Search packs")
         .toolbar {
@@ -76,9 +82,6 @@ struct PacksListView: View {
                 }
                 .accessibilityIdentifier("packs_recent_button")
             }
-        }
-        .safeAreaInset(edge: .top, spacing: 0) {
-            categoryFilterBar
         }
         .task { await viewModel.load(context: modelContext) }
         .refreshable {
@@ -136,7 +139,7 @@ struct PacksListView: View {
         }
         .padding(.horizontal)
         .padding(.vertical, 8)
-        .background(.bar)
+        .background(.background)
     }
 
     // MARK: - Pack Row
@@ -174,6 +177,9 @@ struct PacksListView: View {
                     }
                 }
         }
+        .listStyle(.plain)
+        .scrollContentBackground(.hidden)
+        .background(.background)
         .accessibilityIdentifier(isExplore ? "packs_public_list" : "packs_list")
     }
 

--- a/apps/swift/Sources/PackRat/Features/Packs/PacksListView.swift
+++ b/apps/swift/Sources/PackRat/Features/Packs/PacksListView.swift
@@ -139,7 +139,7 @@ struct PacksListView: View {
         }
         .padding(.horizontal)
         .padding(.vertical, 8)
-        .background(.background)
+        .background(.bar)
     }
 
     // MARK: - Pack Row
@@ -177,9 +177,6 @@ struct PacksListView: View {
                     }
                 }
         }
-        .listStyle(.plain)
-        .scrollContentBackground(.hidden)
-        .background(.background)
         .accessibilityIdentifier(isExplore ? "packs_public_list" : "packs_list")
     }
 


### PR DESCRIPTION
## Summary
- Fixes #2632 — the Packs tab navigation header disappeared once packs were loaded into the list. `.safeAreaInset(edge: .top)` combined with a `List` breaks the navigation title/large-title rendering on iOS; empty/loading states rendered fine because they aren't backed by a scrollable `List`.
- Moves the category filter bar out of `safeAreaInset` and into a plain `VStack` above the content, so the header is stable regardless of list state.
- Also fixes a background color mismatch called out in the issue: the filter bar used `.background(.bar)` (white/blur) while the `List` used the default grouped grey background. Both now use `.background(.background)` with `.listStyle(.plain)` + `.scrollContentBackground(.hidden)` on the list for a uniform surface.

## Test plan
- [x] `xcodebuild -project PackRat.xcodeproj -scheme PackRat-iOS -destination 'generic/platform=iOS Simulator' -sdk iphonesimulator build` — succeeds
- [ ] Manually verify on device/simulator: Packs tab shows header in empty state, loading state, and with packs loaded; category filter bar and list background are now visually uniform