### PR TITLE
fix(api,swift): dedicated Google iOS client ID for Swift app

### DIFF
--- a/apps/swift/Resources/Info-iOS.plist
+++ b/apps/swift/Resources/Info-iOS.plist
@@ -41,14 +41,14 @@
 			<string>world.packrat.google</string>
 			<key>CFBundleURLSchemes</key>
 			<array>
-				<string>com.googleusercontent.apps.993694750638-97t0vhfml04u2avrlbve22jbs9qcinbc</string>
+				<string>com.googleusercontent.apps.993694750638-f2pbg3e5tkt2btn9eih6c8ah8igal55m</string>
 			</array>
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>GOOGLE_IOS_CLIENT_ID</key>
-	<string>993694750638-97t0vhfml04u2avrlbve22jbs9qcinbc.apps.googleusercontent.com</string>
+	<string>993694750638-f2pbg3e5tkt2btn9eih6c8ah8igal55m.apps.googleusercontent.com</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/apps/swift/project.yml
+++ b/apps/swift/project.yml
@@ -87,7 +87,7 @@ targets:
         ITSAppUsesNonExemptEncryption: false
         PACKRAT_ENV: $(PACKRAT_ENV)
         SENTRY_DSN: $(SENTRY_DSN)
-        GOOGLE_IOS_CLIENT_ID: 993694750638-97t0vhfml04u2avrlbve22jbs9qcinbc.apps.googleusercontent.com
+        GOOGLE_IOS_CLIENT_ID: 993694750638-f2pbg3e5tkt2btn9eih6c8ah8igal55m.apps.googleusercontent.com
         NSAppTransportSecurity:
           NSAllowsLocalNetworking: true
         CFBundleURLTypes:
@@ -103,7 +103,7 @@ targets:
               - com.andrewbierman.packrat
           - CFBundleURLName: world.packrat.google
             CFBundleURLSchemes:
-              - com.googleusercontent.apps.993694750638-97t0vhfml04u2avrlbve22jbs9qcinbc
+              - com.googleusercontent.apps.993694750638-f2pbg3e5tkt2btn9eih6c8ah8igal55m
     dependencies:
       - package: Nuke
         product: NukeUI

--- a/packages/api/.dev.vars.e2e.example
+++ b/packages/api/.dev.vars.e2e.example
@@ -59,6 +59,7 @@ EXPO_PUBLIC_GOOGLE_IOS_CLIENT_ID=<your-google-ios-client-id>
 EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID=<your-google-web-client-id>
 GOOGLE_CLIENT_ID=<your-google-client-id>
 GOOGLE_IOS_CLIENT_ID=<your-google-ios-client-id>
+GOOGLE_IOS_SWIFT_CLIENT_ID=<your-google-ios-swift-client-id>
 GOOGLE_CLIENT_SECRET=<your-google-client-secret>
 
 # ── Maps ─────────────────────────────────────────────────────────────────────

--- a/packages/api/src/auth/auth.helpers.ts
+++ b/packages/api/src/auth/auth.helpers.ts
@@ -1,8 +1,7 @@
 import { verifyPassword } from '@better-auth/utils/password';
-import { betterFetch } from '@better-fetch/fetch';
 import type { ValidatedEnv } from '@packrat/api/utils/env-validation';
 import * as bcrypt from 'bcryptjs';
-import { decodeProtectedHeader, importJWK, importPKCS8, jwtVerify, SignJWT } from 'jose';
+import { importPKCS8, SignJWT } from 'jose';
 
 // Matches bcrypt hashes ($2a$, $2b$, $2y$) left over from pre-migration auth.
 const BCRYPT_HASH_RE = /^\$2[aby]\$/;
@@ -44,51 +43,4 @@ export async function generateAppleClientSecret(env: ValidatedEnv): Promise<stri
     );
     return null;
   }
