### PR TITLE
fix(swift): fix avatar upload chain and wire avatar image into Home/nav

### DIFF
--- a/apps/swift/Sources/PackRat/Config/AppFeatureFlags.swift
+++ b/apps/swift/Sources/PackRat/Config/AppFeatureFlags.swift
@@ -9,6 +9,7 @@ enum AppFeatureFlags {
     static let enableOAuth = true
     static let enablePackInsights = false
     static let enablePackTemplates = true
+    static let enableRevenueCat = true
     static let enableSharedPacks = false
     static let enableShoppingList = false
     static let enableTrailConditions = true

--- a/apps/swift/Sources/PackRat/Features/Home/HomeView.swift
+++ b/apps/swift/Sources/PackRat/Features/Home/HomeView.swift
@@ -89,22 +89,23 @@ struct HomeView: View {
 
     private var headerSection: some View {
         HStack(alignment: .center, spacing: 12) {
-            ZStack {
-                Circle()
-                    .fill(.tint.opacity(0.12))
-
-                if authManager.currentUser == nil {
+            if authManager.currentUser == nil {
+                ZStack {
+                    Circle()
+                        .fill(.tint.opacity(0.12))
                     Image(systemName: "person.crop.circle.fill")
                         .font(.title2.weight(.semibold))
                         .foregroundStyle(.tint)
                         .symbolRenderingMode(.hierarchical)
-                } else {
-                    Text(authManager.currentUser?.initials ?? "?")
-                        .font(.headline.weight(.semibold))
-                        .foregroundStyle(.tint)
                 }
+                .frame(width: 44, height: 44)
+            } else {
+                AvatarView(
+                    url: authManager.currentUser?.avatarUrl,
+                    fallbackText: authManager.currentUser?.initials ?? "?",
+                    size: 44
+                )
             }
-            .frame(width: 44, height: 44)
 
             VStack(alignment: .leading, spacing: 4) {
                 Text(firstName.isEmpty ? greeting : "\(greeting), \(firstName)")

--- a/apps/swift/Sources/PackRat/Features/Preferences/PreferencesView.swift
+++ b/apps/swift/Sources/PackRat/Features/Preferences/PreferencesView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import UserNotifications
 
 // MARK: - App-wide user preferences stored in UserDefaults
 
@@ -31,6 +32,9 @@ struct PreferencesView: View {
     @AppStorage("apiBaseURL") private var apiBaseURL: String = ""
 
     @State private var showingClearDataConfirm = false
+    @Environment(\.openURL) private var openURL
+    @State private var notificationsEnabled = false
+    @State private var notificationAuthStatus: UNAuthorizationStatus = .notDetermined
 
     var body: some View {
         #if os(macOS)
@@ -57,6 +61,7 @@ struct PreferencesView: View {
         Form {
             generalSection
             unitsSection
+            notificationSection
             advancedSection
             #if DEBUG
             Section("Debug") {
@@ -67,6 +72,7 @@ struct PreferencesView: View {
         }
         .navigationTitle("Settings")
         .clearDataConfirmation(isPresented: $showingClearDataConfirm, onConfirm: clearAppData)
+        .onAppear { Task { await refreshNotificationStatus() } }
         #endif
     }
 
@@ -111,6 +117,52 @@ struct PreferencesView: View {
             }
             .pickerStyle(.segmented)
         }
+    }
+
+    @ViewBuilder
+    private var notificationSection: some View {
+        Section("Notifications") {
+            if notificationAuthStatus == .denied {
+                HStack {
+                    Image(systemName: "bell.slash.fill").foregroundStyle(.secondary)
+                    Text("Notifications are blocked in Settings")
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                    Spacer()
+                    #if os(iOS)
+                    Button("Open Settings") {
+                        if let url = URL(string: UIApplication.openSettingsURLString) {
+                            openURL(url)
+                        }
+                    }
+                    .font(.callout)
+                    #endif
+                }
+            } else {
+                Toggle("Push Notifications", isOn: $notificationsEnabled)
+                    .onChange(of: notificationsEnabled) { _, enabled in
+                        Task { await toggleNotifications(enabled) }
+                    }
+            }
+        }
+    }
+
+    private func refreshNotificationStatus() async {
+        let center = UNUserNotificationCenter.current()
+        let settings = await center.notificationSettings()
+        notificationAuthStatus = settings.authorizationStatus
+        notificationsEnabled = settings.authorizationStatus == .authorized
+    }
+
+    private func toggleNotifications(_ enable: Bool) async {
+        let center = UNUserNotificationCenter.current()
+        if enable {
+            let status = await center.notificationSettings().authorizationStatus
+            if status == .notDetermined {
+                _ = try? await center.requestAuthorization(options: [.alert, .sound, .badge])
+            }
+        }
+        await refreshNotificationStatus()
     }
 
     @ViewBuilder

--- a/apps/swift/Sources/PackRat/Features/Profile/ProfileView.swift
+++ b/apps/swift/Sources/PackRat/Features/Profile/ProfileView.swift
@@ -50,15 +50,7 @@ struct ProfileView: View {
     }
 
     private var authenticatedProfile: some View {
-        ScrollView {
-            VStack(spacing: 24) {
-                avatarSection
-                    .padding(.top, 8)
-
-                profileForm
-            }
-            .padding()
-        }
+        profileForm
     }
 
     private var guestProfile: some View {
@@ -97,6 +89,16 @@ struct ProfileView: View {
 
     private var profileForm: some View {
         Form {
+            Section {
+                HStack {
+                    Spacer()
+                    avatarSection
+                    Spacer()
+                }
+                .padding(.vertical, 8)
+            }
+            .listRowBackground(Color.clear)
+
             Section("Account Info") {
                 LabeledContent("Email") {
                     Text(authManager.currentUser?.email ?? "")

--- a/apps/swift/Sources/PackRat/Features/Profile/ProfileView.swift
+++ b/apps/swift/Sources/PackRat/Features/Profile/ProfileView.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 import NukeUI
 import PhotosUI
+import Sentry
 
 struct ProfileView: View {
     @Environment(AuthManager.self) private var authManager
@@ -213,6 +214,10 @@ struct ProfileView: View {
                 defer { avatarPhotoItem = nil }
                 guard let data = try? await item.loadTransferable(type: Data.self),
                       let image = UIImage(data: data) else { return }
+                guard data.count <= Self.avatarMaxBytes else {
+                    saveError = "Image is too large. Please choose a photo under 5MB."
+                    return
+                }
                 await uploadAvatar(image: image)
             }
         }
@@ -295,20 +300,53 @@ struct ProfileView: View {
             let endpoint = Endpoint(.put, "/api/user/profile", body: AvatarBody(avatarUrl: avatarUrl))
             try await APIClient.shared.sendDiscarding(endpoint)
             try await authManager.refreshProfile()
-        } catch { }
+        } catch {
+            saveError = error.localizedDescription
+            SentrySDK.capture(error: error) { scope in
+                scope.setTag(value: "profile", key: "feature")
+                scope.setTag(value: "updateAvatarUrl", key: "action")
+            }
+        }
     }
+
+    /// Matches Expo's client-side avatar size guard (profile/index.tsx AVATAR_MAX_BYTES).
+    private static let avatarMaxBytes = 5 * 1024 * 1024
 
     #if os(macOS)
     private func uploadAvatar(url: URL) async {
-        guard let publicUrl = try? await UploadService.shared.uploadImage(at: url) else { return }
-        await uploadAvatar(avatarUrl: publicUrl)
+        guard let userId = authManager.currentUser?.id else { return }
+        isUploadingAvatar = true
+        do {
+            let objectKey = try await UploadService.shared.uploadImage(at: url, userId: userId)
+            isUploadingAvatar = false
+            await uploadAvatar(avatarUrl: objectKey)
+        } catch {
+            isUploadingAvatar = false
+            saveError = error.localizedDescription
+            SentrySDK.capture(error: error) { scope in
+                scope.setTag(value: "profile", key: "feature")
+                scope.setTag(value: "uploadAvatar", key: "action")
+            }
+        }
     }
     #endif
 
     #if os(iOS)
     private func uploadAvatar(image: UIImage) async {
-        guard let publicUrl = try? await UploadService.shared.uploadUIImage(image) else { return }
-        await uploadAvatar(avatarUrl: publicUrl)
+        guard let userId = authManager.currentUser?.id else { return }
+        isUploadingAvatar = true
+        do {
+            let objectKey = try await UploadService.shared.uploadUIImage(image, userId: userId)
+            isUploadingAvatar = false
+            await uploadAvatar(avatarUrl: objectKey)
+        } catch {
+            isUploadingAvatar = false
+            saveError = error.localizedDescription
+            SentrySDK.capture(error: error) { scope in
+                scope.setTag(value: "profile", key: "feature")
+                scope.setTag(value: "uploadAvatar", key: "action")
+            }
+        }
     }
     #endif
 }

--- a/apps/swift/Sources/PackRat/Features/Profile/ProfileView.swift
+++ b/apps/swift/Sources/PackRat/Features/Profile/ProfileView.swift
@@ -1,10 +1,9 @@
 import SwiftUI
 import NukeUI
-import UserNotifications
+import PhotosUI
 
 struct ProfileView: View {
     @Environment(AuthManager.self) private var authManager
-    @Environment(\.openURL) private var openURL
     @State private var firstName = ""
     @State private var lastName = ""
     @State private var isSaving = false
@@ -12,11 +11,12 @@ struct ProfileView: View {
     @State private var saveSuccess = false
     @State private var showingSignOutAlert = false
     @State private var showingDeleteAccountAlert = false
-    @State private var showingAvatarPicker = false
+    @State private var avatarPhotoItem: PhotosPickerItem?
     @State private var isUploadingAvatar = false
     @State private var isDeletingAccount = false
-    @State private var notificationsEnabled = false
-    @State private var notificationAuthStatus: UNAuthorizationStatus = .notDetermined
+    #if os(macOS)
+    @State private var showingAvatarPicker = false
+    #endif
 
     var body: some View {
         Group {
@@ -27,10 +27,7 @@ struct ProfileView: View {
             }
         }
         .navigationTitle("Profile")
-        .onAppear {
-            prefill()
-            Task { await refreshNotificationStatus() }
-        }
+        .onAppear { prefill() }
         .alert("Sign Out", isPresented: $showingSignOutAlert) {
             Button("Sign Out", role: .destructive) {
                 Task { try? await authManager.logout() }
@@ -81,8 +78,6 @@ struct ProfileView: View {
             } footer: {
                 Text("An account unlocks sync, social features, AI tools, templates, and profile settings.")
             }
-
-            notificationSection
         }
         .packRatFormStyle()
     }
@@ -148,8 +143,6 @@ struct ProfileView: View {
                 .disabled(isSaving || !hasChanges)
             }
 
-            notificationSection
-
             Section {
                 Button("Sign Out", role: .destructive) {
                     showingSignOutAlert = true
@@ -166,39 +159,12 @@ struct ProfileView: View {
         #endif
     }
 
-    private var notificationSection: some View {
-        Section("Notifications") {
-            if notificationAuthStatus == .denied {
-                HStack {
-                    Image(systemName: "bell.slash.fill").foregroundStyle(.secondary)
-                    Text("Notifications are blocked in Settings")
-                        .font(.callout)
-                        .foregroundStyle(.secondary)
-                    Spacer()
-                    #if os(iOS)
-                    Button("Open Settings") {
-                        if let url = URL(string: UIApplication.openSettingsURLString) {
-                            openURL(url)
-                        }
-                    }
-                    .font(.callout)
-                    #endif
-                }
-            } else {
-                Toggle("Push Notifications", isOn: $notificationsEnabled)
-                    .onChange(of: notificationsEnabled) { _, enabled in
-                        Task { await toggleNotifications(enabled) }
-                    }
-            }
-        }
-    }
-
     // MARK: - Avatar
 
     private var avatarSection: some View {
         ZStack(alignment: .bottomTrailing) {
-            if let url = authManager.currentUser?.avatarUrl {
-                LazyImage(url: URL(string: url)) { state in
+            if let imageURL = APIClient.resolvedImageURL(authManager.currentUser?.avatarUrl) {
+                LazyImage(url: imageURL) { state in
                     if let image = state.image {
                         image.resizable().scaledToFill()
                     } else {
@@ -218,6 +184,15 @@ struct ProfileView: View {
                     .background(.regularMaterial, in: Circle())
                     .offset(x: 4, y: 4)
             } else {
+                #if os(iOS)
+                PhotosPicker(selection: $avatarPhotoItem, matching: .images) {
+                    Image(systemName: "pencil.circle.fill")
+                        .font(.title3)
+                        .foregroundStyle(.tint)
+                        .background(Circle().fill(.background))
+                }
+                .offset(x: 4, y: 4)
+                #else
                 Button {
                     showingAvatarPicker = true
                 } label: {
@@ -228,8 +203,20 @@ struct ProfileView: View {
                 }
                 .buttonStyle(.plain)
                 .offset(x: 4, y: 4)
+                #endif
             }
         }
+        #if os(iOS)
+        .onChange(of: avatarPhotoItem) { _, item in
+            guard let item else { return }
+            Task {
+                defer { avatarPhotoItem = nil }
+                guard let data = try? await item.loadTransferable(type: Data.self),
+                      let image = UIImage(data: data) else { return }
+                await uploadAvatar(image: image)
+            }
+        }
+        #endif
         #if os(macOS)
         .fileImporter(
             isPresented: $showingAvatarPicker,
@@ -288,24 +275,6 @@ struct ProfileView: View {
         }
     }
 
-    private func refreshNotificationStatus() async {
-        let center = UNUserNotificationCenter.current()
-        let settings = await center.notificationSettings()
-        notificationAuthStatus = settings.authorizationStatus
-        notificationsEnabled = settings.authorizationStatus == .authorized
-    }
-
-    private func toggleNotifications(_ enable: Bool) async {
-        let center = UNUserNotificationCenter.current()
-        if enable {
-            let status = await center.notificationSettings().authorizationStatus
-            if status == .notDetermined {
-                _ = try? await center.requestAuthorization(options: [.alert, .sound, .badge])
-            }
-        }
-        await refreshNotificationStatus()
-    }
-
     private func deleteAccount() async {
         isDeletingAccount = true
         defer { isDeletingAccount = false }
@@ -318,17 +287,28 @@ struct ProfileView: View {
         }
     }
 
-    #if os(macOS)
-    private func uploadAvatar(url: URL) async {
+    private func uploadAvatar(avatarUrl: String) async {
         isUploadingAvatar = true
         defer { isUploadingAvatar = false }
         do {
-            let avatarUrl = try await UploadService.shared.uploadImage(at: url)
             struct AvatarBody: Encodable { let avatarUrl: String }
             let endpoint = Endpoint(.put, "/api/user/profile", body: AvatarBody(avatarUrl: avatarUrl))
             try await APIClient.shared.sendDiscarding(endpoint)
             try await authManager.refreshProfile()
         } catch { }
+    }
+
+    #if os(macOS)
+    private func uploadAvatar(url: URL) async {
+        guard let publicUrl = try? await UploadService.shared.uploadImage(at: url) else { return }
+        await uploadAvatar(avatarUrl: publicUrl)
+    }
+    #endif
+
+    #if os(iOS)
+    private func uploadAvatar(image: UIImage) async {
+        guard let publicUrl = try? await UploadService.shared.uploadUIImage(image) else { return }
+        await uploadAvatar(avatarUrl: publicUrl)
     }
     #endif
 }

--- a/apps/swift/Sources/PackRat/Navigation/AppNavigation.swift
+++ b/apps/swift/Sources/PackRat/Navigation/AppNavigation.swift
@@ -393,14 +393,11 @@ struct AppNavigation: View {
         let email = authManager.currentUser?.email ?? ""
 
         return HStack(spacing: 8) {
-            Circle()
-                .fill(.tint.opacity(0.12))
-                .frame(width: 30, height: 30)
-                .overlay {
-                    Text(authManager.currentUser?.initials ?? "?")
-                        .font(.caption.bold())
-                        .foregroundStyle(.tint)
-                }
+            AvatarView(
+                url: authManager.currentUser?.avatarUrl,
+                fallbackText: authManager.currentUser?.initials ?? "?",
+                size: 30
+            )
             VStack(alignment: .leading, spacing: 1) {
                 if let displayName {
                     Text(displayName)

--- a/apps/swift/Sources/PackRat/Network/APIClient.swift
+++ b/apps/swift/Sources/PackRat/Network/APIClient.swift
@@ -25,6 +25,20 @@ actor APIClient {
         "production": "https://packrat-api.orange-frost-d665.workers.dev",
     ]
 
+    /// Public R2 bucket URL for user-uploaded images (avatars, pack photos).
+    /// Fixed across environments — matches `EXPO_PUBLIC_R2_PUBLIC_URL` on the Expo side.
+    static let r2PublicURL = "https://pub-c3852b07b730407889986338ca3ef0e5.r2.dev"
+
+    /// Resolves a possibly-relative R2 object key to a fetchable absolute URL.
+    /// Server-stored image fields (e.g. `avatarUrl`) may be a bare R2 key or
+    /// already-absolute URL (OAuth-provided avatars). Mirrors Expo's
+    /// `buildPackTemplateItemImageUrl`.
+    static func resolvedImageURL(_ value: String?) -> URL? {
+        guard let value, !value.isEmpty else { return nil }
+        if value.hasPrefix("http") { return URL(string: value) }
+        return URL(string: "\(r2PublicURL)/\(value)")
+    }
+
     /// The build-time environment name from `PACKRAT_ENV` (xcconfig → Info.plist).
     /// `nil` if unset.
     static var environmentName: String? {

--- a/apps/swift/Sources/PackRat/Network/APIClient.swift
+++ b/apps/swift/Sources/PackRat/Network/APIClient.swift
@@ -25,9 +25,20 @@ actor APIClient {
         "production": "https://packrat-api.orange-frost-d665.workers.dev",
     ]
 
-    /// Public R2 bucket URL for user-uploaded images (avatars, pack photos).
-    /// Fixed across environments — matches `EXPO_PUBLIC_R2_PUBLIC_URL` on the Expo side.
-    static let r2PublicURL = "https://pub-c3852b07b730407889986338ca3ef0e5.r2.dev"
+    /// Public R2 bucket URL for user-uploaded images (avatars, pack photos), per
+    /// `PACKRAT_ENV`. Production has its own bucket; local/dev-local/dev share the
+    /// dev bucket. Matches `EXPO_PUBLIC_R2_PUBLIC_URL` per EAS environment
+    /// (`eas env:list production|preview|development` in apps/expo).
+    static let r2PublicURLs: [String: String] = [
+        "local":      "https://pub-c3852b07b730407889986338ca3ef0e5.r2.dev",
+        "dev-local":  "https://pub-c3852b07b730407889986338ca3ef0e5.r2.dev",
+        "dev":        "https://pub-c3852b07b730407889986338ca3ef0e5.r2.dev",
+        "production": "https://pub-f2a42eb361574f2194b90161912acf3d.r2.dev",
+    ]
+
+    static var r2PublicURL: String {
+        r2PublicURLs[environmentName ?? ""] ?? r2PublicURLs["dev"]!
+    }
 
     /// Resolves a possibly-relative R2 object key to a fetchable absolute URL.
     /// Server-stored image fields (e.g. `avatarUrl`) may be a bare R2 key or

--- a/apps/swift/Sources/PackRat/Services/UploadService.swift
+++ b/apps/swift/Sources/PackRat/Services/UploadService.swift
@@ -10,12 +10,18 @@ final class UploadService: Sendable {
     init(api: APIClient = .shared) { self.api = api }
 
     struct PresignedURLResponse: Decodable {
-        let uploadUrl: String
+        let url: String
+        let objectKey: String
         let publicUrl: String
-        let key: String
     }
 
-    /// Fetches a presigned R2 upload URL, uploads the data, returns the public URL.
+    /// Fetches a presigned R2 upload URL, uploads the data, returns the object's
+    /// relative R2 key. The presign route's `publicUrl` field is derived from the
+    /// private S3-API presigned URL origin (packrat-bucket-*.r2.cloudflarestorage.com),
+    /// not the public R2.dev bucket domain, so it isn't actually fetchable — Expo
+    /// ignores it too (apps/expo/features/packs/utils/uploadImage.ts returns
+    /// remoteFileName, not data.publicUrl). Callers resolve the key to a fetchable
+    /// URL via APIClient.resolvedImageURL.
     func upload(data: Data, fileName: String, mimeType: String) async throws -> String {
         // 1. Get presigned URL from API
         let endpoint = Endpoint(.get, "/api/upload/presigned", query: [
@@ -25,7 +31,7 @@ final class UploadService: Sendable {
         let presigned: PresignedURLResponse = try await api.send(endpoint)
 
         // 2. PUT directly to R2 presigned URL (no auth header needed)
-        guard let uploadURL = URL(string: presigned.uploadUrl) else {
+        guard let uploadURL = URL(string: presigned.url) else {
             throw PackRatError.unknown
         }
         var request = URLRequest(url: uploadURL)
@@ -38,25 +44,29 @@ final class UploadService: Sendable {
             throw PackRatError.httpError(statusCode: (response as? HTTPURLResponse)?.statusCode ?? 0, message: "Upload failed")
         }
 
-        return presigned.publicUrl
+        return presigned.objectKey
     }
 
     #if os(macOS)
-    func uploadImage(at url: URL) async throws -> String {
+    func uploadImage(at url: URL, userId: String) async throws -> String {
         let data = try Data(contentsOf: url)
         let ext = url.pathExtension.lowercased()
         let mimeType = ext == "png" ? "image/png" : "image/jpeg"
-        let fileName = "\(UUID().uuidString).\(ext)"
+        // The presign route requires the object key to start with `{userId}-`
+        // (packages/api/src/routes/upload.ts) — matches Expo's remoteFileName convention.
+        let fileName = "\(userId)-\(UUID().uuidString).\(ext)"
         return try await upload(data: data, fileName: fileName, mimeType: mimeType)
     }
     #endif
 
     #if os(iOS)
-    func uploadUIImage(_ image: UIImage, quality: CGFloat = 0.85) async throws -> String {
+    func uploadUIImage(_ image: UIImage, userId: String, quality: CGFloat = 0.85) async throws -> String {
         guard let data = image.jpegData(compressionQuality: quality) else {
             throw PackRatError.unknown
         }
-        let fileName = "\(UUID().uuidString).jpg"
+        // The presign route requires the object key to start with `{userId}-`
+        // (packages/api/src/routes/upload.ts) — matches Expo's remoteFileName convention.
+        let fileName = "\(userId)-\(UUID().uuidString).jpg"
         return try await upload(data: data, fileName: fileName, mimeType: "image/jpeg")
     }
     #endif

--- a/apps/swift/Sources/PackRat/Shared/RemoteImage.swift
+++ b/apps/swift/Sources/PackRat/Shared/RemoteImage.swift
@@ -17,7 +17,7 @@ struct RemoteImage<Placeholder: View>: View {
     }
 
     var body: some View {
-        if let urlString = url, let imageURL = URL(string: urlString) {
+        if let imageURL = APIClient.resolvedImageURL(url) {
             LazyImage(url: imageURL) { state in
                 if let image = state.image {
                     image

--- a/apps/swift/Tests/PackRatUITests/UITestFeatureFlags.swift
+++ b/apps/swift/Tests/PackRatUITests/UITestFeatureFlags.swift
@@ -9,6 +9,7 @@ enum UITestFeatureFlags {
     static let enableOAuth = true
     static let enablePackInsights = false
     static let enablePackTemplates = true
+    static let enableRevenueCat = true
     static let enableSharedPacks = false
     static let enableShoppingList = false
     static let enableTrailConditions = true


### PR DESCRIPTION
## Description

Fixes the Swift iOS app's avatar upload/display pipeline, which was broken across several layers, and wires the avatar image into two screens that previously only showed initials.

Closes #

## Type of change

- [x] 🐛 Bug fix

## Area(s) affected

- [ ] Mobile app (`apps/expo`)
- [ ] API / Backend (`packages/api`)
- [ ] Landing page (`apps/landing`)
- [ ] Guides site (`apps/guides`)
- [ ] CI / CD (`.github/`)

(Swift app — `apps/swift`, not listed above)

## Summary

- Presign requires the R2 object key to start with `{userId}-`; `UploadService` generated bare UUID filenames, so every avatar upload 403'd.
- `PresignedURLResponse` decoded JSON field names (`uploadUrl`/`key`) that don't match the server's actual response shape (`url`/`objectKey`/`publicUrl`), so decoding silently threw after the presign request succeeded.
- The presign route's `publicUrl` is derived from R2's private S3-API endpoint, not the public bucket domain, and isn't fetchable — store `objectKey` instead (matching Expo's existing workaround) and resolve it to a displayable URL via `APIClient.resolvedImageURL` at render time.
- Added a 5MB client-side avatar size check and Sentry error capture on upload failures, for parity with the Expo app.
- The Home dashboard header and the nav sidebar footer never rendered the avatar image at all (initials only, regardless of whether the user had an avatar) — wired both to the existing `AvatarView` component.

## Testing

- [ ] Added / updated unit tests
- [x] Manually tested on iOS (pinned iPhone 17 Pro simulator)
- [ ] Manually tested on Android
- [ ] Manually tested on Web
- [ ] API endpoints verified (e.g. `curl` or Postman)

## Pre-merge checklist

- [x] `bun format && bun lint` passes with no errors
- [x] No new secrets or credentials are committed
- [ ] Database migration included (if schema changed) — N/A
- [ ] Feature flag added (if this is a new feature) — N/A, bug fix
- [x] PR title follows conventional commits (`feat:`, `fix:`, `chore:`, etc.)