### PR TITLE
fix(api,swift): accept native iOS client IDs for Google and Apple sign-in

### DIFF
--- a/apps/swift/Resources/PackRat-iOS.entitlements
+++ b/apps/swift/Resources/PackRat-iOS.entitlements
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict/>
+<dict>
+	<key>com.apple.developer.applesignin</key>
+	<array>
+		<string>Default</string>
+	</array>
+</dict>
 </plist>

--- a/packages/api/.dev.vars.e2e.example
+++ b/packages/api/.dev.vars.e2e.example
@@ -69,6 +69,7 @@ SENTRY_DSN=<your-sentry-dsn>
 
 # ── Apple Sign In ─────────────────────────────────────────────────────────────
 APPLE_CLIENT_ID=<your-apple-client-id>
+APPLE_SWIFT_CLIENT_ID=<your-apple-swift-client-id>
 APPLE_PRIVATE_KEY=<your-apple-private-key>
 APPLE_KEY_ID=<your-apple-key-id>
 APPLE_TEAM_ID=<your-apple-team-id>

--- a/packages/api/.dev.vars.e2e.example
+++ b/packages/api/.dev.vars.e2e.example
@@ -58,6 +58,7 @@ PACKRAT_GUIDES_BASE_URL=https://guides.packratai.com/
 EXPO_PUBLIC_GOOGLE_IOS_CLIENT_ID=<your-google-ios-client-id>
 EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID=<your-google-web-client-id>
 GOOGLE_CLIENT_ID=<your-google-client-id>
+GOOGLE_IOS_CLIENT_ID=<your-google-ios-client-id>
 GOOGLE_CLIENT_SECRET=<your-google-client-secret>
 
 # ── Maps ─────────────────────────────────────────────────────────────────────

--- a/packages/api/src/auth/index.ts
+++ b/packages/api/src/auth/index.ts
@@ -205,7 +205,9 @@ async function buildAuth(env: ValidatedEnv): Promise<any> {
       // verifies against Apple's public JWKS; the secret is only used for the
       // web OAuth redirect flow).
       // audience covers all EAS build variants — Apple puts the bundle ID in
-      // the `aud` claim, which differs per variant (.dev, .preview, base).
+      // the `aud` claim, which differs per variant (.dev, .preview, base) — plus
+      // the native Swift app's distinct bundle ID, which is a separate Xcode
+      // target and not an EAS build variant of the Expo app.
       ...(env.APPLE_CLIENT_ID
         ? {
             apple: {
@@ -216,6 +218,7 @@ async function buildAuth(env: ValidatedEnv): Promise<any> {
                 env.APPLE_CLIENT_ID,
                 `${env.APPLE_CLIENT_ID}.dev`,
                 `${env.APPLE_CLIENT_ID}.preview`,
+                ...(env.APPLE_SWIFT_CLIENT_ID ? [env.APPLE_SWIFT_CLIENT_ID] : []),
               ],
             },
           }

--- a/packages/api/src/auth/index.ts
+++ b/packages/api/src/auth/index.ts
@@ -193,7 +193,11 @@ async function buildAuth(env: ValidatedEnv): Promise<any> {
 
     socialProviders: {
       google: {
-        clientId: env.GOOGLE_CLIENT_ID ?? '',
+        // iOS native Google Sign-In requests an id token whose `aud` claim is the
+        // iOS OAuth client ID, distinct from the web client ID — accept both audiences.
+        clientId: [env.GOOGLE_CLIENT_ID, env.GOOGLE_IOS_CLIENT_ID].filter((id): id is string =>
+          Boolean(id),
+        ),
         clientSecret: env.GOOGLE_CLIENT_SECRET ?? '',
       },
       // Always register Apple when clientId is present so the native id-token

--- a/packages/api/src/utils/env-validation.ts
+++ b/packages/api/src/utils/env-validation.ts
@@ -48,6 +48,9 @@ export const apiEnvObjectSchema = z.object({
   E2E_TEST_USER_ID: z.string().uuid().optional(),
   // Google OAuth (Better Auth social provider)
   GOOGLE_CLIENT_ID: z.string(),
+  // iOS native Google Sign-In uses a separate OAuth client whose ID appears in the
+  // ID token's `aud` claim — Better Auth must accept both audiences or native sign-in fails.
+  GOOGLE_IOS_CLIENT_ID: z.string().optional(),
   GOOGLE_CLIENT_SECRET: z.string(),
   // Apple Sign In (Better Auth social provider)
   APPLE_CLIENT_ID: z.string(), // bundle ID e.g. world.packrat.app

--- a/packages/api/src/utils/env-validation.ts
+++ b/packages/api/src/utils/env-validation.ts
@@ -54,6 +54,9 @@ export const apiEnvObjectSchema = z.object({
   GOOGLE_CLIENT_SECRET: z.string(),
   // Apple Sign In (Better Auth social provider)
   APPLE_CLIENT_ID: z.string(), // bundle ID e.g. world.packrat.app
+  // Native Swift app's distinct bundle ID (separate Xcode target, not an EAS build
+  // variant of the Expo app) — appears in its Apple ID token's `aud` claim.
+  APPLE_SWIFT_CLIENT_ID: z.string().optional(),
   APPLE_PRIVATE_KEY: z.string(), // .p8 key contents — store via wrangler secret
   APPLE_KEY_ID: z.string(),
   APPLE_TEAM_ID: z.string(),


### PR DESCRIPTION
## Description

Native sign-in from the Swift iOS app was failing with "Invalid id token" for both Google and Apple providers.

- **Google**: the Swift app authenticates with the iOS-specific Google OAuth client ID, whose `aud` claim differs from the web client ID Better Auth was validating against.
- **Apple**: the Swift app is a separate Xcode target (`com.andrewbierman.packrat.swift`) from the Expo app's EAS build variants, so its Apple ID token's `aud` claim never matched Better Auth's configured audience list. Its entitlements file also had an empty `<dict/>`, missing the `com.apple.developer.applesignin` capability.

## Type of change

- [x] 🐛 Bug fix

## Area(s) affected

- [x] Mobile app (`apps/swift`, not listed above but affected)
- [x] API / Backend (`packages/api`)

## Testing

- [x] Manually tested on macOS build (Apple Sign-In sheet completes; API config confirmed correct via debug audience/claims logging)
- [x] `bun check-types`, `bun check` (scoped to changed files), `bun test:api:unit` (619 tests) all pass

## Pre-merge checklist

- [x] `bun format && bun lint` passes with no errors
- [x] `bun check-types` passes with no errors
- [x] No new secrets or credentials are committed
- [ ] Database migration included (if schema changed) — N/A
- [ ] Feature flag added (if this is a new feature) — N/A
- [x] PR title follows conventional commits

## Notes for reviewers

Local testing surfaced a separate infra issue unrelated to this PR's code: `wrangler dev`'s local sandbox gets a `403 Forbidden` from `https://appleid.apple.com/auth/keys` (Apple's JWKS endpoint), which blocks Apple Sign-In from completing in local dev regardless of this fix. The audience/bundle-ID config was verified correct via debug logging before this was discovered — this fix should still be validated against a deployed (non-local) API environment.

Requires deploying these new env vars to staging/prod as Worker secrets:
- `GOOGLE_IOS_CLIENT_ID`
- `APPLE_SWIFT_CLIENT_ID` (value: `com.andrewbierman.packrat.swift`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Apple Sign-In support for the iOS app.
  * Improved native iOS Google and Apple authentication compatibility.
  * Added configuration options for native mobile OAuth credentials.

* **Bug Fixes**
  * Fixed validation of authentication tokens from native iOS sign-in flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->