-}
-
-// TEMPORARY DEBUG SHIM — Better Auth's built-in apple.verifyIdToken swallows
-// the underlying jose error and returns bare `false`, so a failed sign-in only
-// ever logs "Invalid id token" with no indication of *why* (bad audience,
-// bad issuer, expired, wrong alg, JWKS lookup failure, etc). This mirrors
-// that verification exactly but logs the caught error before returning false.
-// Remove once the audience mismatch is diagnosed.
-export function verifyAppleIdTokenWithLogging(audience: string[]) {
-  return async (token: string, nonce?: string | null): Promise<boolean> => {
-    try {
-      const { kid, alg } = decodeProtectedHeader(token);
-      if (!kid || !alg) {
-        console.error('[auth][apple-debug] missing kid/alg in protected header', { kid, alg });
-        return false;
-      }
-      const { data } = await betterFetch<{ keys: Array<Record<string, string>> }>(
-        'https://appleid.apple.com/auth/keys',
-      );
-      const jwk = data?.keys?.find((k) => k.kid === kid);
-      if (!jwk) {
-        console.error('[auth][apple-debug] no matching JWK for kid', { kid });
-        return false;
-      }
-      const key = await importJWK(jwk, jwk.alg);
-      const { payload } = await jwtVerify(token, key, {
-        algorithms: [alg],
-        issuer: 'https://appleid.apple.com',
-        audience,
-        maxTokenAge: '1h',
-      });
-      if (nonce && payload.nonce !== nonce) {
-        console.error('[auth][apple-debug] nonce mismatch', {
-          expected: nonce,
-          actual: payload.nonce,
-        });
-        return false;
-      }
-      return true;
-    } catch (err) {
-      console.error('[auth][apple-debug] verifyIdToken failed', {
-        audience,
-        error: err instanceof Error ? `${err.name}: ${err.message}` : err,
-      });
-      return false;
-    }
-  };
 }

--- a/packages/api/src/auth/auth.helpers.ts
+++ b/packages/api/src/auth/auth.helpers.ts
@@ -1,7 +1,8 @@
 import { verifyPassword } from '@better-auth/utils/password';
+import { betterFetch } from '@better-fetch/fetch';
 import type { ValidatedEnv } from '@packrat/api/utils/env-validation';
 import * as bcrypt from 'bcryptjs';
-import { importPKCS8, SignJWT } from 'jose';
+import { decodeProtectedHeader, importJWK, importPKCS8, jwtVerify, SignJWT } from 'jose';
 
 // Matches bcrypt hashes ($2a$, $2b$, $2y$) left over from pre-migration auth.
 const BCRYPT_HASH_RE = /^\$2[aby]\$/;
@@ -43,4 +44,51 @@ export async function generateAppleClientSecret(env: ValidatedEnv): Promise<stri
     );
     return null;
   }
+}
+
+// TEMPORARY DEBUG SHIM — Better Auth's built-in apple.verifyIdToken swallows
+// the underlying jose error and returns bare `false`, so a failed sign-in only
+// ever logs "Invalid id token" with no indication of *why* (bad audience,
+// bad issuer, expired, wrong alg, JWKS lookup failure, etc). This mirrors
+// that verification exactly but logs the caught error before returning false.
+// Remove once the audience mismatch is diagnosed.
+export function verifyAppleIdTokenWithLogging(audience: string[]) {
+  return async (token: string, nonce?: string | null): Promise<boolean> => {
+    try {
+      const { kid, alg } = decodeProtectedHeader(token);
+      if (!kid || !alg) {
+        console.error('[auth][apple-debug] missing kid/alg in protected header', { kid, alg });
+        return false;
+      }
+      const { data } = await betterFetch<{ keys: Array<Record<string, string>> }>(
+        'https://appleid.apple.com/auth/keys',
+      );
+      const jwk = data?.keys?.find((k) => k.kid === kid);
+      if (!jwk) {
+        console.error('[auth][apple-debug] no matching JWK for kid', { kid });
+        return false;
+      }
+      const key = await importJWK(jwk, jwk.alg);
+      const { payload } = await jwtVerify(token, key, {
+        algorithms: [alg],
+        issuer: 'https://appleid.apple.com',
+        audience,
+        maxTokenAge: '1h',
+      });
+      if (nonce && payload.nonce !== nonce) {
+        console.error('[auth][apple-debug] nonce mismatch', {
+          expected: nonce,
+          actual: payload.nonce,
+        });
+        return false;
+      }
+      return true;
+    } catch (err) {
+      console.error('[auth][apple-debug] verifyIdToken failed', {
+        audience,
+        error: err instanceof Error ? `${err.name}: ${err.message}` : err,
+      });
+      return false;
+    }
+  };
 }

--- a/packages/api/src/auth/index.ts
+++ b/packages/api/src/auth/index.ts
@@ -10,7 +10,11 @@
 import { drizzleAdapter } from '@better-auth/drizzle-adapter';
 import { expo } from '@better-auth/expo';
 import { oauthProvider } from '@better-auth/oauth-provider';
-import { generateAppleClientSecret, verifyPasswordCompat } from '@packrat/api/auth/auth.helpers';
+import {
+  generateAppleClientSecret,
+  verifyAppleIdTokenWithLogging,
+  verifyPasswordCompat,
+} from '@packrat/api/auth/auth.helpers';
 import { createConnection } from '@packrat/api/db';
 import type { ValidatedEnv } from '@packrat/api/utils/env-validation';
 import * as schema from '@packrat/db';
@@ -220,6 +224,14 @@ async function buildAuth(env: ValidatedEnv): Promise<any> {
                 `${env.APPLE_CLIENT_ID}.preview`,
                 ...(env.APPLE_SWIFT_CLIENT_ID ? [env.APPLE_SWIFT_CLIENT_ID] : []),
               ],
+              // TEMPORARY: logs the real jose verification error instead of
+              // Better Auth's generic "Invalid id token" — remove once diagnosed.
+              verifyIdToken: verifyAppleIdTokenWithLogging([
+                env.APPLE_CLIENT_ID,
+                `${env.APPLE_CLIENT_ID}.dev`,
+                `${env.APPLE_CLIENT_ID}.preview`,
+                ...(env.APPLE_SWIFT_CLIENT_ID ? [env.APPLE_SWIFT_CLIENT_ID] : []),
+              ]),
             },
           }
         : {}),

--- a/packages/api/src/auth/index.ts
+++ b/packages/api/src/auth/index.ts
@@ -194,10 +194,15 @@ async function buildAuth(env: ValidatedEnv): Promise<any> {
     socialProviders: {
       google: {
         // iOS native Google Sign-In requests an id token whose `aud` claim is the
-        // iOS OAuth client ID, distinct from the web client ID — accept both audiences.
-        clientId: [env.GOOGLE_CLIENT_ID, env.GOOGLE_IOS_CLIENT_ID].filter((id): id is string =>
-          Boolean(id),
-        ),
+        // iOS OAuth client ID, distinct from the web client ID. Google client IDs
+        // are bound to a single bundle ID, so the Swift app (a separate Xcode
+        // target with its own bundle ID) needs its own client ID too — accept
+        // all three audiences.
+        clientId: [
+          env.GOOGLE_CLIENT_ID,
+          env.GOOGLE_IOS_CLIENT_ID,
+          env.GOOGLE_IOS_SWIFT_CLIENT_ID,
+        ].filter((id): id is string => Boolean(id)),
         clientSecret: env.GOOGLE_CLIENT_SECRET ?? '',
       },
       // Always register Apple when clientId is present so the native id-token

--- a/packages/api/src/auth/index.ts
+++ b/packages/api/src/auth/index.ts
@@ -10,11 +10,7 @@
 import { drizzleAdapter } from '@better-auth/drizzle-adapter';
 import { expo } from '@better-auth/expo';
 import { oauthProvider } from '@better-auth/oauth-provider';
-import {
-  generateAppleClientSecret,
-  verifyAppleIdTokenWithLogging,
-  verifyPasswordCompat,
-} from '@packrat/api/auth/auth.helpers';
+import { generateAppleClientSecret, verifyPasswordCompat } from '@packrat/api/auth/auth.helpers';
 import { createConnection } from '@packrat/api/db';
 import type { ValidatedEnv } from '@packrat/api/utils/env-validation';
 import * as schema from '@packrat/db';
@@ -224,14 +220,6 @@ async function buildAuth(env: ValidatedEnv): Promise<any> {
                 `${env.APPLE_CLIENT_ID}.preview`,
                 ...(env.APPLE_SWIFT_CLIENT_ID ? [env.APPLE_SWIFT_CLIENT_ID] : []),
               ],
-              // TEMPORARY: logs the real jose verification error instead of
-              // Better Auth's generic "Invalid id token" — remove once diagnosed.
-              verifyIdToken: verifyAppleIdTokenWithLogging([
-                env.APPLE_CLIENT_ID,
-                `${env.APPLE_CLIENT_ID}.dev`,
-                `${env.APPLE_CLIENT_ID}.preview`,
-                ...(env.APPLE_SWIFT_CLIENT_ID ? [env.APPLE_SWIFT_CLIENT_ID] : []),
-              ]),
             },
           }
         : {}),

--- a/packages/api/src/utils/env-validation.ts
+++ b/packages/api/src/utils/env-validation.ts
@@ -51,6 +51,10 @@ export const apiEnvObjectSchema = z.object({
   // iOS native Google Sign-In uses a separate OAuth client whose ID appears in the
   // ID token's `aud` claim — Better Auth must accept both audiences or native sign-in fails.
   GOOGLE_IOS_CLIENT_ID: z.string().optional(),
+  // Native Swift app's distinct bundle ID (com.andrewbierman.packrat.swift) needs its
+  // own Google iOS OAuth client — Google client IDs are bound to a single bundle ID,
+  // so the Expo app's GOOGLE_IOS_CLIENT_ID doesn't cover it.
+  GOOGLE_IOS_SWIFT_CLIENT_ID: z.string().optional(),
   GOOGLE_CLIENT_SECRET: z.string(),
   // Apple Sign In (Better Auth social provider)
   APPLE_CLIENT_ID: z.string(), // bundle ID e.g. world.packrat.app


### PR DESCRIPTION
## Description

Google Sign-In on the native Swift iOS app failed with `INVALID_TOKEN` even after the Expo iOS client ID was added to the accepted audience list. Root cause: Google OAuth iOS client IDs are bound to a single bundle ID, so the existing `GOOGLE_IOS_CLIENT_ID` (registered against the Expo app's base bundle ID, `com.andrewbierman.packrat`) never covered the Swift app's distinct bundle ID (`com.andrewbierman.packrat.swift`).

Fix mirrors the existing `APPLE_SWIFT_CLIENT_ID` pattern: a new Google Cloud iOS OAuth client was created for the `.swift` bundle ID, added as a third accepted audience (`GOOGLE_IOS_SWIFT_CLIENT_ID`), and the Swift app's `Info.plist` / URL scheme updated to use it.

Closes #<!-- issue number, if applicable -->

## Type of change

- [x] 🐛 Bug fix

## Area(s) affected

- [x] Mobile app (Swift iOS, `apps/swift`)
- [x] API / Backend (`packages/api`)

## Testing

- [x] Manually tested on iOS (rebuilt + reinstalled on iPhone 17 Pro simulator, verified Google Sign-In)

## Pre-merge checklist

- [x] `bun format && bun lint` passes with no errors (scoped to changed files)
- [x] `bun check-types` passes with no errors
- [x] No new secrets or credentials are committed
- [ ] Database migration included (if schema changed) — N/A
- [ ] Feature flag added (if this is a new feature) — N/A
- [x] PR title follows conventional commits

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Google Sign-In configuration for the iOS app.
  * Added support for an additional iOS client identifier during Google authentication.
  * Synchronized the app’s callback configuration with the updated sign-in credentials.

* **Configuration**
  * Added optional environment configuration for the new iOS Google client identifier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->